### PR TITLE
Removing initiator url on requestId as well

### DIFF
--- a/src/entries/Background/db.ts
+++ b/src/entries/Background/db.ts
@@ -73,9 +73,19 @@ export async function removeRequestLog(requestId: string) {
   if (existing) {
     await requestDb.del(requestId);
     await requestDb.sublevel(existing.tabId.toString()).del(requestId);
+
+    // Removing requestId for asset url
     const host = urlify(existing.url)?.host;
     if (host) {
       await requestDb.sublevel(host).del(requestId);
+    }
+
+    // Removing requestId for initiator url
+    if (existing.initiator) {
+      const host = urlify(existing.initiator)?.host;
+      if (host) {
+        await requestDb.sublevel(host).del(requestId);
+      }
     }
   }
 }
@@ -348,14 +358,14 @@ export async function getPlugins(): Promise<
         hash,
         metadata: metadata
           ? {
-              ...metadata,
-              hash,
-            }
+            ...metadata,
+            hash,
+          }
           : {
-              filePath: '',
-              origin: '',
-              hash,
-            },
+            filePath: '',
+            origin: '',
+            hash,
+          },
       });
     }
   }


### PR DESCRIPTION
This PR aims at fixing an issue in the TLSN extension.

## Rationale

When closing a new tab or deleting a request entry, the extension deletes the requestId from the database without removing all the host associated with this request. 
Some requests are saved using their initiator URLs and some requests are saved using their url attribute. 
In the remove request process, I propose to remove the request Id from the url and initiator urls. 

## Issue origin

When opening the extension for the second time, some request IDs lead to the following errors : 
- Entry not found (in Level DB)
Tracing this error, I found that requestIds where kept in the `host` DB when being deleted in the requestDB. 