### PR TITLE
chore(extension): version 0.1.0.1407

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27116,7 +27116,7 @@
       }
     },
     "packages/extension": {
-      "version": "0.1.0.1406",
+      "version": "0.1.0.1407",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "0.1.0.1406",
+  "version": "0.1.0.1407",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.1.0.1406",
+  "version": "0.1.0.1407",
   "name": "TLSNotary",
   "description": "A Chrome extension for TLSNotary",
   "options_page": "options.html",


### PR DESCRIPTION
## Summary
- Bumps extension version from `0.1.0.1406` to `0.1.0.1407`
- Updates both `packages/extension/package.json` and `packages/extension/src/manifest.json`
- Refreshes `package-lock.json`

## Changes since 0.1.0.1406
- #319 fix: replace explicit any with unknown in type annotations
- #278 feat(demo): add ID.me credentials plugin
- #306 fix: handle window close and concurrent plugin execution
- #312 feat(plugin-sdk): configurable plugin timeout with warning modal
- #308 feat(mobile): native progress reporting for proof generation
- #314 feat(plugin-sdk): make plugin UI draggable as opt-in per-element
- #316 feat(plugin-sdk): add getJsonBody utility for decoding POST request bodies
- #309 chore: remove Babel, fix deprecation warnings and vulnerabilities

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` passes (all 462 tests)
- [x] `npm run build` succeeds (produces `extension-0.1.0.1407.zip`)
- [ ] After merge, create GitHub Release `0.1.0.1407` to trigger Chrome Web Store publishing per [RELEASING.md](https://github.com/tlsnotary/tlsn-extension/pull/281)