### PR TITLE
fix: handle window close and concurrent plugin execution

### DIFF
--- a/packages/extension/src/background/ConfirmationManager.ts
+++ b/packages/extension/src/background/ConfirmationManager.ts
@@ -46,7 +46,9 @@ export class ConfirmationManager {
     senderOrigin?: string,
     pluginCode?: string,
   ): Promise<boolean> {
-    // Check if there's already a pending confirmation
+    // Check if there's already a pending confirmation.
+    // Claim the slot synchronously (before any await) to prevent concurrent
+    // requestConfirmation calls from both passing the guard.
     if (this.pendingConfirmations.size > 0) {
       logger.warn(
         '[ConfirmationManager] Another confirmation is already pending, rejecting new request',
@@ -54,75 +56,90 @@ export class ConfirmationManager {
       throw new Error('Another plugin confirmation is already in progress');
     }
 
-    // Store plugin code in memory so the popup can request it
-    if (pluginCode) {
-      this.pluginCodeStore.set(requestId, pluginCode);
-    }
-
-    // Build URL with plugin info as query params
-    const popupUrl = this.buildPopupUrl(config, requestId, senderOrigin);
-
-    // Calculate position to center on the active browser window
-    let left: number | undefined;
-    let top: number | undefined;
+    // Reserve the slot immediately with a placeholder so concurrent calls
+    // see size > 0 even before the popup window is created.
+    const placeholder: PendingConfirmation = {
+      requestId,
+      resolve: () => {},
+      reject: () => {},
+    };
+    this.pendingConfirmations.set(requestId, placeholder);
 
     try {
-      const currentWindow = await browser.windows.getCurrent();
-
-      if (
-        currentWindow.left != null &&
-        currentWindow.top != null &&
-        currentWindow.width != null &&
-        currentWindow.height != null
-      ) {
-        left = Math.round(currentWindow.left + (currentWindow.width - this.POPUP_WIDTH) / 2);
-        top = Math.round(currentWindow.top + (currentWindow.height - this.POPUP_HEIGHT) / 2);
+      // Store plugin code in memory so the popup can request it
+      if (pluginCode) {
+        this.pluginCodeStore.set(requestId, pluginCode);
       }
-    } catch {
-      // Fall back to default positioning
-    }
 
-    // Create the confirmation popup window
-    const window = await browser.windows.create({
-      url: popupUrl,
-      type: 'popup',
-      width: this.POPUP_WIDTH,
-      height: this.POPUP_HEIGHT,
-      left,
-      top,
-      focused: true,
-    });
+      // Build URL with plugin info as query params
+      const popupUrl = this.buildPopupUrl(config, requestId, senderOrigin);
 
-    if (!window.id) {
-      throw new Error('Failed to create confirmation popup window');
-    }
+      // Calculate position to center on the active browser window
+      let left: number | undefined;
+      let top: number | undefined;
 
-    this.currentPopupWindowId = window.id;
+      try {
+        const currentWindow = await browser.windows.getCurrent();
 
-    return new Promise<boolean>((resolve, reject) => {
-      // Set up timeout
-      const timeoutId = setTimeout(() => {
-        const pending = this.pendingConfirmations.get(requestId);
-        if (pending) {
-          logger.debug('[ConfirmationManager] Confirmation timed out');
-          this.cleanup(requestId);
-          resolve(false); // Treat timeout as denial
+        if (
+          currentWindow.left != null &&
+          currentWindow.top != null &&
+          currentWindow.width != null &&
+          currentWindow.height != null
+        ) {
+          left = Math.round(currentWindow.left + (currentWindow.width - this.POPUP_WIDTH) / 2);
+          top = Math.round(currentWindow.top + (currentWindow.height - this.POPUP_HEIGHT) / 2);
         }
-      }, this.CONFIRMATION_TIMEOUT_MS);
+      } catch {
+        // Fall back to default positioning
+      }
 
-      // Store pending confirmation
-      this.pendingConfirmations.set(requestId, {
-        requestId,
-        resolve,
-        reject,
-        windowId: window.id!,
-        timeoutId,
+      // Create the confirmation popup window
+      const window = await browser.windows.create({
+        url: popupUrl,
+        type: 'popup',
+        width: this.POPUP_WIDTH,
+        height: this.POPUP_HEIGHT,
+        left,
+        top,
+        focused: true,
       });
 
-      logger.debug(
-        `[ConfirmationManager] Confirmation popup opened: ${window.id} for request: ${requestId}`,
-      );
-    });
+      if (!window.id) {
+        throw new Error('Failed to create confirmation popup window');
+      }
+
+      this.currentPopupWindowId = window.id;
+
+      return new Promise<boolean>((resolve, reject) => {
+        // Set up timeout
+        const timeoutId = setTimeout(() => {
+          const pending = this.pendingConfirmations.get(requestId);
+          if (pending) {
+            logger.debug('[ConfirmationManager] Confirmation timed out');
+            this.cleanup(requestId);
+            resolve(false); // Treat timeout as denial
+          }
+        }, this.CONFIRMATION_TIMEOUT_MS);
+
+        // Replace placeholder with real confirmation state
+        this.pendingConfirmations.set(requestId, {
+          requestId,
+          resolve,
+          reject,
+          windowId: window.id!,
+          timeoutId,
+        });
+
+        logger.debug(
+          `[ConfirmationManager] Confirmation popup opened: ${window.id} for request: ${requestId}`,
+        );
+      });
+    } catch (error) {
+      // Clean up placeholder on failure so subsequent requests aren't blocked
+      this.cleanup(requestId);
+      throw error;
+    }
   }
 
   /**

--- a/packages/extension/src/background/WindowManager.ts
+++ b/packages/extension/src/background/WindowManager.ts
@@ -182,7 +182,11 @@ export class WindowManager implements IWindowManager {
     this.windows.delete(windowId);
     this.clearBatchState(windowId);
 
-    browser.windows.remove(windowId);
+    try {
+      await browser.windows.remove(windowId);
+    } catch {
+      // Ignore — window may already be closed (e.g. user closed it manually)
+    }
 
     browser.runtime.sendMessage({
       type: 'WINDOW_CLOSED',

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -94,12 +94,22 @@ export type ProgressCallback = (data: {
 export class ProveManager {
   /** Maps proverId to its session state - each prover has isolated session */
   private sessions: Map<string, SessionState> = new Map();
-  private onProgress: ProgressCallback | null = null;
+
+  /**
+   * Per-prover progress callbacks. Keyed by proverId so concurrent plugin
+   * executions don't overwrite each other's callback.
+   */
+  private progressCallbacks: Map<string, ProgressCallback> = new Map();
+
   private listenerAdded = false;
 
-  /** Set a callback to receive WASM-side progress events from the worker. */
-  setProgressCallback(cb: ProgressCallback | null) {
-    this.onProgress = cb;
+  /** Register a progress callback for a specific prover. */
+  setProgressCallbackForProver(proverId: string, cb: ProgressCallback | null) {
+    if (cb) {
+      this.progressCallbacks.set(proverId, cb);
+    } else {
+      this.progressCallbacks.delete(proverId);
+    }
   }
 
   async init() {
@@ -107,13 +117,18 @@ export class ProveManager {
     if (!this.listenerAdded) {
       this.listenerAdded = true;
       worker.addEventListener('message', (event: MessageEvent) => {
-        if (event.data?.type === 'WASM_PROGRESS' && this.onProgress) {
-          this.onProgress({
-            step: event.data.step,
-            progress: event.data.progress,
-            message: event.data.message,
-            source: 'wasm',
-          });
+        if (event.data?.type === 'WASM_PROGRESS') {
+          // WASM worker doesn't include proverId in progress messages, so
+          // broadcast to all registered callbacks. In practice only one
+          // prove() runs at a time in the WASM worker.
+          for (const cb of this.progressCallbacks.values()) {
+            cb({
+              step: event.data.step,
+              progress: event.data.progress,
+              message: event.data.message,
+              source: 'wasm',
+            });
+          }
         }
       });
     }
@@ -456,8 +471,9 @@ export class ProveManager {
     // Close WebSocket if open
     this.closeSession(proverId);
 
-    // Remove session state
+    // Remove session state and progress callback
     this.sessions.delete(proverId);
+    this.progressCallbacks.delete(proverId);
 
     // Free worker prover
     try {

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -26,15 +26,64 @@ interface ChromeRuntimeLike {
 import { validateProvePermission, validateOpenWindowPermission } from './permissionValidator';
 
 export class SessionManager {
-  private host: Host;
+  /** Shared Host instance — only used for config extraction (stateless). */
+  private configHost: Host;
   private proveManager: ProveManager;
   private initPromise: Promise<void>;
-  private currentConfig: PluginConfig | null = null;
-  private currentRequestId: string | null = null;
-  private currentSessionData: Record<string, string> | null = null;
 
   constructor() {
-    this.host = new Host({
+    // Lightweight Host for config extraction only (no execution-scoped state)
+    this.configHost = new Host({
+      onProve: async () => {
+        throw new Error('Config host should not be used for proving');
+      },
+      onRenderPluginUi: () => {},
+      onCloseWindow: () => {},
+      onOpenWindow: async () => {
+        throw new Error('Config host should not be used for opening windows');
+      },
+    });
+    this.proveManager = new ProveManager();
+    this.initPromise = this.proveManager.init();
+  }
+
+  private static getChromeRuntime(): ChromeRuntimeLike {
+    const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } }).chrome
+      ?.runtime;
+    if (!chromeRuntime?.sendMessage) {
+      throw new Error('Chrome runtime not available');
+    }
+    return chromeRuntime;
+  }
+
+  /**
+   * Create a per-execution Host with callbacks that close over execution-scoped
+   * state (config, requestId, sessionData). This prevents concurrent plugin
+   * executions from contaminating each other's permission validation.
+   */
+  private createExecutionHost(
+    pluginConfig: PluginConfig | null,
+    requestId: string | null,
+    execSessionData: Record<string, string> | null,
+  ): Host {
+    const proveManager = this.proveManager;
+
+    const emitProgress = (step: string, progress: number, message: string, source = 'js') => {
+      if (!requestId) return;
+      const chromeRuntime = SessionManager.getChromeRuntime();
+      chromeRuntime
+        .sendMessage({
+          type: 'PROVE_PROGRESS',
+          requestId,
+          step,
+          progress,
+          message,
+          source,
+        })
+        .catch((err: unknown) => logger.warn('[SessionManager] emitProgress failed:', err));
+    };
+
+    return new Host({
       onProve: async (
         requestOptions: {
           url: string;
@@ -60,24 +109,24 @@ export class SessionManager {
           throw new Error('Invalid URL');
         }
 
-        // Validate permissions before proceeding
-        validateProvePermission(requestOptions, proverOptions, this.currentConfig);
+        // Validate permissions using this execution's config (not shared state)
+        validateProvePermission(requestOptions, proverOptions, pluginConfig);
 
         // Build sessionData with defaults + execCode-level data + plugin-provided data
         const sessionData: Record<string, string> = {
-          ...this.currentSessionData,
+          ...execSessionData,
           ...proverOptions.sessionData,
         };
 
         // Helper: emit to both the page (via background) and the plugin UI
         const emitBoth = (step: string, progress: number, message: string) => {
-          this.emitProgress(step, progress, message);
+          emitProgress(step, progress, message);
           onProgress?.({ step, progress, message });
         };
 
         emitBoth('CONNECTING', 0.0, 'Connecting to verifier...');
 
-        const proverId = await this.proveManager.createProver(
+        const proverId = await proveManager.createProver(
           url.hostname,
           proverOptions.verifierUrl,
           proverOptions.maxRecvData,
@@ -85,12 +134,19 @@ export class SessionManager {
           sessionData,
         );
 
+        // Register per-prover WASM progress callback
+        if (requestId) {
+          proveManager.setProgressCallbackForProver(proverId, (data) => {
+            emitProgress(data.step, data.progress, data.message, data.source);
+          });
+        }
+
         try {
           emitBoth('MPC_SETUP', 0.15, 'MPC session established');
 
           // Send request via ProveManager which handles IoChannel creation in the worker.
           emitBoth('SENDING_REQUEST', 0.3, 'Sending request...');
-          await this.proveManager.sendRequest(proverId, proverOptions.proxyUrl, {
+          await proveManager.sendRequest(proverId, proverOptions.proxyUrl, {
             url: requestOptions.url,
             method: requestOptions.method as Method,
             headers: requestOptions.headers,
@@ -100,43 +156,39 @@ export class SessionManager {
           // Compute reveal ranges via WASM (parses HTTP transcripts + maps handlers to byte ranges)
           emitBoth('PROCESSING_TRANSCRIPT', 0.5, 'Processing transcript...');
           const { sentRanges, recvRanges, sentRangesWithHandlers, recvRangesWithHandlers } =
-            await this.proveManager.computeReveal(proverId, proverOptions.handlers);
+            await proveManager.computeReveal(proverId, proverOptions.handlers);
 
           logger.debug('sentRanges', sentRanges);
           logger.debug('recvRanges', recvRanges);
 
           // Send reveal config (ranges + handlers) to verifier BEFORE calling reveal()
           emitBoth('SENDING_REVEAL_CONFIG', 0.6, 'Configuring selective disclosure...');
-          await this.proveManager.sendRevealConfig(proverId, {
+          await proveManager.sendRevealConfig(proverId, {
             sent: sentRangesWithHandlers,
             recv: recvRangesWithHandlers,
           });
 
           // Reveal the ranges
           emitBoth('GENERATING_PROOF', 0.7, 'Generating proof...');
-          await this.proveManager.reveal(proverId, {
+          await proveManager.reveal(proverId, {
             sent: sentRanges,
             recv: recvRanges,
           });
 
           // Get structured response from verifier (now includes handler results)
           emitBoth('WAITING_FOR_VERIFICATION', 0.85, 'Waiting for verification...');
-          const response = await this.proveManager.getResponse(proverId);
+          const response = await proveManager.getResponse(proverId);
 
           emitBoth('COMPLETE', 1.0, 'Complete');
 
           return response;
         } finally {
           // Always clean up prover resources to prevent memory leaks
-          await this.proveManager.cleanupProver(proverId);
+          await proveManager.cleanupProver(proverId);
         }
       },
       onRenderPluginUi: (windowId: number, result: DomJson) => {
-        const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } })
-          .chrome?.runtime;
-        if (!chromeRuntime?.sendMessage) {
-          throw new Error('Chrome runtime not available');
-        }
+        const chromeRuntime = SessionManager.getChromeRuntime();
         chromeRuntime.sendMessage({
           type: 'RENDER_PLUGIN_UI',
           json: result,
@@ -144,11 +196,7 @@ export class SessionManager {
         });
       },
       onCloseWindow: (windowId: number) => {
-        const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } })
-          .chrome?.runtime;
-        if (!chromeRuntime?.sendMessage) {
-          throw new Error('Chrome runtime not available');
-        }
+        const chromeRuntime = SessionManager.getChromeRuntime();
         logger.debug('onCloseWindow', windowId);
         return chromeRuntime.sendMessage({
           type: 'CLOSE_WINDOW',
@@ -159,14 +207,10 @@ export class SessionManager {
         url: string,
         options?: { width?: number; height?: number; showOverlay?: boolean },
       ) => {
-        // Validate permissions before proceeding
-        validateOpenWindowPermission(url, this.currentConfig);
+        // Validate permissions using this execution's config (not shared state)
+        validateOpenWindowPermission(url, pluginConfig);
 
-        const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } })
-          .chrome?.runtime;
-        if (!chromeRuntime?.sendMessage) {
-          throw new Error('Chrome runtime not available');
-        }
+        const chromeRuntime = SessionManager.getChromeRuntime();
         return chromeRuntime.sendMessage({
           type: 'OPEN_WINDOW',
           url,
@@ -176,27 +220,6 @@ export class SessionManager {
         }) as Promise<OpenWindowResponse>;
       },
     });
-    this.proveManager = new ProveManager();
-    this.initPromise = this.proveManager.init();
-  }
-
-  /** Send a progress event to the background script for routing to the page. */
-  private emitProgress(step: string, progress: number, message: string, source = 'js') {
-    if (!this.currentRequestId) return;
-    const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } }).chrome
-      ?.runtime;
-    if (chromeRuntime?.sendMessage) {
-      chromeRuntime
-        .sendMessage({
-          type: 'PROVE_PROGRESS',
-          requestId: this.currentRequestId,
-          step,
-          progress,
-          message,
-          source,
-        })
-        .catch((err: unknown) => logger.warn('[SessionManager] emitProgress failed:', err));
-    }
   }
 
   async awaitInit(): Promise<SessionManager> {
@@ -209,51 +232,60 @@ export class SessionManager {
     requestId?: string,
     sessionData?: Record<string, string>,
   ): Promise<unknown> {
-    const chromeRuntime = (global as unknown as { chrome?: { runtime?: ChromeRuntimeLike } }).chrome
-      ?.runtime;
-    if (!chromeRuntime?.onMessage) {
+    const chromeRuntime = SessionManager.getChromeRuntime();
+    if (!chromeRuntime.onMessage) {
       throw new Error('Chrome runtime not available');
     }
 
-    // Store requestId, sessionData, and wire up WASM progress callback
-    this.currentRequestId = requestId || null;
-    this.currentSessionData = sessionData || null;
-    this.proveManager.setProgressCallback(
-      this.currentRequestId
-        ? (data) => {
-            this.emitProgress(data.step, data.progress, data.message, data.source);
-          }
-        : null,
-    );
+    const execRequestId = requestId || null;
 
-    // Extract and store plugin config before execution for permission validation
-    this.currentConfig = await this.extractConfig(code);
-    logger.debug('[SessionManager] Extracted plugin config:', this.currentConfig);
+    // Extract plugin config for permission validation (scoped to this execution)
+    const pluginConfig = await this.extractConfig(code);
+    logger.debug('[SessionManager] Extracted plugin config:', pluginConfig);
 
-    try {
-      return await this.host.executePlugin(code, {
-        eventEmitter: {
-          addListener: (listener: (message: WindowMessage) => void) => {
-            chromeRuntime.onMessage.addListener(listener as (message: unknown) => void);
-          },
-          removeListener: (listener: (message: WindowMessage) => void) => {
-            chromeRuntime.onMessage.removeListener(listener as (message: unknown) => void);
-          },
-          emit: (message: WindowMessage) => {
-            chromeRuntime.sendMessage(message);
-          },
+    // Create a per-execution Host with callbacks that close over this execution's state
+    const host = this.createExecutionHost(pluginConfig, execRequestId, sessionData || null);
+
+    // Wrap the plugin's event listener so it does NOT return a Promise to
+    // Chrome's messaging API. The plugin listener (makeOpenWindow's onMessage)
+    // is async, so it always returns a Promise. If added directly to
+    // chrome.runtime.onMessage, Chrome may use its Promise<undefined> as the
+    // response to unrelated messages (e.g. EXTRACT_CONFIG), racing with the
+    // offscreen's main listener that returns the actual result.
+    const listenerWrappers = new Map<
+      (message: WindowMessage) => void,
+      (message: unknown) => void
+    >();
+
+    return host.executePlugin(code, {
+      eventEmitter: {
+        addListener: (listener: (message: WindowMessage) => void) => {
+          const wrapper = (message: unknown) => {
+            // Fire-and-forget: don't return the Promise so Chrome doesn't
+            // treat it as a messaging response.
+            listener(message as WindowMessage);
+          };
+          listenerWrappers.set(listener, wrapper);
+          chromeRuntime.onMessage.addListener(wrapper);
         },
-      });
-    } finally {
-      this.currentSessionData = null;
-      this.currentRequestId = null;
-    }
+        removeListener: (listener: (message: WindowMessage) => void) => {
+          const wrapper = listenerWrappers.get(listener);
+          if (wrapper) {
+            chromeRuntime.onMessage.removeListener(wrapper);
+            listenerWrappers.delete(listener);
+          }
+        },
+        emit: (message: WindowMessage) => {
+          chromeRuntime.sendMessage(message);
+        },
+      },
+    });
   }
 
   /**
    * Extract plugin config using QuickJS sandbox (more reliable than regex)
    */
   async extractConfig(code: string): Promise<PluginConfig | null> {
-    return (await this.host.getPluginConfig(code)) ?? null;
+    return (await this.configHost.getPluginConfig(code)) ?? null;
   }
 }

--- a/packages/extension/tests/background/ConfirmationManager.test.ts
+++ b/packages/extension/tests/background/ConfirmationManager.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for ConfirmationManager concurrency fix.
+ *
+ * Bug: The pendingConfirmations.size > 0 guard had an async gap between the
+ * check (line 50) and the Map.set (line 114). Two concurrent
+ * requestConfirmation() calls could both pass the guard since the Map wasn't
+ * populated until after awaiting browser.windows.create().
+ *
+ * Fix: Claim the slot synchronously with a placeholder entry before any await.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import browser from 'webextension-polyfill';
+
+// Must import after mocks are set up (via setup.ts)
+const { ConfirmationManager } = await import('../../src/background/ConfirmationManager');
+
+describe('ConfirmationManager', () => {
+  let cm: InstanceType<typeof ConfirmationManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // windows.remove is called in handleConfirmationResponse and must return a thenable
+    vi.mocked(browser.windows.remove).mockResolvedValue(undefined as never);
+    cm = new ConfirmationManager();
+  });
+
+  it('rejects second concurrent requestConfirmation while first is pending', async () => {
+    // Mock windows.create to resolve (but the returned Promise from
+    // requestConfirmation won't settle until handleConfirmationResponse)
+    const mockedCreate = vi.mocked(browser.windows.create);
+    mockedCreate.mockResolvedValue({ id: 100, tabs: [] } as browser.Windows.Window);
+
+    // Start first confirmation (don't await — it won't settle yet)
+    const first = cm.requestConfirmation(
+      { name: 'Plugin A', description: 'desc' },
+      'req-1',
+      'https://example.com',
+    );
+
+    // Let microtasks settle so the first call completes its sync portion
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Second confirmation should be immediately rejected
+    await expect(
+      cm.requestConfirmation(
+        { name: 'Plugin B', description: 'desc' },
+        'req-2',
+        'https://example.com',
+      ),
+    ).rejects.toThrow('Another plugin confirmation is already in progress');
+
+    // Clean up: resolve the first confirmation so it doesn't leak
+    cm.handleConfirmationResponse('req-1', false);
+    await first;
+  });
+
+  it('allows new confirmation after previous one completes', async () => {
+    const mockedCreate = vi.mocked(browser.windows.create);
+    mockedCreate.mockResolvedValue({ id: 200, tabs: [] } as browser.Windows.Window);
+
+    // Start and complete first confirmation
+    const first = cm.requestConfirmation(
+      { name: 'Plugin A', description: 'desc' },
+      'req-1',
+      'https://example.com',
+    );
+
+    // Let the async window creation settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    cm.handleConfirmationResponse('req-1', true);
+    const result = await first;
+    expect(result).toBe(true);
+
+    // Second confirmation should now work
+    const second = cm.requestConfirmation(
+      { name: 'Plugin B', description: 'desc' },
+      'req-2',
+      'https://example.com',
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    cm.handleConfirmationResponse('req-2', true);
+    const result2 = await second;
+    expect(result2).toBe(true);
+  });
+
+  it('cleans up placeholder if window creation fails', async () => {
+    const mockedCreate = vi.mocked(browser.windows.create);
+    mockedCreate.mockRejectedValue(new Error('Browser not available'));
+
+    await expect(
+      cm.requestConfirmation(
+        { name: 'Plugin A', description: 'desc' },
+        'req-1',
+        'https://example.com',
+      ),
+    ).rejects.toThrow('Browser not available');
+
+    // Should not be blocked — placeholder was cleaned up
+    expect(cm.hasPendingConfirmation()).toBe(false);
+  });
+
+  it('cleans up placeholder if window has no id', async () => {
+    const mockedCreate = vi.mocked(browser.windows.create);
+    mockedCreate.mockResolvedValue({} as browser.Windows.Window);
+
+    await expect(
+      cm.requestConfirmation(
+        { name: 'Plugin A', description: 'desc' },
+        'req-1',
+        'https://example.com',
+      ),
+    ).rejects.toThrow('Failed to create confirmation popup window');
+
+    expect(cm.hasPendingConfirmation()).toBe(false);
+  });
+});

--- a/packages/extension/tests/browser/globalSetup.ts
+++ b/packages/extension/tests/browser/globalSetup.ts
@@ -26,13 +26,13 @@ async function waitForHealth(url: string, timeoutMs: number): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
-      const resp = await fetch(url);
+      const resp = await fetch(url, { signal: AbortSignal.timeout(3000) });
       if (resp.ok) {
         const text = await resp.text();
         if (text === 'ok') return;
       }
     } catch {
-      // Server not ready yet
+      // Server not ready yet, or request timed out
     }
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
   }
@@ -76,7 +76,7 @@ function findVerifierBin(verifierDir: string): { cmd: string; args: string[] } |
 export async function setup(): Promise<void> {
   // Check if the server is already running (handles double-invocation by Vitest)
   try {
-    const resp = await fetch(HEALTH_URL);
+    const resp = await fetch(HEALTH_URL, { signal: AbortSignal.timeout(3000) });
     if (resp.ok && (await resp.text()) === 'ok') {
       console.log(
         `[globalSetup] Verifier already running on port ${VERIFIER_PORT}, skipping start`,

--- a/packages/extension/tests/offscreen/ProveManager.test.ts
+++ b/packages/extension/tests/offscreen/ProveManager.test.ts
@@ -152,4 +152,73 @@ describe('ProveManager', () => {
       /Session not found/,
     );
   });
+
+  // -----------------------------------------------------------------------
+  // Per-prover progress callbacks (concurrency fix)
+  // -----------------------------------------------------------------------
+  describe('Per-prover progress callbacks', () => {
+    it('routes WASM progress to the correct prover callback', async () => {
+      await pm.init();
+
+      const callsA: string[] = [];
+      const callsB: string[] = [];
+
+      pm.setProgressCallbackForProver('prover-A', (data) => callsA.push(data.message));
+      pm.setProgressCallbackForProver('prover-B', (data) => callsB.push(data.message));
+
+      // Simulate WASM_PROGRESS worker message — broadcasts to all callbacks
+      const listener = mockAddEventListener.mock.calls[0][1];
+      listener({
+        data: { type: 'WASM_PROGRESS', step: 'TEST', progress: 0.5, message: 'half done' },
+      });
+
+      expect(callsA).toEqual(['half done']);
+      expect(callsB).toEqual(['half done']);
+    });
+
+    it('does not fire callback after prover is cleaned up', async () => {
+      await pm.init();
+
+      const calls: string[] = [];
+      pm.setProgressCallbackForProver('prover-X', (data) => calls.push(data.message));
+
+      // Simulate cleanup (removes callback)
+      (pm as unknown as { sessions: Map<string, unknown> }).sessions.set('prover-X', {
+        sessionId: 'sess-x',
+        webSocket: { readyState: 3, close: vi.fn() },
+        response: null,
+        responseReceived: false,
+      });
+      await pm.cleanupProver('prover-X');
+
+      // Fire progress after cleanup
+      const listener = mockAddEventListener.mock.calls[0][1];
+      listener({
+        data: { type: 'WASM_PROGRESS', step: 'TEST', progress: 1, message: 'late' },
+      });
+
+      expect(calls).toEqual([]);
+    });
+
+    it('isolates callbacks — removing one does not affect the other', async () => {
+      await pm.init();
+
+      const callsA: string[] = [];
+      const callsB: string[] = [];
+
+      pm.setProgressCallbackForProver('prover-A', (data) => callsA.push(data.message));
+      pm.setProgressCallbackForProver('prover-B', (data) => callsB.push(data.message));
+
+      // Remove A's callback
+      pm.setProgressCallbackForProver('prover-A', null);
+
+      const listener = mockAddEventListener.mock.calls[0][1];
+      listener({
+        data: { type: 'WASM_PROGRESS', step: 'TEST', progress: 1, message: 'msg' },
+      });
+
+      expect(callsA).toEqual([]);
+      expect(callsB).toEqual(['msg']);
+    });
+  });
 });

--- a/packages/extension/tests/setup.ts
+++ b/packages/extension/tests/setup.ts
@@ -27,7 +27,7 @@ const chromeMock = {
   windows: {
     create: vi.fn(),
     get: vi.fn(),
-    remove: vi.fn(),
+    remove: vi.fn().mockResolvedValue(undefined),
     update: vi.fn(),
     onRemoved: {
       addListener: vi.fn(),

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -266,9 +266,22 @@ function makeOpenWindow(
         return;
       }
 
-      // Handle window closed first - always remove listener
+      // Handle window closed — check if it's our window
       if (message.type === 'WINDOW_CLOSED') {
+        const executionContext = executionContextRegistry.get(uuid);
+        const ourWindowId = executionContext?.windowId ?? resolvedWindowId;
+
+        // Ignore close events for other windows
+        if (ourWindowId != null && message.windowId !== ourWindowId) {
+          return;
+        }
+
         eventEmitter.removeListener(onMessage);
+
+        // Terminate the plugin if it hasn't already completed
+        if (!lifecycle.isCompleted && onError) {
+          onError(new Error('Window closed by user'));
+        }
         return;
       }
 
@@ -415,11 +428,14 @@ function makeOpenWindow(
           let headers = executionContext.headers || [];
           let requests = executionContext.requests || [];
           let bufferedCount = 0;
+          let windowWasClosed = false;
 
           for (const msg of pendingMessages) {
             if (msg.windowId !== windowId) continue;
 
-            if (msg.type === 'HEADER_INTERCEPTED' && msg.header) {
+            if (msg.type === 'WINDOW_CLOSED') {
+              windowWasClosed = true;
+            } else if (msg.type === 'HEADER_INTERCEPTED' && msg.header) {
               headers = [...headers, msg.header];
               bufferedCount++;
             } else if (msg.type === 'HEADERS_BATCH' && msg.headers) {
@@ -441,6 +457,20 @@ function makeOpenWindow(
             updateExecutionContext(uuid, { headers, requests });
             // Trigger a single re-render so the plugin sees the buffered data
             executionContext.main(true);
+          }
+          // If window was closed while we were waiting, terminate
+          if (windowWasClosed) {
+            eventEmitter.removeListener(onMessage);
+            if (!lifecycle.isCompleted && onError) {
+              onError(new Error('Window closed by user'));
+            }
+            pendingMessages.length = 0;
+            cachedResult = {
+              windowId: response.payload.windowId,
+              uuid: response.payload.uuid,
+              tabId: response.payload.tabId,
+            };
+            return cachedResult;
           }
         }
         pendingMessages.length = 0;

--- a/packages/plugin-sdk/test/index.browser.test.ts
+++ b/packages/plugin-sdk/test/index.browser.test.ts
@@ -1304,7 +1304,16 @@ describe('QuickJS Browser E2E', () => {
 
         await new Promise((r) => setTimeout(r, 200));
 
-        // Close the window — listener should be removed
+        // Attach rejection handler BEFORE emitting WINDOW_CLOSED to prevent
+        // unhandled rejection (the emit synchronously rejects the promise).
+        let rejected2 = false;
+        let rejectError2: Error | null = null;
+        donePromise2.catch((err: Error) => {
+          rejected2 = true;
+          rejectError2 = err;
+        });
+
+        // Close the window — listener should be removed, plugin terminates
         emitter2.emit({ type: 'WINDOW_CLOSED', windowId: 1 } as WindowMessage);
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1323,19 +1332,9 @@ describe('QuickJS Browser E2E', () => {
 
         await new Promise((r) => setTimeout(r, 100));
 
-        // donePromise2 should never resolve because no requests were received
-        // before WINDOW_CLOSED, and requests after close are ignored.
-        // We verify by checking it's still pending after the timeout.
-        let resolved = false;
-        donePromise2
-          .then(() => {
-            resolved = true;
-          })
-
-          .catch(() => {});
-        await new Promise((r) => setTimeout(r, 100));
-
-        expect(resolved).toBe(false);
+        // donePromise2 should have rejected with "Window closed by user"
+        expect(rejected2).toBe(true);
+        expect(rejectError2?.message).toContain('Window closed by user');
 
         // Cleanup: emit WINDOW_CLOSED on original emitter too
         void donePromise;

--- a/packages/plugin-sdk/test/windowClose.test.ts
+++ b/packages/plugin-sdk/test/windowClose.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for window close handling.
+ *
+ * Bug: When a user closes a managed window (e.g. the Spotify page) while a
+ * plugin is running, the plugin never terminates — done() is never called,
+ * so the execCode() Promise hangs forever and the demo page spinner keeps
+ * spinning.
+ *
+ * Fix: When WINDOW_CLOSED is received for the plugin's window, terminate
+ * the plugin via onError so the donePromise rejects.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Host } from '../src/index';
+import type { WindowMessage } from '../src/types';
+
+type Listener = (message: WindowMessage) => void;
+
+function createTestEventEmitter() {
+  const listeners: Listener[] = [];
+  return {
+    emit: (message: WindowMessage) => {
+      listeners.forEach((l) => l(message));
+    },
+    addListener: (listener: Listener) => {
+      listeners.push(listener);
+    },
+    removeListener: (listener: Listener) => {
+      const idx = listeners.indexOf(listener);
+      if (idx >= 0) listeners.splice(idx, 1);
+    },
+    get listenerCount() {
+      return listeners.length;
+    },
+  };
+}
+
+describe.skipIf(typeof window !== 'undefined')('Window close handling', () => {
+  it('should terminate plugin when its window is closed by user', async () => {
+    const eventEmitter = createTestEventEmitter();
+    const WINDOW_ID = 50;
+    const onCloseWindow = vi.fn();
+
+    const onOpenWindow = vi.fn().mockResolvedValue({
+      type: 'WINDOW_OPENED',
+      payload: { windowId: WINDOW_ID, uuid: 'test-uuid', tabId: 100 },
+    });
+
+    const host = new Host({
+      onProve: vi.fn(),
+      onRenderPluginUi: vi.fn(),
+      onCloseWindow,
+      onOpenWindow,
+    });
+
+    // Plugin opens a window and waits for headers — never calls done()
+    const pluginCode = `
+export const config = { name: 'Window Close Test' };
+
+export function main() {
+  openWindow('https://x.com');
+  const allHeaders = useHeaders((h) => h);
+  return div({}, ['waiting for headers: ' + allHeaders.length]);
+}
+`.trim();
+
+    const executePromise = host.executePlugin(pluginCode, { eventEmitter });
+
+    // Wait for plugin to initialize and open window
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Simulate user closing the window
+    eventEmitter.emit({
+      type: 'WINDOW_CLOSED',
+      windowId: WINDOW_ID,
+    });
+
+    // The plugin should reject with "Window closed by user"
+    await expect(executePromise).rejects.toThrow('Window closed by user');
+
+    // Listener should be cleaned up
+    expect(eventEmitter.listenerCount).toBe(0);
+  }, 30_000);
+
+  it('should NOT terminate plugin when a different window is closed', async () => {
+    const eventEmitter = createTestEventEmitter();
+    const WINDOW_ID = 51;
+    const OTHER_WINDOW_ID = 999;
+
+    const onOpenWindow = vi.fn().mockResolvedValue({
+      type: 'WINDOW_OPENED',
+      payload: { windowId: WINDOW_ID, uuid: 'test-uuid', tabId: 100 },
+    });
+
+    const host = new Host({
+      onProve: vi.fn(),
+      onRenderPluginUi: vi.fn(),
+      onCloseWindow: vi.fn(),
+      onOpenWindow,
+    });
+
+    // Plugin opens a window and calls done() when it sees a header
+    const pluginCode = `
+export const config = { name: 'Other Window Close Test' };
+
+export function main() {
+  openWindow('https://x.com');
+  const allHeaders = useHeaders((h) => h);
+  if (allHeaders.length > 0) {
+    done('completed');
+  }
+  return div({}, ['waiting...']);
+}
+`.trim();
+
+    const executePromise = host.executePlugin(pluginCode, { eventEmitter });
+
+    // Wait for plugin to initialize
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // Close a DIFFERENT window — plugin should keep running
+    eventEmitter.emit({
+      type: 'WINDOW_CLOSED',
+      windowId: OTHER_WINDOW_ID,
+    });
+
+    // Plugin should still be running — send a header so it completes
+    eventEmitter.emit({
+      type: 'HEADER_INTERCEPTED',
+      header: {
+        id: '1',
+        method: 'GET',
+        url: 'https://api.x.com/test',
+        timestamp: Date.now(),
+        type: 'xmlhttprequest',
+        requestHeaders: [],
+        tabId: 100,
+      },
+      windowId: WINDOW_ID,
+    });
+
+    const result = await executePromise;
+    expect(result).toBe('completed');
+  }, 30_000);
+
+  it('should terminate plugin when window is closed during onOpenWindow buffering', async () => {
+    const eventEmitter = createTestEventEmitter();
+    const WINDOW_ID = 52;
+
+    // onOpenWindow emits WINDOW_CLOSED while still resolving
+    const onOpenWindow = vi.fn().mockImplementation(async () => {
+      // Window opens then immediately closes (user closes it very fast)
+      eventEmitter.emit({
+        type: 'WINDOW_CLOSED',
+        windowId: WINDOW_ID,
+      });
+
+      return {
+        type: 'WINDOW_OPENED',
+        payload: { windowId: WINDOW_ID, uuid: 'test-uuid', tabId: 100 },
+      };
+    });
+
+    const host = new Host({
+      onProve: vi.fn(),
+      onRenderPluginUi: vi.fn(),
+      onCloseWindow: vi.fn(),
+      onOpenWindow,
+    });
+
+    const pluginCode = `
+export const config = { name: 'Buffered Close Test' };
+
+export function main() {
+  openWindow('https://x.com');
+  const allHeaders = useHeaders((h) => h);
+  return div({}, ['waiting...']);
+}
+`.trim();
+
+    const executePromise = host.executePlugin(pluginCode, { eventEmitter });
+
+    // The plugin should reject because WINDOW_CLOSED was buffered
+    await expect(executePromise).rejects.toThrow('Window closed by user');
+
+    // Listener should be cleaned up
+    expect(eventEmitter.listenerCount).toBe(0);
+  }, 30_000);
+
+  it('should clean up listener after window close terminates plugin', async () => {
+    const eventEmitter = createTestEventEmitter();
+    const WINDOW_ID = 53;
+    const onCloseWindow = vi.fn();
+
+    const onOpenWindow = vi.fn().mockResolvedValue({
+      type: 'WINDOW_OPENED',
+      payload: { windowId: WINDOW_ID, uuid: 'test-uuid', tabId: 100 },
+    });
+
+    const host = new Host({
+      onProve: vi.fn(),
+      onRenderPluginUi: vi.fn(),
+      onCloseWindow,
+      onOpenWindow,
+    });
+
+    const pluginCode = `
+export const config = { name: 'Cleanup Test' };
+
+export function main() {
+  openWindow('https://x.com');
+  const allHeaders = useHeaders((h) => h);
+  return div({}, ['waiting...']);
+}
+`.trim();
+
+    const executePromise = host.executePlugin(pluginCode, { eventEmitter });
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    // At this point, there should be a listener registered
+    expect(eventEmitter.listenerCount).toBeGreaterThan(0);
+
+    // Close the window
+    eventEmitter.emit({
+      type: 'WINDOW_CLOSED',
+      windowId: WINDOW_ID,
+    });
+
+    await executePromise.catch(() => {
+      // Expected rejection
+    });
+
+    // Listener should be fully cleaned up — no leaks
+    expect(eventEmitter.listenerCount).toBe(0);
+
+    // onCloseWindow should have been called (terminateWithError closes the window)
+    expect(onCloseWindow).toHaveBeenCalledWith(WINDOW_ID);
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- **Window close handling**: When a user closes a managed window (e.g. the Spotify page) while a plugin is running, the plugin now terminates with "Window closed by user" instead of hanging forever. Also filters WINDOW_CLOSED by windowId so unrelated windows don't interfere.
- **Concurrent plugin execution**: Fixed shared mutable state on the SessionManager singleton (`currentConfig`, `currentRequestId`, `currentSessionData`) that caused plugins to use each other's permission config. Each execution now gets its own Host instance with closures over execution-scoped state.
- **Chrome messaging race**: Wrapped the plugin event listener so it doesn't return a Promise to Chrome's messaging API, preventing it from racing with the offscreen's EXTRACT_CONFIG response (which caused "Unknown plugin" in the confirmation dialog).
- **Per-prover progress callbacks**: Replaced single shared `onProgress` callback on ProveManager with a per-prover `progressCallbacks` Map.
- **ConfirmationManager race**: Fixed async gap in the `pendingConfirmations.size > 0` guard by claiming the slot synchronously before any await.
- **Browser test globalSetup**: Added 3s timeout to fetch() health checks so a stale process holding the port doesn't hang Vitest indefinitely.

## Test plan

- [x] `npm run test` — 393 tests passing (172 extension + 221 plugin-sdk)
- [x] `npm run test:browser -w @tlsn/plugin-sdk` — 41 browser tests passing
- [x] `npm run lint` — clean
- [x] New tests: `windowClose.test.ts` (4 tests), `ConfirmationManager.test.ts` (4 tests), `ProveManager.test.ts` (3 new tests)
- [x] Updated `index.browser.test.ts` to expect rejection on WINDOW_CLOSED
- [ ] Manual: run demo, start plugin A, close its window → spinner stops with error
- [ ] Manual: run plugin A, then plugin B → both use correct permissions