### PR TITLE
[chore] MV3 migration: remove persistent key from background'

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,8 @@
   "name": "TLSN Extension",
   "description": "A chrome extension for TLSN",
   "options_page": "options.html",
-  "background": { "service_worker": "background.bundle.js",
-    "persistent": true
+  "background": {
+    "service_worker": "background.bundle.js"
   },
   "action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
this key was causing an error in chrome dev tools:

https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers