### PR TITLE
Add support for passing params to plugin

### DIFF
--- a/src/entries/Background/rpc.ts
+++ b/src/entries/Background/rpc.ts
@@ -1343,7 +1343,7 @@ async function handleRunPluginCSRequest(request: BackgroundAction) {
   });
 
   const defer = deferredPromise();
-  const { origin, position, hash } = request.data;
+  const { origin, position, hash, params } = request.data;
 
   const plugin = await getPluginByHash(hash);
   const config = await getPluginConfigByHash(hash);
@@ -1355,7 +1355,7 @@ async function handleRunPluginCSRequest(request: BackgroundAction) {
   }
 
   const { popup, tab } = await openPopup(
-    `run-plugin-approval?hash=${hash}&origin=${encodeURIComponent(origin)}&favIconUrl=${encodeURIComponent(currentTab?.favIconUrl || '')}`,
+    `run-plugin-approval?hash=${hash}&origin=${encodeURIComponent(origin)}&favIconUrl=${encodeURIComponent(currentTab?.favIconUrl || '')}&params=${encodeURIComponent(JSON.stringify(params) || '')}`,
     position.left,
     position.top,
   );

--- a/src/entries/Content/content.ts
+++ b/src/entries/Content/content.ts
@@ -95,9 +95,10 @@ class TLSN {
     return resp;
   }
 
-  async runPlugin(hash: string) {
+  async runPlugin(hash: string, params?: Record<string, string>) {
     const resp = await client.call(ContentScriptTypes.run_plugin, {
       hash,
+      params,
     });
 
     return resp;

--- a/src/entries/Content/index.ts
+++ b/src/entries/Content/index.ts
@@ -196,8 +196,13 @@ import { urlify } from '../../utils/misc';
 
   server.on(
     ContentScriptTypes.run_plugin,
-    async (request: ContentScriptRequest<{ hash: string }>) => {
-      const { hash } = request.params || {};
+    async (
+      request: ContentScriptRequest<{
+        hash: string;
+        params?: Record<string, string>;
+      }>,
+    ) => {
+      const { hash, params } = request.params || {};
 
       if (!hash) throw new Error('params must include hash');
 
@@ -206,6 +211,7 @@ import { urlify } from '../../utils/misc';
         data: {
           ...getPopupData(),
           hash,
+          params,
         },
       });
 

--- a/src/pages/RunPluginApproval/index.tsx
+++ b/src/pages/RunPluginApproval/index.tsx
@@ -19,6 +19,7 @@ export function RunPluginApproval(): ReactElement {
   const origin = params.get('origin');
   const favIconUrl = params.get('favIconUrl');
   const hash = params.get('hash');
+  const pluginParams = params.get('params');
   const hostname = urlify(origin || '')?.hostname;
   const [error, showError] = useState('');
   const [metadata, setPluginMetadata] = useState<PluginMetadata | null>(null);
@@ -60,6 +61,7 @@ export function RunPluginApproval(): ReactElement {
         type: SidePanelActionTypes.execute_plugin_request,
         data: {
           pluginHash: hash,
+          pluginParams: pluginParams ? JSON.parse(pluginParams) : undefined,
         },
       });
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -343,6 +343,11 @@ export type StepConfig = {
   prover?: boolean; // Boolean indicating if this step outputs a notarization (optional)
 };
 
+export type ParameterConfig = {
+  name: string;
+  description: string;
+};
+
 export type PluginConfig = {
   title: string; // The name of the plugin
   description: string; // A description of the plugin purpose
@@ -356,6 +361,7 @@ export type PluginConfig = {
   requests: { method: string; url: string }[]; // List of requests that the plugin is allowed to make
   notaryUrls?: string[]; // List of notary services that the plugin is allowed to use (optional)
   proxyUrls?: string[]; // List of websocket proxies that the plugin is allowed to use (optional)
+  parameters?: Record<string, ParameterConfig>;
 };
 
 export type PluginMetadata = {


### PR DESCRIPTION
Resolves #149

<img width="354" alt="Screenshot 2025-02-27 at 9 37 45 PM" src="https://github.com/user-attachments/assets/d608d14f-0d7a-466c-bd9b-bbde67cab7f9" />
<img width="350" alt="Screenshot 2025-02-27 at 9 38 28 PM" src="https://github.com/user-attachments/assets/2fce6135-7957-4f31-9684-8c40a231572a" />

Can pass params via `client.runPlugin("abc..", {characterId: 1234})` or input with GUI.

Specify params in plugin config.json 

<img width="470" alt="Screenshot 2025-02-27 at 9 38 53 PM" src="https://github.com/user-attachments/assets/39b183d3-06ad-4fca-a242-43dfde54ef27" />

I was going to make an example plugin etc but ran out of time for now maybe this is useful.