### PR TITLE
Set `max_transcript_size` in `ProverConfig`

### DIFF
--- a/wasm/prover/src/lib.rs
+++ b/wasm/prover/src/lib.rs
@@ -158,6 +158,7 @@ pub async fn prover(
     let config = ProverConfig::builder()
         .id(notarization_response.session_id)
         .server_dns(target_host)
+        .max_transcript_size(options.max_transcript_size)
         .build()
         .unwrap();
 


### PR DESCRIPTION
## What's wrong?
We only put `max_transcript_size` in [`NotarizationSessionRequest`](https://github.com/tlsnotary/tlsn-extension/blob/fbf4770b87dec6d2eccbeb5edfbae79239133ab2/src/lib.rs#L164-L167) but didn't set it in `ProverConfig`. `ProverConfig` uses the default one no matter what we set for `max_transcript_size`

## How it is fixed?
Set `max_transcript_size` when `ProverConfig::builder()`