### PR TITLE
chore(extension): version 0.1.0.1406

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2231,6 +2231,7 @@
       "version": "6.20.1",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
       "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -2243,6 +2244,7 @@
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
       "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -2255,6 +2257,7 @@
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
       "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -2270,6 +2273,7 @@
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
       "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2284,6 +2288,7 @@
       "version": "6.9.5",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
       "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2295,6 +2300,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
       "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -2306,27 +2312,17 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
       "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/theme-one-dark": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
-      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0",
-        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
       "version": "6.41.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
       "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.6.0",
@@ -3772,7 +3768,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3790,7 +3785,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3808,7 +3802,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3826,7 +3819,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3844,7 +3836,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3862,7 +3853,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3880,7 +3870,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3898,7 +3887,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3916,7 +3904,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3934,7 +3921,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3952,7 +3938,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3970,7 +3955,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3988,7 +3972,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4006,7 +3989,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4024,7 +4006,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4042,7 +4023,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4060,7 +4040,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4078,7 +4057,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4096,7 +4074,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4114,7 +4091,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4132,7 +4108,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4150,7 +4125,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4168,7 +4142,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4186,7 +4159,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4204,7 +4176,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4222,7 +4193,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6316,12 +6286,14 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
@@ -6331,6 +6303,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
       "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -6342,6 +6315,7 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
       "integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -6351,6 +6325,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@metamask/abi-utils": {
@@ -6998,7 +6973,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -7041,7 +7015,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7063,7 +7036,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7085,7 +7057,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7107,7 +7078,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7129,7 +7099,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7151,7 +7120,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7173,7 +7141,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7195,7 +7162,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7217,7 +7183,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7239,7 +7204,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7261,7 +7225,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7283,7 +7246,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7305,7 +7267,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7321,7 +7282,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10338,33 +10298,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.25.9",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
-      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codemirror/autocomplete": "^6.0.0",
-        "@codemirror/commands": "^6.0.0",
-        "@codemirror/language": "^6.0.0",
-        "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.0.0",
-        "@codemirror/state": "^6.0.0",
-        "@codemirror/view": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@codemirror/autocomplete": ">=6.0.0",
-        "@codemirror/commands": ">=6.0.0",
-        "@codemirror/language": ">=6.0.0",
-        "@codemirror/lint": ">=6.0.0",
-        "@codemirror/search": ">=6.0.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0"
-      }
-    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -12923,6 +12856,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
       "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -13293,6 +13227,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -20330,8 +20265,7 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -25141,6 +25075,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/styleq": {
@@ -25730,7 +25665,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -26612,6 +26546,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/walker": {
@@ -28138,21 +28073,15 @@
       }
     },
     "packages/extension": {
-      "version": "0.1.0.1405",
+      "version": "0.1.0.1406",
       "license": "MIT",
       "dependencies": {
-        "@codemirror/lang-javascript": "^6.2.4",
-        "@codemirror/state": "^6.5.2",
-        "@codemirror/theme-one-dark": "^6.1.3",
-        "@codemirror/view": "^6.38.6",
         "@fortawesome/fontawesome-free": "^6.4.2",
         "@tlsn/common": "*",
         "@tlsn/plugin-sdk": "*",
-        "@uiw/react-codemirror": "^4.25.2",
         "assert": "^2.1.0",
         "buffer": "^6.0.3",
         "classnames": "^2.3.2",
-        "codemirror": "^6.0.1",
         "comlink": "^4.4.2",
         "events": "^3.3.0",
         "fast-deep-equal": "^3.1.3",
@@ -28231,32 +28160,6 @@
       "name": "tlsn-wasm",
       "version": "0.1.0-alpha.15-pre",
       "license": "MIT OR Apache-2.0"
-    },
-    "packages/extension/node_modules/@uiw/react-codemirror": {
-      "version": "4.25.9",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
-      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@codemirror/commands": "^6.1.0",
-        "@codemirror/state": "^6.1.1",
-        "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
-        "codemirror": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://jaywcjlove.github.io/#/sponsor"
-      },
-      "peerDependencies": {
-        "@babel/runtime": ">=7.11.0",
-        "@codemirror/state": ">=6.0.0",
-        "@codemirror/theme-one-dark": ">=6.0.0",
-        "@codemirror/view": ">=6.0.0",
-        "codemirror": ">=6.0.0",
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
     },
     "packages/extension/node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "0.1.0.1405",
+  "version": "0.1.0.1406",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.1.0.1405",
+  "version": "0.1.0.1406",
   "name": "TLSNotary",
   "description": "A Chrome extension for TLSNotary",
   "options_page": "options.html",


### PR DESCRIPTION
## Summary
- Bump extension version from 0.1.0.1405 to 0.1.0.1406

## Changes since 0.1.0.1405
- feat(mobile): React Native mobile app with native TLSNotary prover (#298)
- chore(extension): remove DevConsole (#305)
- chore: upgrade React to v19 in demo, tutorial, and extension (#304)
- chore: upgrade Tailwind CSS v3 to v4 (tutorial) and remove from extension (#303)
- chore: upgrade multiple dependencies (vite v8, webpack loaders, webextension-polyfill 0.12, etc.)
- ci: run plugin-sdk browser tests in CI (#302)
- docs: add /create-plugin Claude Code command (#276)