### PR TITLE
remove defaultPluginsInstalled as it blocks testing with twitter-plugin-boilerplate

### DIFF
--- a/src/entries/Background/index.ts
+++ b/src/entries/Background/index.ts
@@ -37,40 +37,6 @@ import { installPlugin } from './plugins/utils';
     removeRequestLogsByTabId(tabId);
   });
 
-  const { defaultPluginsInstalled } = await getAppState();
-
-  switch (defaultPluginsInstalled) {
-    case false: {
-      try {
-        const twitterProfileUrl = browser.runtime.getURL(
-          'twitter_profile.wasm',
-        );
-        const discordDmUrl = browser.runtime.getURL('discord_dm.wasm');
-        await installPlugin(twitterProfileUrl);
-        await installPlugin(discordDmUrl);
-      } finally {
-        await setDefaultPluginsInstalled('0.1.0.703');
-      }
-      break;
-    }
-    case true: {
-      try {
-        await removePlugin(
-          '6931d2ad63340d3a1fb1a5c1e3f4454c5a518164d6de5ad272e744832355ee02',
-        );
-        const twitterProfileUrl = browser.runtime.getURL(
-          'twitter_profile.wasm',
-        );
-        await installPlugin(twitterProfileUrl);
-      } finally {
-        await setDefaultPluginsInstalled('0.1.0.703');
-      }
-      break;
-    }
-    case '0.1.0.703':
-      break;
-  }
-
   const { initRPC } = await import('./rpc');
   await createOffscreenDocument();
   initRPC();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -205,16 +205,6 @@ var options = {
           to: path.join(__dirname, "build"),
           force: true,
         },
-        {
-          from: "src/assets/plugins/discord_dm.wasm",
-          to: path.join(__dirname, "build"),
-          force: true,
-        },
-        {
-          from: "src/assets/plugins/twitter_profile.wasm",
-          to: path.join(__dirname, "build"),
-          force: true,
-        },
       ],
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
twitter and discord plugins are installed by default `defaultPluginsInstalled `, meaning that when the tlsn-extension when built for dev it already uses a pre-built .wasm file which blocks any further testing, like overriding action titles, etc. 

I tested the extension with this changes and also works with the official twitter demo on https://demo.tlsnotary.org