### PR TITLE
feat(mobile): native progress reporting for proof generation

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -117,7 +117,13 @@ cd packages/verifier
 cargo run
 ```
 
-The verifier runs on `http://localhost:7047`. On iOS simulator this is accessible as-is. On Android emulator, the app automatically rewrites `localhost` to `10.0.2.2`.
+The verifier runs on `http://localhost:7047` by default. On iOS simulator this is accessible as-is. On Android emulator, the app automatically rewrites `localhost` to `10.0.2.2`.
+
+To use a remote verifier (e.g. the public demo server), set the environment variable before bundling the app:
+
+```bash
+EXPO_PUBLIC_VERIFIER_URL=https://demo.tlsnotary.org npx expo start
+```
 
 ## Build Dependency Chain
 

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -119,10 +119,11 @@ cargo run
 
 The verifier runs on `http://localhost:7047` by default. On iOS simulator this is accessible as-is. On Android emulator, the app automatically rewrites `localhost` to `10.0.2.2`.
 
-To use a remote verifier (e.g. the public demo server), set the environment variable before bundling the app:
+To use a remote verifier (e.g. the public demo server), rebuild the plugins with `MOBILE_VERIFIER_URL` and start the app:
 
 ```bash
-EXPO_PUBLIC_VERIFIER_URL=https://demo.tlsnotary.org npx expo start
+MOBILE_VERIFIER_URL=https://demo.tlsnotary.org npm run build:plugins
+npm run mobile:ios
 ```
 
 ## Build Dependency Chain

--- a/packages/mobile/assets/plugins/registry.ts
+++ b/packages/mobile/assets/plugins/registry.ts
@@ -28,7 +28,7 @@ const CODE_MAP: Record<string, () => string> = {
     require('@tlsn/plugins/dist/mobile/discord_profile').DISCORD_PROFILE_PLUGIN_CODE,
 };
 
-const VERIFIER_URL = 'http://localhost:7047';
+const VERIFIER_URL = process.env.EXPO_PUBLIC_VERIFIER_URL || 'http://localhost:7047';
 
 function toPluginEntry(meta: PluginMetadata): PluginEntry {
   return {

--- a/packages/mobile/assets/plugins/registry.ts
+++ b/packages/mobile/assets/plugins/registry.ts
@@ -28,8 +28,6 @@ const CODE_MAP: Record<string, () => string> = {
     require('@tlsn/plugins/dist/mobile/discord_profile').DISCORD_PROFILE_PLUGIN_CODE,
 };
 
-const VERIFIER_URL = process.env.EXPO_PUBLIC_VERIFIER_URL || 'http://localhost:7047';
-
 function toPluginEntry(meta: PluginMetadata): PluginEntry {
   return {
     id: meta.id,
@@ -41,10 +39,7 @@ function toPluginEntry(meta: PluginMetadata): PluginEntry {
     pluginConfig: {
       name: meta.pluginConfig.name,
       description: meta.pluginConfig.description,
-      requests: meta.pluginConfig.requests.map((r) => ({
-        ...r,
-        verifierUrl: VERIFIER_URL,
-      })),
+      requests: meta.pluginConfig.requests,
       urls: meta.pluginConfig.urls,
       oauthHosts: meta.pluginConfig.oauthHosts,
     },

--- a/packages/mobile/build.sh
+++ b/packages/mobile/build.sh
@@ -18,7 +18,7 @@ set -e
 #   --clean                 # Clean prebuild before building
 #
 # Environment:
-#   MOBILE_VERIFIER_URL     # Verifier URL for plugins (default: http://localhost:7047)
+#   EXPO_PUBLIC_VERIFIER_URL  # Verifier URL inlined at bundle time (default: http://localhost:7047)
 ##############################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/packages/mobile/build.sh
+++ b/packages/mobile/build.sh
@@ -18,7 +18,7 @@ set -e
 #   --clean                 # Clean prebuild before building
 #
 # Environment:
-#   EXPO_PUBLIC_VERIFIER_URL  # Verifier URL inlined at bundle time (default: http://localhost:7047)
+#   MOBILE_VERIFIER_URL     # Verifier URL for plugins (default: http://localhost:7047)
 ##############################################################################
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/packages/mobile/components/tlsn/NativeProver.tsx
+++ b/packages/mobile/components/tlsn/NativeProver.tsx
@@ -8,54 +8,20 @@ import React, {
 } from 'react';
 import { Platform } from 'react-native';
 
-// Type definitions (will be replaced with actual module import after prebuild)
-interface ProveRequest {
-  url: string;
-  method: string;
-  headers: Record<string, string>;
-  body?: string;
-}
+// Type-only imports are erased at compile time, so they're safe even before prebuild.
+import type {
+  ProveRequest,
+  HandlerType,
+  HandlerPart,
+  HandlerAction,
+  HandlerParams,
+  Handler,
+  ProverOptions,
+  ProveResult,
+  ProveProgress,
+} from '../../modules/tlsn-native/src';
 
-// Handler types matching Rust enums
-export type HandlerType = 'Sent' | 'Recv';
-export type HandlerPart = 'StartLine' | 'Headers' | 'Body' | 'All';
-export type HandlerAction = 'Reveal';
-
-export interface HandlerParams {
-  key?: string; // For HEADERS: specific header key
-  contentType?: string; // For BODY: "json" for JSON parsing
-  path?: string; // For BODY with JSON: JSON path like "items.0.name"
-}
-
-export interface Handler {
-  handlerType: HandlerType;
-  part: HandlerPart;
-  action: HandlerAction;
-  params?: HandlerParams;
-}
-
-interface ProverOptions {
-  verifierUrl: string;
-  maxSentData?: number;
-  maxRecvData?: number;
-  handlers?: Handler[];
-}
-
-interface ProveResult {
-  status: number;
-  body: unknown;
-  transcript: {
-    sentLength: number;
-    recvLength: number;
-  };
-  handlersReceived?: number;
-}
-
-export interface ProveProgress {
-  step: string;
-  progress: number;
-  message: string;
-}
+export type { HandlerType, HandlerPart, HandlerAction, HandlerParams, Handler, ProveProgress };
 
 export interface NativeProveParams {
   url: string;

--- a/packages/mobile/components/tlsn/NativeProver.tsx
+++ b/packages/mobile/components/tlsn/NativeProver.tsx
@@ -51,6 +51,12 @@ interface ProveResult {
   handlersReceived?: number;
 }
 
+export interface ProveProgress {
+  step: string;
+  progress: number;
+  message: string;
+}
+
 export interface NativeProveParams {
   url: string;
   method: string;
@@ -71,6 +77,7 @@ export interface NativeProverHandle {
 interface NativeProverProps {
   onReady?: () => void;
   onError?: (error: string) => void;
+  onProgress?: (progress: ProveProgress) => void;
 }
 
 // Lazy load the native module to avoid errors during metro bundling
@@ -78,6 +85,7 @@ let TlsnNative: {
   initialize: () => void;
   prove: (request: ProveRequest, options: ProverOptions) => Promise<ProveResult>;
   isAvailable: () => boolean;
+  addProgressListener: (callback: (event: ProveProgress) => void) => { remove: () => void };
 } | null = null;
 
 function getNativeModule() {
@@ -93,11 +101,13 @@ function getNativeModule() {
 }
 
 function NativeProverComponent(
-  { onReady, onError }: NativeProverProps,
+  { onReady, onError, onProgress }: NativeProverProps,
   ref: React.ForwardedRef<NativeProverHandle>,
 ) {
   const [isReady, setIsReady] = useState(false);
   const initAttempted = useRef(false);
+  const onProgressRef = useRef(onProgress);
+  onProgressRef.current = onProgress; // eslint-disable-line react-hooks/refs
 
   useEffect(() => {
     if (initAttempted.current) return;
@@ -133,6 +143,21 @@ function NativeProverComponent(
 
     initializeModule();
   }, [onReady, onError]);
+
+  // Subscribe to native progress events
+  useEffect(() => {
+    const module = getNativeModule();
+    if (!module) return;
+
+    const subscription = module.addProgressListener((event: ProveProgress) => {
+      console.log(
+        `[NativeProver] Progress: ${event.step} ${Math.round(event.progress * 100)}% - ${event.message}`,
+      );
+      onProgressRef.current?.(event);
+    });
+
+    return () => subscription.remove();
+  }, []);
 
   const prove = useCallback(
     async (params: NativeProveParams): Promise<ProveResult> => {

--- a/packages/mobile/components/tlsn/PluginScreen.tsx
+++ b/packages/mobile/components/tlsn/PluginScreen.tsx
@@ -142,6 +142,10 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
     return emitter;
   }, []);
 
+  // Resolve verifier URL: prefer the registry config (driven by EXPO_PUBLIC_VERIFIER_URL)
+  // over whatever the plugin code has baked in.
+  const configVerifierUrl = pluginConfig.requests?.[0]?.verifierUrl;
+
   // Create host
   /* eslint-disable react-hooks/refs */
   const host = useMemo(() => {
@@ -166,7 +170,7 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
           method: requestOptions.method,
           headers: requestOptions.headers,
           proverOptions: {
-            verifierUrl: proverOptions.verifierUrl,
+            verifierUrl: configVerifierUrl || proverOptions.verifierUrl,
             maxSentData: proverOptions.maxSentData ?? 4096,
             maxRecvData: proverOptions.maxRecvData ?? 16384,
             handlers: nativeHandlers,

--- a/packages/mobile/components/tlsn/PluginScreen.tsx
+++ b/packages/mobile/components/tlsn/PluginScreen.tsx
@@ -142,10 +142,6 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
     return emitter;
   }, []);
 
-  // Resolve verifier URL: prefer the registry config (driven by EXPO_PUBLIC_VERIFIER_URL)
-  // over whatever the plugin code has baked in.
-  const configVerifierUrl = pluginConfig.requests?.[0]?.verifierUrl;
-
   // Create host
   /* eslint-disable react-hooks/refs */
   const host = useMemo(() => {
@@ -170,7 +166,7 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
           method: requestOptions.method,
           headers: requestOptions.headers,
           proverOptions: {
-            verifierUrl: configVerifierUrl || proverOptions.verifierUrl,
+            verifierUrl: proverOptions.verifierUrl,
             maxSentData: proverOptions.maxSentData ?? 4096,
             maxRecvData: proverOptions.maxRecvData ?? 16384,
             handlers: nativeHandlers,

--- a/packages/mobile/components/tlsn/PluginScreen.tsx
+++ b/packages/mobile/components/tlsn/PluginScreen.tsx
@@ -2,7 +2,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, StyleSheet, ActivityIndicator, PanResponder, Animated } from 'react-native';
 import { PluginWebView, InterceptedRequestHeader } from './PluginWebView';
 import { PluginRenderer, DomJson } from './PluginRenderer';
-import { NativeProver, NativeProverHandle, Handler as NativeHandler } from './NativeProver';
+import {
+  NativeProver,
+  NativeProverHandle,
+  Handler as NativeHandler,
+  ProveProgress,
+} from './NativeProver';
 import {
   MobilePluginHost,
   PluginConfig,
@@ -225,6 +230,14 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
     [host],
   );
 
+  // Forward native prover progress events to plugin state
+  const handleProveProgress = useCallback(
+    (progress: ProveProgress) => {
+      host.setProveProgress(progress);
+    },
+    [host],
+  );
+
   // Start plugin execution when prover is ready
   useEffect(() => {
     if (!proverReady || isRunning) return;
@@ -289,6 +302,7 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
           console.error('[PluginScreen] Native prover error:', err);
           setError(`Prover error: ${err}`);
         }}
+        onProgress={handleProveProgress}
       />
 
       {/* WebView for login/header interception */}

--- a/packages/mobile/lib/MobilePluginHost.ts
+++ b/packages/mobile/lib/MobilePluginHost.ts
@@ -381,11 +381,30 @@ export class MobilePluginHost {
   private onOpenWindow: MobilePluginHostOptions['onOpenWindow'];
   private onCloseWindow: MobilePluginHostOptions['onCloseWindow'];
 
+  // References to the active execution's state, used by setProveProgress()
+  private _activeStateStore: Record<string, unknown> | null = null;
+  private _activeEventEmitter: EventEmitter | null = null;
+  private _activeUuid: string | null = null;
+
   constructor(options: MobilePluginHostOptions) {
     this.onProve = options.onProve;
     this.onRenderPluginUi = options.onRenderPluginUi;
     this.onOpenWindow = options.onOpenWindow;
     this.onCloseWindow = options.onCloseWindow;
+  }
+
+  /**
+   * Update the _proveProgress state from an external source (e.g. native progress events).
+   * This triggers a UI re-render so the plugin's progress bar updates.
+   */
+  setProveProgress(data: { step: string; progress: number; message: string } | null): void {
+    if (!this._activeStateStore || !this._activeEventEmitter || !this._activeUuid) return;
+    this._activeStateStore['_proveProgress'] = data;
+    const ctx = contextRegistry.get(this._activeUuid);
+    this._activeEventEmitter.emit({
+      type: 'RE_RENDER_PLUGIN_UI',
+      windowId: ctx?.windowId || 0,
+    });
   }
 
   /**
@@ -401,6 +420,11 @@ export class MobilePluginHost {
     const uuid = uuidv4();
     const hookContext: Record<string, { effects: unknown[][]; selectors: unknown[][] }> = {};
     const stateStore: Record<string, unknown> = {};
+
+    // Store references so setProveProgress() can update state externally
+    this._activeStateStore = stateStore;
+    this._activeEventEmitter = eventEmitter;
+    this._activeUuid = uuid;
 
     let doneResolve: (result?: unknown) => void;
     let doneReject: (error: Error) => void;
@@ -484,7 +508,29 @@ export class MobilePluginHost {
       useHeaders: makeUseHeaders(uuid, hookContext),
       useState: makeUseState(uuid, stateStore),
       setState: makeSetState(uuid, stateStore, eventEmitter),
-      prove: onProve,
+      prove: async (
+        requestOptions: Parameters<MobilePluginHostOptions['onProve']>[0],
+        proverOptions: Parameters<MobilePluginHostOptions['onProve']>[1],
+      ) => {
+        // Native progress events update _proveProgress via setProveProgress().
+        // The wrapper only handles COMPLETE and error cleanup.
+        try {
+          const result = await onProve(requestOptions, proverOptions);
+          stateStore['_proveProgress'] = { step: 'COMPLETE', progress: 1, message: 'Complete' };
+          eventEmitter.emit({
+            type: 'RE_RENDER_PLUGIN_UI',
+            windowId: contextRegistry.get(uuid)?.windowId || 0,
+          });
+          return result;
+        } catch (err) {
+          stateStore['_proveProgress'] = null;
+          eventEmitter.emit({
+            type: 'RE_RENDER_PLUGIN_UI',
+            windowId: contextRegistry.get(uuid)?.windowId || 0,
+          });
+          throw err;
+        }
+      },
       done: (result?: unknown) => {
         if (isCompleted) return;
         isCompleted = true;

--- a/packages/mobile/lib/MobilePluginHost.ts
+++ b/packages/mobile/lib/MobilePluginHost.ts
@@ -407,6 +407,12 @@ export class MobilePluginHost {
     });
   }
 
+  private _clearActiveRefs(): void {
+    this._activeStateStore = null;
+    this._activeEventEmitter = null;
+    this._activeUuid = null;
+  }
+
   /**
    * Execute a plugin in the host environment.
    *
@@ -537,6 +543,7 @@ export class MobilePluginHost {
         const ctx = contextRegistry.get(uuid);
         if (ctx?.windowId) onCloseWindow(ctx.windowId);
         contextRegistry.delete(uuid);
+        this._clearActiveRefs();
         doneResolve(result);
       },
       doneWithOverlay: (result?: unknown) => {
@@ -545,6 +552,7 @@ export class MobilePluginHost {
         const ctx = contextRegistry.get(uuid);
         if (ctx?.windowId) onCloseWindow(ctx.windowId);
         contextRegistry.delete(uuid);
+        this._clearActiveRefs();
         doneResolve(result);
       },
     };
@@ -559,6 +567,7 @@ export class MobilePluginHost {
       exportedCode = evaluatePluginCode(code, capabilities);
     } catch (evalError) {
       const error = evalError instanceof Error ? evalError : new Error(String(evalError));
+      this._clearActiveRefs();
       doneReject!(new Error(`Plugin evaluation failed: ${error.message}`));
       return donePromise;
     }
@@ -566,6 +575,7 @@ export class MobilePluginHost {
     const { main: mainFn, ...otherExports } = exportedCode;
 
     if (typeof mainFn !== 'function') {
+      this._clearActiveRefs();
       doneReject!(new Error('Main function not found in plugin'));
       return donePromise;
     }
@@ -638,6 +648,7 @@ export class MobilePluginHost {
           const ctx = contextRegistry.get(uuid);
           if (ctx?.windowId) onCloseWindow(ctx.windowId);
           contextRegistry.delete(uuid);
+          this._clearActiveRefs();
           doneReject!(new Error(`Plugin main() error: ${err.message}`));
         }
         return null;

--- a/packages/mobile/lib/MobilePluginHost.ts
+++ b/packages/mobile/lib/MobilePluginHost.ts
@@ -111,8 +111,6 @@ export interface PluginConfig {
     method: string;
     host: string;
     pathname: string;
-    verifierUrl: string;
-    proxyUrl?: string;
   }[];
   urls?: string[];
   oauthHosts?: string[];

--- a/packages/mobile/metro.config.js
+++ b/packages/mobile/metro.config.js
@@ -19,15 +19,12 @@ config.resolver.nodeModulesPaths = [
 // 3. Enable package.json "exports" field resolution
 config.resolver.unstable_enablePackageExports = true;
 
-// 4. Force resolving these packages from mobile's node_modules
+// 4. Force resolving these packages from mobile's node_modules to avoid
+// duplicate instances. The symlinks in mobile/node_modules (created by
+// postinstall) point to the root copies, so no blockList is needed.
 config.resolver.extraNodeModules = {
   react: path.resolve(projectRoot, 'node_modules/react'),
   'react-native': path.resolve(projectRoot, 'node_modules/react-native'),
 };
-
-// 4. Block the root copy of react to avoid duplicate React instances.
-// Note: react-native is NOT blocked because it only exists at the root
-// and is symlinked into the local node_modules via postinstall.
-config.resolver.blockList = [new RegExp(`^${monorepoRoot}/node_modules/react/.*$`)];
 
 module.exports = config;

--- a/packages/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
+++ b/packages/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
@@ -11,6 +11,7 @@ import uniffi.tlsn_mobile.HandlerType
 import uniffi.tlsn_mobile.HandlerPart
 import uniffi.tlsn_mobile.HandlerAction
 import uniffi.tlsn_mobile.HandlerParams
+import uniffi.tlsn_mobile.ProgressCallback
 import uniffi.tlsn_mobile.initialize as rustInitialize
 import uniffi.tlsn_mobile.prove as rustProve
 import org.json.JSONObject
@@ -39,6 +40,9 @@ private fun jsonToNative(value: Any?): Any? = when (value) {
 class TlsnNativeModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("TlsnNative")
+
+        // Declare events that can be sent to JS
+        Events("onProveProgress")
 
         Function("initialize") {
             rustInitialize()
@@ -150,8 +154,19 @@ class TlsnNativeModule : Module() {
                         handlers = handlers
                     )
 
-                    // Call the prove function
-                    val result = rustProve(request, options)
+                    // Create progress callback that emits Expo events
+                    val progressCallback = object : ProgressCallback {
+                        override fun onProgress(step: String, progress: Double, message: String) {
+                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
+                                "step" to step,
+                                "progress" to progress,
+                                "message" to message
+                            ))
+                        }
+                    }
+
+                    // Call the prove function with progress callback
+                    val result = rustProve(request, options, progressCallback)
 
                     // Convert response headers
                     val responseHeaders = result.response.headers.map { header ->

--- a/packages/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
+++ b/packages/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
@@ -6,9 +6,29 @@ import os.log
 
 private let logger = OSLog(subsystem: "com.tlsn.mobile", category: "TlsnNative")
 
+/// Bridge the UniFFI ProgressCallback interface to Expo event emission.
+class SwiftProgressCallback: ProgressCallback {
+    private let sendEvent: (_ name: String, _ body: [String: Any]) -> Void
+
+    init(sendEvent: @escaping (_ name: String, _ body: [String: Any]) -> Void) {
+        self.sendEvent = sendEvent
+    }
+
+    func onProgress(step: String, progress: Double, message: String) {
+        sendEvent("onProveProgress", [
+            "step": step,
+            "progress": progress,
+            "message": message
+        ])
+    }
+}
+
 public class TlsnNativeModule: Module {
     public func definition() -> ModuleDefinition {
         Name("TlsnNative")
+
+        // Declare events that can be sent to JS
+        Events("onProveProgress")
 
         // Initialize the TLSN library
         Function("initialize") {
@@ -160,8 +180,13 @@ public class TlsnNativeModule: Module {
                         handlers: handlers
                     )
 
-                    // Call the prove function
-                    let result = try prove(request: request, options: options)
+                    // Create progress callback that emits Expo events
+                    let progressCallback = SwiftProgressCallback { [weak self] name, body in
+                        self?.sendEvent(name, body)
+                    }
+
+                    // Call the prove function with progress callback
+                    let result = try prove(request: request, options: options, progress: progressCallback)
 
                     // Convert response headers to dictionary
                     var responseHeaders: [[String: String]] = []

--- a/packages/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
+++ b/packages/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
@@ -8,6 +8,8 @@ interface TlsnNativeModuleInterface {
     options: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
   isAvailable(): boolean;
+  addListener(eventName: string): void;
+  removeListeners(count: number): void;
 }
 
 // This call loads the native module object from the JSI

--- a/packages/mobile/modules/tlsn-native/src/index.ts
+++ b/packages/mobile/modules/tlsn-native/src/index.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { EventEmitter, type Subscription } from 'expo-modules-core';
 
 // Import the native module
 import TlsnNativeModule from './TlsnNativeModule';
@@ -52,6 +53,14 @@ export interface ProveResult {
   handlersReceived?: number;
 }
 
+export interface ProveProgress {
+  step: string;
+  progress: number;
+  message: string;
+}
+
+const emitter = new EventEmitter(TlsnNativeModule);
+
 /**
  * Initialize the TLSN library.
  * Call this once at app startup.
@@ -90,6 +99,16 @@ export async function prove(request: ProveRequest, options: ProverOptions): Prom
     ) as unknown as Promise<ProveResult>;
   }
   return TlsnNativeModule.prove(request, options) as unknown as Promise<ProveResult>;
+}
+
+/**
+ * Subscribe to proof progress events from the native prover.
+ *
+ * @param callback - Called with progress data at each proof step
+ * @returns Subscription that can be removed when no longer needed
+ */
+export function addProgressListener(callback: (event: ProveProgress) => void): Subscription {
+  return emitter.addListener('onProveProgress', callback);
 }
 
 /**

--- a/packages/mobile/package.json
+++ b/packages/mobile/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "serve:prover": "node assets/prover/server.js",
-    "postinstall": "ln -sf ../modules/tlsn-native node_modules/tlsn-native || true; ln -sf ../modules/quickjs-native node_modules/quickjs-native || true; ln -sf ../../../node_modules/react-native node_modules/react-native || true"
+    "postinstall": "ln -sf ../modules/tlsn-native node_modules/tlsn-native || true; ln -sf ../modules/quickjs-native node_modules/quickjs-native || true; ln -sf ../../../node_modules/react-native node_modules/react-native || true; ln -sf ../../../node_modules/react node_modules/react || true"
   },
   "dependencies": {
     "@tlsn/plugins": "*",

--- a/packages/plugins/build.js
+++ b/packages/plugins/build.js
@@ -10,7 +10,9 @@
  * Environment variables:
  *   VITE_VERIFIER_HOST  - Verifier host (default: localhost:7047)
  *   VITE_SSL            - Use https/wss (default: false)
- *   MOBILE_VERIFIER_URL - Mobile verifier URL (default: http://localhost:7047)
+ *
+ * Mobile verifier URL is configured via EXPO_PUBLIC_VERIFIER_URL when
+ * bundling the mobile app (see packages/mobile/README.md).
  */
 import * as esbuild from 'esbuild';
 import fs from 'fs';
@@ -35,9 +37,6 @@ const VERIFIER_HOST = process.env.VITE_VERIFIER_HOST || 'localhost:7047';
 const SSL = process.env.VITE_SSL === 'true';
 const DEMO_VERIFIER_URL = `${SSL ? 'https' : 'http'}://${VERIFIER_HOST}`;
 const DEMO_PROXY_URL = `${SSL ? 'wss' : 'ws'}://${VERIFIER_HOST}/proxy?token=`;
-
-// Mobile configuration
-const MOBILE_VERIFIER_URL = process.env.MOBILE_VERIFIER_URL || 'http://localhost:7047';
 
 fs.mkdirSync(path.resolve(__dirname, 'dist/demo'), { recursive: true });
 fs.mkdirSync(path.resolve(__dirname, 'dist/mobile'), { recursive: true });
@@ -67,7 +66,7 @@ if (target === 'all' || target === 'demo') {
 
 if (target === 'all' || target === 'mobile') {
   console.log('Building plugins for MOBILE...');
-  console.log(`  VERIFIER_URL: ${MOBILE_VERIFIER_URL}`);
+  console.log(`  VERIFIER_URL: (set via EXPO_PUBLIC_VERIFIER_URL when bundling the app)`);
   console.log(`  PROXY_URL:    (empty)`);
 
   for (const plugin of plugins) {
@@ -84,7 +83,7 @@ if (target === 'all' || target === 'mobile') {
       target: 'es2016',
       outfile: tmpfile,
       define: {
-        __VERIFIER_URL__: JSON.stringify(MOBILE_VERIFIER_URL),
+        __VERIFIER_URL__: JSON.stringify(''),
         __PROXY_URL__: JSON.stringify(''),
       },
     });

--- a/packages/plugins/build.js
+++ b/packages/plugins/build.js
@@ -10,9 +10,7 @@
  * Environment variables:
  *   VITE_VERIFIER_HOST  - Verifier host (default: localhost:7047)
  *   VITE_SSL            - Use https/wss (default: false)
- *
- * Mobile verifier URL is configured via EXPO_PUBLIC_VERIFIER_URL when
- * bundling the mobile app (see packages/mobile/README.md).
+ *   MOBILE_VERIFIER_URL - Mobile verifier URL baked into plugin code (default: http://localhost:7047)
  */
 import * as esbuild from 'esbuild';
 import fs from 'fs';
@@ -37,6 +35,9 @@ const VERIFIER_HOST = process.env.VITE_VERIFIER_HOST || 'localhost:7047';
 const SSL = process.env.VITE_SSL === 'true';
 const DEMO_VERIFIER_URL = `${SSL ? 'https' : 'http'}://${VERIFIER_HOST}`;
 const DEMO_PROXY_URL = `${SSL ? 'wss' : 'ws'}://${VERIFIER_HOST}/proxy?token=`;
+
+// Mobile configuration
+const MOBILE_VERIFIER_URL = process.env.MOBILE_VERIFIER_URL || 'http://localhost:7047';
 
 fs.mkdirSync(path.resolve(__dirname, 'dist/demo'), { recursive: true });
 fs.mkdirSync(path.resolve(__dirname, 'dist/mobile'), { recursive: true });
@@ -66,7 +67,7 @@ if (target === 'all' || target === 'demo') {
 
 if (target === 'all' || target === 'mobile') {
   console.log('Building plugins for MOBILE...');
-  console.log(`  VERIFIER_URL: (set via EXPO_PUBLIC_VERIFIER_URL when bundling the app)`);
+  console.log(`  VERIFIER_URL: ${MOBILE_VERIFIER_URL}`);
   console.log(`  PROXY_URL:    (empty)`);
 
   for (const plugin of plugins) {
@@ -83,7 +84,7 @@ if (target === 'all' || target === 'mobile') {
       target: 'es2016',
       outfile: tmpfile,
       define: {
-        __VERIFIER_URL__: JSON.stringify(''),
+        __VERIFIER_URL__: JSON.stringify(MOBILE_VERIFIER_URL),
         __PROXY_URL__: JSON.stringify(''),
       },
     });

--- a/packages/tlsn-mobile/src/lib.rs
+++ b/packages/tlsn-mobile/src/lib.rs
@@ -233,6 +233,22 @@ impl HttpRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Progress callback
+// ---------------------------------------------------------------------------
+
+/// Callback interface for receiving proof progress updates.
+///
+/// Implement this on the Swift/Kotlin side to receive real-time progress
+/// from the Rust prover. Each call includes:
+/// - `step`: machine-readable step name (e.g. "MPC_SETUP")
+/// - `progress`: 0.0–1.0 fraction
+/// - `message`: human-readable description
+#[uniffi::export(callback_interface)]
+pub trait ProgressCallback: Send + Sync {
+    fn on_progress(&self, step: String, progress: f64, message: String);
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -247,7 +263,7 @@ pub fn initialize() -> Result<(), TlsnError> {
     Ok(())
 }
 
-/// High-level prove function.
+/// High-level prove function with progress reporting.
 ///
 /// Handles the entire proof flow:
 /// 1. Register session with verifier
@@ -257,9 +273,13 @@ pub fn initialize() -> Result<(), TlsnError> {
 /// 5. Generate and finalize proof
 /// 6. Send reveal config to verifier session
 #[uniffi::export]
-pub fn prove(request: HttpRequest, options: ProverOptions) -> Result<ProofResult, TlsnError> {
+pub fn prove(
+    request: HttpRequest,
+    options: ProverOptions,
+    progress: Option<Box<dyn ProgressCallback>>,
+) -> Result<ProofResult, TlsnError> {
     let rt = tokio::runtime::Runtime::new()
         .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
 
-    rt.block_on(prover::prove_async(request, options))
+    rt.block_on(prover::prove_async(request, options, progress.as_deref()))
 }

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -15,8 +15,8 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 use url::Url;
 
 use crate::{
-    ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, ProofResult, ProverOptions,
-    TlsnError, Transcript,
+    ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, ProofResult, ProgressCallback,
+    ProverOptions, TlsnError, Transcript,
 };
 
 /// Connect to a WebSocket URL and return an [`WsIoAdapter`].
@@ -25,14 +25,23 @@ async fn connect_ws(url: &str) -> Result<WsIoAdapter, TlsnError> {
     Ok(WsIoAdapter::new(ws))
 }
 
+/// Emit progress if a callback is provided.
+fn emit_progress(cb: Option<&dyn ProgressCallback>, step: &str, progress: f64, message: &str) {
+    if let Some(cb) = cb {
+        cb.on_progress(step.to_string(), progress, message.to_string());
+    }
+}
+
 /// Main async prove function.
 pub(crate) async fn prove_async(
     request: HttpRequest,
     options: ProverOptions,
+    progress: Option<&dyn ProgressCallback>,
 ) -> Result<ProofResult, TlsnError> {
     let handlers_received = options.handlers.len() as u32;
 
     tracing::info!("starting proof for {} ({} handlers)", request.url, handlers_received);
+    emit_progress(progress, "CONNECTING", 0.0, "Connecting to verifier...");
 
     // Parse URL to extract hostname for ProverConfig.
     let url = Url::parse(&request.url)?;
@@ -99,6 +108,7 @@ pub(crate) async fn prove_async(
         }
     };
     tracing::info!("session registered: {session_id}");
+    emit_progress(progress, "SESSION_REGISTERED", 0.1, "Session registered");
 
     // -----------------------------------------------------------------------
     // 2. Create prover & MPC setup
@@ -116,6 +126,7 @@ pub(crate) async fn prove_async(
     let verifier_io = connect_ws(&verifier_ws_url).await?;
     prover.setup(verifier_io).await?;
     tracing::info!("MPC setup complete");
+    emit_progress(progress, "MPC_SETUP", 0.25, "MPC session established");
 
     // -----------------------------------------------------------------------
     // 3. Send HTTP request through direct TCP (no proxy needed on native)
@@ -130,9 +141,11 @@ pub(crate) async fn prove_async(
     // Convert tokio TcpStream (tokio::io::AsyncRead) to futures::AsyncRead for sdk-core's Io trait.
     let server_io = tcp_stream.compat();
 
+    emit_progress(progress, "SENDING_REQUEST", 0.35, "Sending request...");
     let sdk_request = request.into_sdk();
     let sdk_response = prover.send_request(server_io, sdk_request).await?;
     tracing::info!("HTTP response: status {}", sdk_response.status);
+    emit_progress(progress, "REQUEST_COMPLETE", 0.5, "Processing transcript...");
 
     // -----------------------------------------------------------------------
     // 4. Compute reveal ranges from handlers
@@ -165,8 +178,10 @@ pub(crate) async fn prove_async(
     // -----------------------------------------------------------------------
     // 5. Reveal and finalize
     // -----------------------------------------------------------------------
+    emit_progress(progress, "GENERATING_PROOF", 0.65, "Generating proof...");
     prover.reveal(compute_output.reveal).await?;
     tracing::info!("proof generated");
+    emit_progress(progress, "REVEAL_COMPLETE", 0.8, "Sending verification data...");
 
     // -----------------------------------------------------------------------
     // 6. Send reveal_config to verifier session
@@ -216,6 +231,7 @@ pub(crate) async fn prove_async(
         Ok(Err(e)) => return Err(e),
         Err(_) => tracing::warn!("timed out waiting for session_completed (proof still valid)"),
     }
+    emit_progress(progress, "VERIFICATION_COMPLETE", 0.95, "Verification complete");
 
     // -----------------------------------------------------------------------
     // 7. Build result


### PR DESCRIPTION
## Summary

- Add `ProgressCallback` UniFFI callback interface to the Rust prover, emitting progress at 8 stages (CONNECTING → SESSION_REGISTERED → MPC_SETUP → SENDING_REQUEST → REQUEST_COMPLETE → GENERATING_PROOF → REVEAL_COMPLETE → VERIFICATION_COMPLETE)
- Implement the callback in Swift (iOS) and Kotlin (Android) bridges, forwarding via Expo `sendEvent("onProveProgress", ...)`
- Add `addProgressListener()` to the JS native module interface
- Subscribe in `NativeProver` component and forward to `MobilePluginHost.setProveProgress()`
- Plugin `proveProgressBar()` now shows real granular progress instead of hardcoded 0%→30%→100% jumps

### Files changed

| Layer | File | Change |
|-------|------|--------|
| Rust | `packages/tlsn-mobile/src/lib.rs` | Add `ProgressCallback` trait, update `prove()` signature |
| Rust | `packages/tlsn-mobile/src/prover.rs` | Emit progress at each proof step |
| iOS | `TlsnNativeModule.swift` | `SwiftProgressCallback` + `Events("onProveProgress")` |
| Android | `TlsnNativeModule.kt` | `ProgressCallback` impl + `Events("onProveProgress")` |
| JS | `modules/tlsn-native/src/index.ts` | `addProgressListener()` via Expo EventEmitter |
| JS | `modules/tlsn-native/src/TlsnNativeModule.ts` | Add event listener types |
| RN | `NativeProver.tsx` | `onProgress` prop, native event subscription |
| RN | `PluginScreen.tsx` | Forward progress to host |
| RN | `MobilePluginHost.ts` | `setProveProgress()` method, simplified prove wrapper |

## Test plan

- [ ] Rebuild native libraries: `./build.sh ios --rebuild-native`
- [ ] Run on device/simulator and tap "Generate Proof" for any plugin
- [ ] Verify progress bar updates smoothly through all 8 steps
- [ ] Verify error case clears the progress bar
- [ ] Run `npx vitest run` in `packages/mobile` — all tests pass