### PR TITLE
fix: replace explicit any with unknown in type annotations

### DIFF
--- a/packages/demo/src/components/OnchainDemo.tsx
+++ b/packages/demo/src/components/OnchainDemo.tsx
@@ -13,7 +13,7 @@ type Phase = 'idle' | 'connecting' | 'proving' | 'waiting' | 'complete' | 'error
 declare global {
   interface Window {
     ethereum?: {
-      request: (args: { method: string; params?: unknown[] }) => Promise<any>;
+      request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
       isMetaMask?: boolean;
     };
   }
@@ -86,10 +86,10 @@ export function OnchainDemo({ allChecksPass, addConsoleEntry }: Props) {
     }
 
     try {
-      const accounts = await window.ethereum.request({
+      const accounts = (await window.ethereum.request({
         method: 'eth_requestAccounts',
-      });
-      const address = accounts[0] as string;
+      })) as string[];
+      const address = accounts[0];
       setWalletAddress(address);
 
       // Sign challenge message

--- a/packages/mobile/components/tlsn/NativeProver.tsx
+++ b/packages/mobile/components/tlsn/NativeProver.tsx
@@ -158,7 +158,10 @@ function NativeProverComponent(
         const result = await module.prove(request, options);
         console.log('[NativeProver] Proof generation complete');
         console.log('[NativeProver] Transcript:', JSON.stringify(result.transcript));
-        console.log('[NativeProver] Debug info:', JSON.stringify((result as any).debug));
+        console.log(
+          '[NativeProver] Debug info:',
+          JSON.stringify((result as { debug?: unknown }).debug),
+        );
         return result;
       } catch (e) {
         console.error('[NativeProver] Proof generation failed:', e);

--- a/packages/mobile/components/tlsn/PluginRenderer.tsx
+++ b/packages/mobile/components/tlsn/PluginRenderer.tsx
@@ -174,7 +174,7 @@ function renderTextChildren(children: DomJson[]): string {
  * Extract text-relevant styles from a combined style object.
  * RN requires text styles to be on Text components, not Views.
  */
-function extractTextStyle(style: Record<string, any>): Record<string, any> {
+function extractTextStyle(style: Record<string, unknown>): Record<string, unknown> {
   const textProps = [
     'color',
     'fontSize',
@@ -186,7 +186,7 @@ function extractTextStyle(style: Record<string, any>): Record<string, any> {
     'textAlign',
     'textTransform',
   ];
-  const result: Record<string, any> = {};
+  const result: Record<string, unknown> = {};
   for (const prop of textProps) {
     if (style[prop] !== undefined) {
       result[prop] = style[prop];

--- a/packages/mobile/lib/cssToRN.ts
+++ b/packages/mobile/lib/cssToRN.ts
@@ -196,7 +196,7 @@ function parseBorder(value: string): Partial<RNStyle> {
 export function cssToRN(cssStyle: Record<string, string> | undefined): Partial<RNStyle> {
   if (!cssStyle) return {};
 
-  const rnStyle: Record<string, any> = {};
+  const rnStyle: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(cssStyle)) {
     if (IGNORED_PROPERTIES.has(key)) continue;


### PR DESCRIPTION
## Summary
- Clears all `@typescript-eslint/no-explicit-any` warnings in `packages/demo` and `packages/mobile`
- Narrows to `unknown` (with localized casts at use sites) rather than silencing the rule