### PR TITLE
Support for utf8 bodies

### DIFF
--- a/src/entries/Background/plugins/utils.ts
+++ b/src/entries/Background/plugins/utils.ts
@@ -1,11 +1,12 @@
 import { addPlugin, addPluginConfig, addPluginMetadata } from '../db';
 import { getPluginConfig } from '../../../utils/misc';
+import { bytesSize, indexOfString } from '../../../utils/utf8';
 
 export async function installPlugin(
   urlOrBuffer: ArrayBuffer | string,
   origin = '',
   filePath = '',
-  metadata: {[key: string]: string} = {},
+  metadata: { [key: string]: string } = {},
 ) {
   let arrayBuffer;
 
@@ -31,11 +32,11 @@ export async function installPlugin(
 export function mapSecretsToRange(secrets: string[], text: string) {
   return secrets
     .map((secret: string) => {
-      const index = text.indexOf(secret);
-      return index > -1
+      const byteIdx = indexOfString(text, secret);
+      return byteIdx > -1
         ? {
-          start: index,
-          end: index + secret.length,
+          start: byteIdx,
+          end: byteIdx + bytesSize(secret)
         }
         : null;
     })

--- a/src/utils/utf8.ts
+++ b/src/utils/utf8.ts
@@ -1,0 +1,7 @@
+export function indexOfString(str: string, substr: string): number {
+	return Buffer.from(str).indexOf(Buffer.from(substr));
+}
+
+export function bytesSize(str: string): number {
+	return Buffer.from(str).byteLength;
+}


### PR DESCRIPTION
I didn't changed any code working with ranges on the frontend-side, because it doesn't needed for the correct work for the extension. It will fix the https://github.com/tlsnotary/tlsn-extension/issues/122 and https://github.com/tlsnotary/tlsn-js/issues/79 and will fix the plugin behaviour.

But i see now the bug, on the notarization step, when hide multiple response ranges, i see in the result only one range hidden. But idk, maybe this is not a bug. 