### PR TITLE
feat(extension): add user-configurable proxy URL override

### DIFF
--- a/packages/extension/src/entries/Options/index.scss
+++ b/packages/extension/src/entries/Options/index.scss
@@ -67,6 +67,12 @@ body {
       margin-bottom: 8px;
       color: #fff;
     }
+
+    & + & {
+      margin-top: 32px;
+      padding-top: 24px;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
   }
 
   &__section-description {
@@ -184,6 +190,60 @@ body {
     margin-left: auto;
     color: #a0a0a0;
     font-family: 'Monaco', 'Menlo', monospace;
+  }
+
+  &__proxy-field {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+  }
+
+  &__text-input {
+    flex: 1;
+    padding: 12px 16px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    color: #e8e8e8;
+    font-size: 14px;
+    font-family: 'Monaco', 'Menlo', monospace;
+    outline: none;
+    transition: border-color 0.2s ease;
+
+    &:focus {
+      border-color: rgba(74, 158, 255, 0.5);
+    }
+
+    &::placeholder {
+      color: #666;
+    }
+  }
+
+  &__save-button {
+    padding: 12px 24px;
+    background: rgba(74, 158, 255, 0.2);
+    border: 1px solid rgba(74, 158, 255, 0.4);
+    border-radius: 8px;
+    color: #4a9eff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: rgba(74, 158, 255, 0.3);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  &__error {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #ef4444;
   }
 
   &__footer {

--- a/packages/extension/src/entries/Options/index.tsx
+++ b/packages/extension/src/entries/Options/index.tsx
@@ -5,6 +5,10 @@ import {
   getStoredLogLevel,
   setStoredLogLevel,
 } from '../../utils/logLevelStorage';
+import {
+  getStoredProxyUrl,
+  setStoredProxyUrl,
+} from '../../utils/proxyUrlStorage';
 import './index.scss';
 
 interface LogLevelOption {
@@ -42,22 +46,29 @@ const Options: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
+  const [proxyUrl, setProxyUrl] = useState('');
+  const [proxySaving, setProxySaving] = useState(false);
+  const [proxySaveSuccess, setProxySaveSuccess] = useState(false);
+  const [proxyError, setProxyError] = useState('');
+
   // Load current log level on mount
   useEffect(() => {
-    const loadLevel = async () => {
+    const loadSettings = async () => {
       try {
         const level = await getStoredLogLevel();
         setCurrentLevel(level);
-        // Initialize the logger with the stored level
         logger.init(level);
+
+        const storedProxy = await getStoredProxyUrl();
+        if (storedProxy) setProxyUrl(storedProxy);
       } catch (error) {
-        logger.error('Failed to load log level:', error);
+        logger.error('Failed to load settings:', error);
       } finally {
         setLoading(false);
       }
     };
 
-    loadLevel();
+    loadSettings();
   }, []);
 
   const handleLevelChange = useCallback(async (level: LogLevel) => {
@@ -79,6 +90,37 @@ const Options: React.FC = () => {
       setSaving(false);
     }
   }, []);
+
+  const handleProxySave = useCallback(async () => {
+    setProxyError('');
+    const trimmed = proxyUrl.trim();
+
+    if (trimmed) {
+      if (!trimmed.startsWith('ws://') && !trimmed.startsWith('wss://')) {
+        setProxyError('URL must start with ws:// or wss://');
+        return;
+      }
+
+      try {
+        new URL(trimmed);
+      } catch {
+        setProxyError('Invalid URL format');
+        return;
+      }
+    }
+
+    setProxySaving(true);
+
+    try {
+      await setStoredProxyUrl(trimmed || null);
+      setProxySaveSuccess(true);
+      setTimeout(() => setProxySaveSuccess(false), 2000);
+    } catch {
+      setProxyError('Failed to save');
+    } finally {
+      setProxySaving(false);
+    }
+  }, [proxyUrl]);
 
   if (loading) {
     return (
@@ -140,6 +182,46 @@ const Options: React.FC = () => {
             )}
             <span className="options__current">
               Current: {logLevelToName(currentLevel)}
+            </span>
+          </div>
+        </section>
+
+        <section className="options__section options__section--proxy">
+          <h2>Proxy Override</h2>
+          <p className="options__section-description">
+            Override the proxy used by plugins with your own. The extension
+            appends <code>/proxy?token=&lt;host&gt;</code> automatically. Leave
+            empty to use the default proxy from each plugin.
+          </p>
+
+          <div className="options__proxy-field">
+            <input
+              type="text"
+              className="options__text-input"
+              placeholder="wss://my-verifier.example.com"
+              value={proxyUrl}
+              onChange={(e) => setProxyUrl(e.target.value)}
+              disabled={proxySaving}
+            />
+            <button
+              className="options__save-button"
+              onClick={handleProxySave}
+              disabled={proxySaving}
+            >
+              {proxySaving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+
+          {proxyError && <p className="options__error">{proxyError}</p>}
+
+          <div className="options__status">
+            {proxySaveSuccess && (
+              <span className="options__success">Proxy setting saved!</span>
+            )}
+            <span className="options__current">
+              {proxyUrl.trim()
+                ? `Override active: ${proxyUrl.trim()}`
+                : 'Using plugin defaults'}
             </span>
           </div>
         </section>

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -12,6 +12,7 @@ import {
   validateProvePermission,
   validateOpenWindowPermission,
 } from './permissionValidator';
+import { getStoredProxyUrl } from '../utils/proxyUrlStorage';
 
 export class SessionManager {
   private host: Host;
@@ -47,11 +48,19 @@ export class SessionManager {
           throw new Error('Invalid URL');
         }
 
+        // Check for user-configured proxy override
+        const proxyOverride = await getStoredProxyUrl();
+        const proxyOverrideActive = !!proxyOverride;
+        const effectiveProxyUrl = proxyOverrideActive
+          ? `${proxyOverride.replace(/\/+$/, '')}/proxy?token=${url.hostname}`
+          : proverOptions.proxyUrl;
+
         // Validate permissions before proceeding
         validateProvePermission(
           requestOptions,
-          proverOptions,
+          { ...proverOptions, proxyUrl: effectiveProxyUrl },
           this.currentConfig,
+          proxyOverrideActive,
         );
 
         // Build sessionData with defaults + user-provided data
@@ -64,6 +73,13 @@ export class SessionManager {
           this.emitProgress(step, progress, message);
           onProgress?.({ step, progress, message });
         };
+
+        // Quick connectivity check when using a custom proxy
+        if (proxyOverrideActive) {
+          emitBoth('PROXY_CHECK', 0.0, 'Checking proxy connection...');
+          await checkProxyReachable(effectiveProxyUrl);
+          logger.info(`Using custom proxy override: ${effectiveProxyUrl}`);
+        }
 
         emitBoth('CONNECTING', 0.0, 'Connecting to verifier...');
 
@@ -80,16 +96,12 @@ export class SessionManager {
 
           // Send request via ProveManager which handles IoChannel creation in the worker.
           emitBoth('SENDING_REQUEST', 0.3, 'Sending request...');
-          await this.proveManager.sendRequest(
-            proverId,
-            proverOptions.proxyUrl,
-            {
-              url: requestOptions.url,
-              method: requestOptions.method as Method,
-              headers: requestOptions.headers,
-              body: requestOptions.body,
-            },
-          );
+          await this.proveManager.sendRequest(proverId, effectiveProxyUrl, {
+            url: requestOptions.url,
+            method: requestOptions.method as Method,
+            headers: requestOptions.headers,
+            body: requestOptions.body,
+          });
 
           // Compute reveal ranges via WASM (parses HTTP transcripts + maps handlers to byte ranges)
           emitBoth('PROCESSING_TRANSCRIPT', 0.5, 'Processing transcript...');
@@ -276,4 +288,42 @@ export class SessionManager {
   async extractConfig(code: string): Promise<any> {
     return this.host.getPluginConfig(code);
   }
+}
+
+/**
+ * Quick connectivity check: opens a WebSocket to the proxy URL and
+ * resolves on successful connection or rejects with a clear error.
+ */
+function checkProxyReachable(
+  proxyUrl: string,
+  timeoutMs = 5000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(
+        new Error(
+          `Custom proxy is not reachable (timed out after ${timeoutMs}ms): ${proxyUrl}`,
+        ),
+      );
+    }, timeoutMs);
+
+    const ws = new WebSocket(proxyUrl);
+
+    ws.onopen = () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve();
+    };
+
+    ws.onerror = () => {
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `Custom proxy is not reachable: ${proxyUrl}. ` +
+            `Make sure the proxy server is running and accessible.`,
+        ),
+      );
+    };
+  });
 }

--- a/packages/extension/src/offscreen/permissionValidator.ts
+++ b/packages/extension/src/offscreen/permissionValidator.ts
@@ -36,11 +36,15 @@ export function matchesPathnamePattern(
 /**
  * Validates that a prove() call is allowed by the plugin's permissions.
  * Throws an error if the permission is not granted.
+ *
+ * When skipProxyCheck is true (user has a proxy override configured),
+ * the proxy URL is not validated against plugin permissions.
  */
 export function validateProvePermission(
   requestOptions: { url: string; method: string },
   proverOptions: { verifierUrl: string; proxyUrl: string },
   config: PluginConfig | null,
+  skipProxyCheck = false,
 ): void {
   // If no config or no requests permissions defined, deny by default
   if (!config?.requests || config.requests.length === 0) {
@@ -70,11 +74,13 @@ export function validateProvePermission(
     const verifierMatch = perm.verifierUrl === proverOptions.verifierUrl;
     if (!verifierMatch) return false;
 
-    // Check proxy URL (use derived default if not specified in permission)
-    const expectedProxyUrl =
-      perm.proxyUrl ?? deriveProxyUrl(perm.verifierUrl, url.hostname);
-    const proxyMatch = expectedProxyUrl === proverOptions.proxyUrl;
-    if (!proxyMatch) return false;
+    // Check proxy URL (skip if user override is active)
+    if (!skipProxyCheck) {
+      const expectedProxyUrl =
+        perm.proxyUrl ?? deriveProxyUrl(perm.verifierUrl, url.hostname);
+      const proxyMatch = expectedProxyUrl === proverOptions.proxyUrl;
+      if (!proxyMatch) return false;
+    }
 
     return true;
   });

--- a/packages/extension/src/utils/proxyUrlStorage.ts
+++ b/packages/extension/src/utils/proxyUrlStorage.ts
@@ -1,0 +1,95 @@
+const DB_NAME = 'tlsn-settings';
+const STORE_NAME = 'settings';
+const PROXY_URL_KEY = 'proxyBaseUrl';
+
+/**
+ * Open the IndexedDB database for settings storage
+ */
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+
+    request.onerror = () => {
+      reject(new Error('Failed to open IndexedDB'));
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+  });
+}
+
+/**
+ * Get the stored proxy base URL from IndexedDB.
+ * Returns null if not set or on error.
+ */
+export async function getStoredProxyUrl(): Promise<string | null> {
+  try {
+    const db = await openDatabase();
+    return new Promise((resolve) => {
+      const transaction = db.transaction(STORE_NAME, 'readonly');
+      const store = transaction.objectStore(STORE_NAME);
+      const request = store.get(PROXY_URL_KEY);
+
+      request.onsuccess = () => {
+        const value = request.result;
+        if (typeof value === 'string' && value.length > 0) {
+          resolve(value);
+        } else {
+          resolve(null);
+        }
+      };
+
+      request.onerror = () => {
+        resolve(null);
+      };
+
+      transaction.oncomplete = () => {
+        db.close();
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store the proxy base URL in IndexedDB.
+ * Pass null to clear the setting.
+ */
+export async function setStoredProxyUrl(url: string | null): Promise<void> {
+  try {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite');
+      const store = transaction.objectStore(STORE_NAME);
+      const request =
+        url !== null
+          ? store.put(url, PROXY_URL_KEY)
+          : store.delete(PROXY_URL_KEY);
+
+      request.onsuccess = () => {
+        resolve();
+      };
+
+      request.onerror = () => {
+        reject(new Error('Failed to store proxy URL'));
+      };
+
+      transaction.oncomplete = () => {
+        db.close();
+      };
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to store proxy URL:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a "Proxy Override" setting in the extension options page where users can specify their own WebSocket proxy base URL (e.g. `wss://my-verifier.example.com`)
- When set, the extension appends `/proxy?token=<target_host>` automatically and uses it instead of the plugin-specified proxy
- Performs a quick WebSocket connectivity check before calling TLSNotary WASM, giving users a clear error if their custom proxy is unreachable
- Permission validation skips proxy URL matching when the override is active (method, host, pathname, and verifier URL are still validated)

## Files changed
- **`src/utils/proxyUrlStorage.ts`** (new): IndexedDB get/set for proxy base URL, reusing the existing `tlsn-settings` store
- **`src/offscreen/permissionValidator.ts`**: Added optional `skipProxyCheck` parameter
- **`src/offscreen/SessionManager.ts`**: Reads override, computes effective proxy URL, runs health check
- **`src/entries/Options/index.tsx`**: New "Proxy Override" section with URL validation
- **`src/entries/Options/index.scss`**: Styles for the new UI elements

## Test plan
- [ ] Set a custom proxy URL in extension settings, verify it persists across page reloads
- [ ] Run a plugin with the override active, confirm it uses the custom proxy
- [ ] Enter an unreachable proxy URL, confirm a clear error appears before WASM runs
- [ ] Clear the proxy URL, confirm plugins fall back to their default proxy
- [ ] Enter invalid URLs (no ws:// prefix, malformed), verify validation errors appear