### PR TITLE
fix: webpack-dev-server config and remove unused storage permission

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "0.1.0",
+  "version": "0.1.0.1300",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -30,7 +30,6 @@
   "permissions": [
     "offscreen",
     "webRequest",
-    "storage",
     "activeTab",
     "tabs",
     "windows",

--- a/packages/extension/utils/webserver.js
+++ b/packages/extension/utils/webserver.js
@@ -27,7 +27,7 @@ var compiler = webpack(config);
 
 var server = new WebpackDevServer(
   {
-    https: false,
+    server: 'http',
     hot: true,
     liveReload: false,
     client: {


### PR DESCRIPTION
- Update webpack-dev-server config to use server: 'http' instead of deprecated https property
- Remove unused 'storage' permission from manifest (extension only uses IndexedDB)
- Bump version to 0.1.0.1300