### PR TITLE
feat(plugin-sdk): add getJsonBody utility

### DIFF
--- a/packages/plugin-sdk/src/globals.ts
+++ b/packages/plugin-sdk/src/globals.ts
@@ -14,6 +14,12 @@ import type {
 } from './types';
 
 /**
+ * Extract and parse a JSON body from an intercepted request.
+ * Returns the parsed JSON object, the raw string if not valid JSON, or null if no body.
+ */
+export type GetJsonBodyFunction = (request: InterceptedRequest) => unknown;
+
+/**
  * Create a div DOM element
  */
 export type DivFunction = {
@@ -137,6 +143,7 @@ export interface PluginAPI {
   useState: UseStateFunction;
   setState: SetStateFunction;
   prove: ProveFunction;
+  getJsonBody: GetJsonBodyFunction;
   done: DoneFunction;
   doneWithOverlay: DoneWithOverlayFunction;
 }
@@ -157,6 +164,7 @@ declare global {
   const useState: UseStateFunction;
   const setState: SetStateFunction;
   const prove: ProveFunction;
+  const getJsonBody: GetJsonBodyFunction;
   const done: DoneFunction;
   const doneWithOverlay: DoneWithOverlayFunction;
 }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -466,6 +466,31 @@ function makeOpenWindow(
   };
 }
 
+/**
+ * Extract and parse a JSON body from an intercepted request.
+ *
+ * For JSON POST/PUT requests, the body is stored in `requestBody.raw[].bytes`
+ * as an ArrayBuffer or number array. This utility decodes the bytes to a string
+ * and attempts to parse it as JSON.
+ *
+ * @param request - An intercepted request from useRequests()
+ * @returns The parsed JSON object, the raw string if not valid JSON, or null if no body
+ */
+function getJsonBody(request: InterceptedRequest): unknown {
+  const bytes = request.requestBody?.raw?.[0]?.bytes;
+  if (!bytes) return null;
+
+  const text = String.fromCharCode(
+    ...(bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes),
+  );
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 // Export Parser and its types
 export {
   Parser,
@@ -808,6 +833,7 @@ const mapStringToRange = env.mapStringToRange;
 const reveal = env.reveal;
 const getResponse = env.getResponse;
 const closeWindow = env.closeWindow;
+const getJsonBody = env.getJsonBody;
 const done = env.done;
 const doneWithOverlay = env.doneWithOverlay;
 ${processedCode};
@@ -1030,6 +1056,7 @@ ${processedCode};
           finalize();
         }
       },
+      getJsonBody: (request: InterceptedRequest) => getJsonBody(request),
       doneWithOverlay: (
         args?: unknown,
         options?: { title?: string; message?: string; delayMs?: number },
@@ -1098,6 +1125,7 @@ const useHeaders = env.useHeaders;
 const useState = env.useState;
 const setState = env.setState;
 const prove = env.prove;
+const getJsonBody = env.getJsonBody;
 const closeWindow = env.closeWindow;
 const done = env.done;
 const doneWithOverlay = env.doneWithOverlay;
@@ -1340,6 +1368,7 @@ export type {
   UseStateFunction,
   SetStateFunction,
   ProveFunction,
+  GetJsonBodyFunction,
   DoneFunction,
 } from './globals';
 
@@ -1348,6 +1377,9 @@ export { LogLevel } from '@tlsn/common';
 
 // Export internal utilities (used by tests)
 export { preprocessPluginCode };
+
+// Export getJsonBody utility for plugin authors
+export { getJsonBody };
 
 // Default export
 export default Host;

--- a/packages/plugin-sdk/test/getJsonBody.test.ts
+++ b/packages/plugin-sdk/test/getJsonBody.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { getJsonBody } from '../src/index';
+import type { InterceptedRequest } from '../src/types';
+
+function makeRequest(overrides?: Partial<InterceptedRequest>): InterceptedRequest {
+  return {
+    id: '1',
+    method: 'POST',
+    url: 'https://example.com/api',
+    timestamp: Date.now(),
+    tabId: 1,
+    ...overrides,
+  };
+}
+
+describe('getJsonBody', () => {
+  it('should return null when request has no requestBody', () => {
+    expect(getJsonBody(makeRequest())).toBeNull();
+  });
+
+  it('should return null when requestBody has no raw data', () => {
+    expect(getJsonBody(makeRequest({ requestBody: { formData: { key: 'val' } } }))).toBeNull();
+  });
+
+  it('should return null when raw bytes are missing', () => {
+    expect(getJsonBody(makeRequest({ requestBody: { raw: [{}] } }))).toBeNull();
+  });
+
+  it('should parse valid JSON from number array bytes', () => {
+    const json = { username: 'test_user', action: 'login' };
+    const bytes = Array.from(new TextEncoder().encode(JSON.stringify(json)));
+
+    const result = getJsonBody(
+      makeRequest({ requestBody: { raw: [{ bytes: new Uint8Array(bytes).buffer }] } }),
+    );
+
+    expect(result).toEqual(json);
+  });
+
+  it('should parse valid JSON from ArrayBuffer', () => {
+    const json = { count: 42 };
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode(JSON.stringify(json)).buffer;
+
+    const result = getJsonBody(makeRequest({ requestBody: { raw: [{ bytes: buffer }] } }));
+
+    expect(result).toEqual(json);
+  });
+
+  it('should return raw string when body is not valid JSON', () => {
+    const text = 'not-json-content';
+    const bytes = new TextEncoder().encode(text).buffer;
+
+    const result = getJsonBody(makeRequest({ requestBody: { raw: [{ bytes }] } }));
+
+    expect(result).toBe(text);
+  });
+
+  it('should handle empty JSON object', () => {
+    const bytes = new TextEncoder().encode('{}').buffer;
+
+    const result = getJsonBody(makeRequest({ requestBody: { raw: [{ bytes }] } }));
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle JSON arrays', () => {
+    const json = [1, 2, 3];
+    const bytes = new TextEncoder().encode(JSON.stringify(json)).buffer;
+
+    const result = getJsonBody(makeRequest({ requestBody: { raw: [{ bytes }] } }));
+
+    expect(result).toEqual(json);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `getJsonBody(request)` utility to `@tlsn/plugin-sdk` that decodes `requestBody.raw[].bytes` from intercepted POST/PUT requests and parses as JSON
- Available as a global inside the plugin sandbox (like `useState`, `prove`, etc.) and as a named export for direct use
- Includes type definition (`GetJsonBodyFunction`) in `PluginAPI` interface and global declarations

Closes #263

## Usage in plugins

```javascript
const requests = useRequests({ method: 'POST' });
const target = requests.find(r => r.url.includes('/api/endpoint'));
if (target) {
  const body = getJsonBody(target);
  // body is parsed JSON object, raw string (if not valid JSON), or null (if no body)
}
```

## Test plan
- [x] 8 unit tests covering: null body, missing raw data, valid JSON, invalid JSON fallback, ArrayBuffer input, empty objects, arrays
- [x] Full monorepo lint passes (0 errors)
- [x] All 439 tests pass across all packages (common: 16, extension: 165, mobile: 33, plugin-sdk: 225)