### PR TITLE
fix: parser to return range for entire array when accessing array field

### DIFF
--- a/packages/plugin-sdk/src/parser.ts
+++ b/packages/plugin-sdk/src/parser.ts
@@ -425,7 +425,33 @@ export class Parser {
       // Handle different value types
       if (typeof value === 'object' && value !== null) {
         if (Array.isArray(value)) {
-          // Handle array
+          // Handle array - first store the array itself, then process elements
+          const valueStr = JSON.stringify(value);
+          const valueBytes = Buffer.from(valueStr, 'utf8');
+          const valueByteIndex = textBytes.indexOf(valueBytes, actualValueByteStart);
+
+          if (valueByteIndex !== -1) {
+            const valueByteEnd = valueByteIndex + valueBytes.length;
+
+            // Store the array itself as a field
+            result[pathKey] = {
+              value: value,
+              ranges: {
+                start: baseOffset + keyByteIndex,
+                end: baseOffset + valueByteEnd,
+              },
+              keyRange: {
+                start: baseOffset + keyByteIndex,
+                end: baseOffset + keyByteIndex + keyBytes.length,
+              },
+              valueRange: {
+                start: baseOffset + valueByteIndex,
+                end: baseOffset + valueByteEnd,
+              },
+            };
+          }
+
+          // Then recursively process array elements
           this.processJsonArray(
             value,
             textBytes,


### PR DESCRIPTION
When calling parser.ranges.body('a', {type: 'json'}) for a body like {a: [{b: 1}, {c: 2}]}, the parser now returns the range for the entire array value instead of returning empty.

Changes:
- Store array field with full range (key + value) before processing elements
- hideKey option returns just the array value: [{b: 1}, {c: 2}]
- hideValue option returns just the key: "a"

Added tests for:
- Extracting entire array value directly
- hideKey/hideValue options for array fields
- Array of primitives
- Nested array fields (e.g., data.items)