### PR TITLE
Added close panel listener

### DIFF
--- a/src/entries/Background/rpc.ts
+++ b/src/entries/Background/rpc.ts
@@ -1094,6 +1094,14 @@ async function handleRunPluginByURLRequest(request: BackgroundAction) {
     browser.runtime.onMessage.removeListener(onPluginRequest);
   };
 
+  const onSidePanelClosing = async (req: any) => {
+    if (req.type === SidePanelActionTypes.panel_closing) {
+        browser.runtime.onMessage.removeListener(onSidePanelClosing);
+        defer.reject(new Error('user rejected.'));
+    }
+
+  };
+
   const onMessage = async (req: BackgroundAction) => {
     if (req.type === BackgroundActiontype.run_plugin_by_url_response) {
       if (req.data) {
@@ -1116,6 +1124,7 @@ async function handleRunPluginByURLRequest(request: BackgroundAction) {
   };
 
   browser.runtime.onMessage.addListener(onMessage);
+  browser.runtime.onMessage.addListener(onSidePanelClosing);
   browser.windows.onRemoved.addListener(onPopUpClose);
 
   return defer.promise;

--- a/src/entries/SidePanel/SidePanel.tsx
+++ b/src/entries/SidePanel/SidePanel.tsx
@@ -80,6 +80,13 @@ export default function SidePanel(): ReactElement {
         }
       }
     });
+   document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'hidden') {
+          browser.runtime.sendMessage({
+                type: SidePanelActionTypes.panel_closing,
+          });
+        }
+    });
   }, []);
 
   return (

--- a/src/entries/SidePanel/types.ts
+++ b/src/entries/SidePanel/types.ts
@@ -1,5 +1,6 @@
 export enum SidePanelActionTypes {
   panel_opened = 'sidePanel/panel_opened',
+  panel_closing = 'sidePanel/panel_closing',
   execute_plugin_request = 'sidePanel/execute_plugin_request',
   execute_plugin_response = 'sidePanel/execute_plugin_response',
   run_p2p_plugin_request = 'sidePanel/run_p2p_plugin_request',


### PR DESCRIPTION
For a plugin interaction, when Side Panel is closed, nothing gets returned to the application and therefore, it blocks the current flow on the WebApp. 

It also blocks subsequent calls, because no response was sent and the browser returns null on subsequent calls. 

This PR proposes to add a listener to closing the SidePanel to error in the plugin request flow. 

Closes #201 