### PR TITLE
fix(plugins): bump swissbank maxRecvData to 520

### DIFF
--- a/packages/plugins/src/swissbank.plugin.ts
+++ b/packages/plugins/src/swissbank.plugin.ts
@@ -61,7 +61,7 @@ const onClick = async (): Promise<void> => {
     {
       verifierUrl: __VERIFIER_URL__,
       proxyUrl: __PROXY_URL__ + host,
-      maxRecvData: 460,
+      maxRecvData: 520,
       maxSentData: 180,
       handlers: [
         { type: 'SENT', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,


### PR DESCRIPTION
## Summary

- The `swissbank.tlsnotary.org` edge proxy now emits `strict-transport-security` (~46 bytes) and `alt-svc` (~31 bytes) response headers, adding ~77 bytes to every response.
- The app container [hasn't changed in 5 months](https://github.com/tlsnotary/devconnect25_demo/pkgs/container/devconnect25_demo%2Fswissbank) — the growth is purely from a TLS-terminating proxy reconfiguration (which also rotated the cert and enabled HTTP/2 + HTTP/3 via ALPN).
- Measured response is exactly 490 bytes (203 header + 287 body). Raising `maxRecvData` from 460 → 520 fixes the proof and leaves ~30 bytes of headroom for future header or balance-value changes.

## Test plan

- [ ] Load the demo plugin in the extension and click "Generate Proof" against the logged-in Swiss Bank demo account — proof should complete without a `max_recv_data` overflow.
- [ ] Confirm the revealed fields (`account_id`, `accounts.CHF`) still match the server response.

## Notes

- `packages/tutorial/swissbank.js:40` still hardcodes `460` in the tutorial copy. Leaving that out of this PR to keep the scope minimal, but worth a follow-up sync.