### PR TITLE
fix(demo): filter useHeaders for requests that have cookies

### DIFF
--- a/packages/demo/plugins/swissbank.plugin.ts
+++ b/packages/demo/plugins/swissbank.plugin.ts
@@ -162,7 +162,11 @@ const main = (): DomJson => {
   // Only search for cookie if not already cached
   if (!cachedCookie) {
     const [header] = useHeaders((headers) =>
-      headers.filter((h) => h.url.includes(`https://${host}`)),
+      headers.filter(
+        (h) =>
+          h.url.includes(`https://${host}`) &&
+          h.requestHeaders.some((r) => r.name === 'Cookie'),
+      ),
     );
 
     if (header) {


### PR DESCRIPTION
## Summary
- Fix Swiss Bank plugin not activating the prove button when user logs in within the extension window
- The `useHeaders` filter matched all requests to the host, including the initial unauthenticated page load (no cookies). Since `[header]` destructures the first element, it always picked the cookieless request, preventing cookie detection after login.
- Added `h.requestHeaders.some((r) => r.name === 'Cookie')` to the filter so only authenticated requests are matched

## Test plan
- [x] Open Swiss Bank plugin from demo
- [x] Do NOT log in before starting the plugin
- [x] Log in within the extension-opened window (admin / admin)
- [x] Verify the prove button becomes active without needing to restart