### PR TITLE
feat(plugin-sdk): make plugin UI draggable as opt-in per-element

### DIFF
--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -444,8 +444,8 @@ async function createOffscreenDocument(): Promise<void> {
       logger.debug('Creating offscreen document...');
       await chrome.offscreen.createDocument({
         url: 'offscreen.html',
-        reasons: ['DOM_SCRAPING'],
-        justification: 'Offscreen document for background processing',
+        reasons: ['WORKERS'],
+        justification: 'Run QuickJS sandbox and TLS prover in a worker context',
       });
       logger.debug('Offscreen document created successfully');
     } finally {

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -40,13 +40,25 @@ function makeDraggable(el: HTMLElement) {
 
   let offsetX = 0;
   let offsetY = 0;
-  let dragging = false;
 
-  const onMouseDown = (e: MouseEvent) => {
+  const onMouseMove = (e: MouseEvent) => {
+    const x = Math.max(0, Math.min(e.clientX - offsetX, window.innerWidth - el.offsetWidth));
+    const y = Math.max(0, Math.min(e.clientY - offsetY, window.innerHeight - el.offsetHeight));
+
+    el.style.left = x + 'px';
+    el.style.top = y + 'px';
+  };
+
+  const onMouseUp = () => {
+    handle.style.cursor = 'grab';
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  };
+
+  handle.addEventListener('mousedown', (e: MouseEvent) => {
     // Only drag on primary button, ignore clicks on buttons inside the handle
     if (e.button !== 0 || (e.target as HTMLElement).closest('button')) return;
 
-    dragging = true;
     handle.style.cursor = 'grabbing';
 
     // Convert bottom/right positioning to top/left
@@ -60,29 +72,11 @@ function makeDraggable(el: HTMLElement) {
     offsetX = e.clientX - rect.left;
     offsetY = e.clientY - rect.top;
 
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+
     e.preventDefault();
-  };
-
-  const onMouseMove = (e: MouseEvent) => {
-    if (!dragging) return;
-
-    const x = Math.max(0, Math.min(e.clientX - offsetX, window.innerWidth - el.offsetWidth));
-    const y = Math.max(0, Math.min(e.clientY - offsetY, window.innerHeight - el.offsetHeight));
-
-    el.style.left = x + 'px';
-    el.style.top = y + 'px';
-  };
-
-  const onMouseUp = () => {
-    if (!dragging) return;
-
-    dragging = false;
-    handle.style.cursor = 'grab';
-  };
-
-  handle.addEventListener('mousedown', onMouseDown);
-  document.addEventListener('mousemove', onMouseMove);
-  document.addEventListener('mouseup', onMouseUp);
+  });
 }
 
 const ALLOWED_ELEMENT_TYPES = new Set([

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -26,8 +26,24 @@ function renderPluginUI(json: DomJson, windowId: number) {
     container = el;
   }
 
+  // Preserve drag position across re-renders: if the user dragged the element,
+  // its positioning was converted from bottom/right to top/left (bottom becomes 'auto').
+  const prev = container.querySelector('[data-tlsn-draggable]') as HTMLElement | null;
+  const savedPosition =
+    prev && prev.style.bottom === 'auto' ? { top: prev.style.top, left: prev.style.left } : null;
+
   container.innerHTML = '';
   container.appendChild(createNode(json, windowId));
+
+  if (savedPosition) {
+    const el = container.querySelector('[data-tlsn-draggable]') as HTMLElement | null;
+    if (el) {
+      el.style.top = savedPosition.top;
+      el.style.left = savedPosition.left;
+      el.style.bottom = 'auto';
+      el.style.right = 'auto';
+    }
+  }
 }
 
 function makeDraggable(el: HTMLElement) {
@@ -164,6 +180,7 @@ function createNode(json: DomJson, windowId: number): HTMLElement | Text {
   });
 
   if (json.options.draggable) {
+    node.dataset.tlsnDraggable = '';
     makeDraggable(node);
   }
 

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -28,16 +28,11 @@ function renderPluginUI(json: DomJson, windowId: number) {
 
   container.innerHTML = '';
   container.appendChild(createNode(json, windowId));
-  makeDraggable(container);
 }
 
-function makeDraggable(container: HTMLElement) {
-  const root = container.firstElementChild as HTMLElement | null;
-
-  if (!root || root.style.position !== 'fixed') return;
-
-  // Use the first child div as the drag handle (the header bar)
-  const handle = root.firstElementChild as HTMLElement | null;
+function makeDraggable(el: HTMLElement) {
+  // Use the first child as the drag handle (the header bar)
+  const handle = el.firstElementChild as HTMLElement | null;
 
   if (!handle) return;
 
@@ -55,12 +50,12 @@ function makeDraggable(container: HTMLElement) {
     handle.style.cursor = 'grabbing';
 
     // Convert bottom/right positioning to top/left
-    const rect = root.getBoundingClientRect();
+    const rect = el.getBoundingClientRect();
 
-    root.style.top = rect.top + 'px';
-    root.style.left = rect.left + 'px';
-    root.style.bottom = 'auto';
-    root.style.right = 'auto';
+    el.style.top = rect.top + 'px';
+    el.style.left = rect.left + 'px';
+    el.style.bottom = 'auto';
+    el.style.right = 'auto';
 
     offsetX = e.clientX - rect.left;
     offsetY = e.clientY - rect.top;
@@ -71,11 +66,11 @@ function makeDraggable(container: HTMLElement) {
   const onMouseMove = (e: MouseEvent) => {
     if (!dragging) return;
 
-    const x = Math.max(0, Math.min(e.clientX - offsetX, window.innerWidth - root.offsetWidth));
-    const y = Math.max(0, Math.min(e.clientY - offsetY, window.innerHeight - root.offsetHeight));
+    const x = Math.max(0, Math.min(e.clientX - offsetX, window.innerWidth - el.offsetWidth));
+    const y = Math.max(0, Math.min(e.clientY - offsetY, window.innerHeight - el.offsetHeight));
 
-    root.style.left = x + 'px';
-    root.style.top = y + 'px';
+    el.style.left = x + 'px';
+    el.style.top = y + 'px';
   };
 
   const onMouseUp = () => {
@@ -173,6 +168,10 @@ function createNode(json: DomJson, windowId: number): HTMLElement | Text {
   json.children.forEach((child) => {
     node.appendChild(createNode(child, windowId));
   });
+
+  if (json.options.draggable) {
+    makeDraggable(node);
+  }
 
   return node;
 }

--- a/packages/mobile/components/tlsn/PluginRenderer.tsx
+++ b/packages/mobile/components/tlsn/PluginRenderer.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, PanResponder, Animated } from 'react-native';
 import { cssToRN } from '../../lib/cssToRN';
 
 /**
@@ -11,6 +11,7 @@ export type DomOptions = {
   id?: string;
   style?: Record<string, string>;
   onclick?: string;
+  draggable?: boolean;
 };
 
 export type DomJson =
@@ -103,10 +104,62 @@ function renderNode(
     );
   }
 
+  if (options.draggable) {
+    return (
+      <DraggableView key={key} style={rnStyle}>
+        {content}
+      </DraggableView>
+    );
+  }
+
   return (
     <View key={key} style={rnStyle}>
       {content}
     </View>
+  );
+}
+
+/**
+ * Wrapper that makes a View draggable via PanResponder.
+ * Drag starts only after a 5px move threshold so button taps still work.
+ */
+function DraggableView({
+  style,
+  children,
+}: {
+  style: Record<string, unknown>;
+  children: React.ReactNode;
+}) {
+  const pan = useMemo(() => new Animated.ValueXY(), []);
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_, gs) => Math.abs(gs.dx) > 5 || Math.abs(gs.dy) > 5,
+        onPanResponderGrant: () => {
+          pan.setOffset({
+            x: (pan.x as unknown as { _value: number })._value,
+            y: (pan.y as unknown as { _value: number })._value,
+          });
+          pan.setValue({ x: 0, y: 0 });
+        },
+        onPanResponderMove: Animated.event([null, { dx: pan.x, dy: pan.y }], {
+          useNativeDriver: false,
+        }),
+        onPanResponderRelease: () => {
+          pan.flattenOffset();
+        },
+      }),
+    [pan],
+  );
+
+  return (
+    <Animated.View
+      style={[style, { transform: pan.getTranslateTransform() }]}
+      {...panResponder.panHandlers}
+    >
+      {children}
+    </Animated.View>
   );
 }
 

--- a/packages/mobile/components/tlsn/PluginScreen.tsx
+++ b/packages/mobile/components/tlsn/PluginScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, PanResponder, Animated } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { PluginWebView, InterceptedRequestHeader } from './PluginWebView';
 import { PluginRenderer, DomJson } from './PluginRenderer';
 import { NativeProver, NativeProverHandle, Handler as NativeHandler } from './NativeProver';
@@ -249,33 +249,6 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
       });
   }, [proverReady, pluginCode, eventEmitter, host, onComplete, onError]);
 
-  // Draggable plugin UI overlay — drag starts only after a 5px move threshold
-  // so taps on buttons inside the plugin UI still work normally.
-  // Uses useMemo (not useRef) because these values are read during render.
-  const pan = useMemo(() => new Animated.ValueXY(), []);
-  const panResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponder: (_, gestureState) =>
-          Math.abs(gestureState.dx) > 5 || Math.abs(gestureState.dy) > 5,
-        onPanResponderGrant: () => {
-          pan.setOffset({
-            x: (pan.x as unknown as { _value: number })._value,
-            y: (pan.y as unknown as { _value: number })._value,
-          });
-          pan.setValue({ x: 0, y: 0 });
-        },
-        onPanResponderMove: Animated.event([null, { dx: pan.x, dy: pan.y }], {
-          useNativeDriver: false,
-        }),
-        onPanResponderRelease: () => {
-          pan.flattenOffset();
-        },
-      }),
-    [pan],
-  );
-
   return (
     <View style={styles.container}>
       {/* Native TLSN prover (headless) */}
@@ -302,14 +275,11 @@ export function PluginScreen({ pluginCode, pluginConfig, onComplete, onError }: 
         </View>
       )}
 
-      {/* Plugin UI overlay (draggable) */}
+      {/* Plugin UI overlay */}
       {domJson && (
-        <Animated.View
-          style={[styles.pluginUiContainer, { transform: pan.getTranslateTransform() }]}
-          {...panResponder.panHandlers}
-        >
+        <View style={styles.pluginUiContainer}>
           <PluginRenderer domJson={domJson} onPluginAction={handlePluginAction} />
-        </Animated.View>
+        </View>
       )}
 
       {/* Loading state */}

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -65,6 +65,7 @@ export type DomOptions = {
   id?: string;
   style?: { [key: string]: string };
   onclick?: string;
+  draggable?: boolean;
   inputType?: string;
   checked?: boolean;
   value?: string;

--- a/packages/plugins/src/discord_dm.plugin.ts
+++ b/packages/plugins/src/discord_dm.plugin.ts
@@ -241,6 +241,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/discord_profile.plugin.ts
+++ b/packages/plugins/src/discord_profile.plugin.ts
@@ -214,6 +214,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/duolingo.plugin.ts
+++ b/packages/plugins/src/duolingo.plugin.ts
@@ -199,6 +199,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/spotify.plugin.ts
+++ b/packages/plugins/src/spotify.plugin.ts
@@ -197,6 +197,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/swissbank.plugin.ts
+++ b/packages/plugins/src/swissbank.plugin.ts
@@ -204,6 +204,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/twitter.plugin.ts
+++ b/packages/plugins/src/twitter.plugin.ts
@@ -220,6 +220,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',

--- a/packages/plugins/src/uber.plugin.ts
+++ b/packages/plugins/src/uber.plugin.ts
@@ -224,6 +224,7 @@ const main = (): DomJson => {
 
   return div(
     {
+      draggable: true,
       style: {
         position: 'fixed',
         bottom: '0',


### PR DESCRIPTION
Add `draggable` option to DomOptions so plugins control which elements are draggable instead of applying it globally to all plugin UIs.

Extension: move drag logic from renderPluginUI() into createNode(),
triggered only when `draggable: true` is set on the element.

Mobile: move PanResponder from PluginScreen into a DraggableView component in PluginRenderer, applied per-element.

All 7 plugins updated to opt-in on their expanded card root div.