### PR TITLE
chore(verifier): bump non-tlsn dependencies

### DIFF
--- a/packages/verifier/Cargo.lock
+++ b/packages/verifier/Cargo.lock
@@ -36,13 +36,13 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
 dependencies = [
  "cipher 0.5.1",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c348fb0b6d132c596eca3dcd941df48fb597aafcb07a738ec41c004b087dc99"
+checksum = "ef0f7efedeac57d9b26170f72965ecfd31473ca52ca7a64e925b0b6f5f079886"
 dependencies = [
  "atomic-waker",
  "futures-core",
@@ -274,13 +274,13 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -293,14 +293,13 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -308,19 +307,17 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -358,7 +355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -450,12 +447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,9 +454,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -732,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1309,9 +1300,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "serde",
  "typenum",
@@ -1585,18 +1576,18 @@ checksum = "f242558c18a6d4ec99bc1eaf1603ab49e857ab36b4c1b911ebd0028cb8165e79"
 
 [[package]]
 name = "itybity"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0e73cb5daa3b9fa8b85908c8698cc6f8004addacdaa6a574e0161b8e659c6a"
+checksum = "4055cc498fadc1565ac2e28c90a693471f0476005baaf63cc500e26e36698afd"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1632,9 +1623,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1674,16 +1665,16 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matrix-transpose"
 version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1724,13 +1715,13 @@ version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
  "bincode",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serde_arrays",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1753,7 +1744,7 @@ dependencies = [
  "mpz-common",
  "mpz-core",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1764,7 +1755,7 @@ dependencies = [
  "mpz-core",
  "opaque-debug",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1781,7 +1772,7 @@ dependencies = [
  "pollster",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
 ]
@@ -1791,7 +1782,7 @@ name = "mpz-core"
 version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.0-rc.4",
  "bcs",
  "bitvec",
  "blake3",
@@ -1800,16 +1791,16 @@ dependencies = [
  "cipher 0.5.1",
  "clmul",
  "hybrid-array",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "once_cell",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.6.4",
  "rand_core 0.9.5",
  "rayon",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1821,14 +1812,14 @@ dependencies = [
  "ark-secp256r1",
  "ark-serialize",
  "hybrid-array",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-core",
  "num-bigint",
  "opaque-debug",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "typenum",
 ]
 
@@ -1849,11 +1840,11 @@ dependencies = [
  "mpz-ot",
  "mpz-vm-core",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rangeset",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -1863,13 +1854,13 @@ name = "mpz-garble-core"
 version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.0-rc.4",
  "bitvec",
  "blake3",
  "cfg-if",
  "cipher 0.5.1",
  "derive_builder 0.11.2",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-circuits",
  "mpz-common",
  "mpz-core",
@@ -1878,14 +1869,14 @@ dependencies = [
  "mpz-vm-core",
  "once_cell",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "rangeset",
  "rayon",
  "serde",
  "serde_arrays",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1895,11 +1886,11 @@ version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
  "blake3",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-circuits",
  "mpz-core",
  "mpz-vm-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1916,7 +1907,7 @@ dependencies = [
  "rangeset",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1926,12 +1917,12 @@ source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a83
 dependencies = [
  "blake3",
  "futures",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-core",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rangeset",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1941,15 +1932,15 @@ source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a83
 dependencies = [
  "async-trait",
  "futures",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-common",
  "mpz-core",
  "mpz-fields",
  "mpz-ole-core",
  "mpz-ot",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1958,14 +1949,14 @@ version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
  "hybrid-array",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-common",
  "mpz-core",
  "mpz-fields",
  "mpz-ot-core",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1977,17 +1968,17 @@ dependencies = [
  "cfg-if",
  "enum-try-as-inner",
  "futures",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-cointoss",
  "mpz-common",
  "mpz-core",
  "mpz-ot-core",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1996,7 +1987,7 @@ name = "mpz-ot-core"
 version = "0.1.0-alpha.5"
 source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a8370ccf554aded53deb6ea76e081645eeb5"
 dependencies = [
- "aes 0.9.0",
+ "aes 0.9.0-rc.4",
  "blake3",
  "bytemuck",
  "cfg-if",
@@ -2007,17 +1998,17 @@ dependencies = [
  "derive_builder 0.11.2",
  "enum-try-as-inner",
  "futures",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "matrix-transpose",
  "mpz-common",
  "mpz-core",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "rayon",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "zerocopy",
 ]
@@ -2033,9 +2024,9 @@ dependencies = [
  "mpz-fields",
  "mpz-ole",
  "mpz-share-conversion-core",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2047,9 +2038,9 @@ dependencies = [
  "mpz-core",
  "mpz-fields",
  "mpz-ole-core",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2062,7 +2053,7 @@ dependencies = [
  "mpz-circuits",
  "mpz-common",
  "mpz-memory-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2080,7 +2071,7 @@ dependencies = [
  "mpz-vm-core",
  "mpz-zk-core",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2090,7 +2081,7 @@ source = "git+https://github.com/privacy-ethereum/mpz?tag=v0.1.0-alpha.5#2974a83
 dependencies = [
  "blake3",
  "cfg-if",
- "itybity 0.3.2",
+ "itybity 0.3.1",
  "mpz-circuits",
  "mpz-core",
  "mpz-memory-core",
@@ -2099,7 +2090,7 @@ dependencies = [
  "rangeset",
  "rayon",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "zerocopy",
 ]
 
@@ -2434,9 +2425,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2445,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2599,8 +2590,8 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.3",
- "tower-http 0.6.8",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2665,9 +2656,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2687,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -2866,10 +2857,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3107,7 +3098,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3115,6 +3115,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3152,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "tlsn"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "aes 0.8.4",
  "ctr 0.9.2",
@@ -3174,14 +3185,14 @@ dependencies = [
  "once_cell",
  "opaque-debug",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rangeset",
  "rustls-pki-types",
  "rustls-webpki",
  "semver",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tlsn-attestation",
  "tlsn-cipher",
  "tlsn-core",
@@ -3198,16 +3209,16 @@ dependencies = [
 [[package]]
 name = "tlsn-attestation"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "bcs",
  "blake3",
  "k256",
  "opaque-debug",
  "p256",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "tlsn-core",
  "tlsn-tls-core",
@@ -3216,26 +3227,26 @@ dependencies = [
 [[package]]
 name = "tlsn-cipher"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "aes 0.8.4",
  "async-trait",
  "mpz-circuits",
  "mpz-memory-core",
  "mpz-vm-core",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "tlsn-core"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "bimap",
  "blake3",
  "itybity 0.2.1",
  "opaque-debug",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "rangeset",
@@ -3244,7 +3255,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "tlsn-tls-core",
  "web-time 0.2.4",
@@ -3256,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "tlsn-deap"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "async-trait",
  "futures",
@@ -3266,28 +3277,28 @@ dependencies = [
  "rangeset",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
 [[package]]
 name = "tlsn-hmac-sha256"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "mpz-circuits",
  "mpz-core",
  "mpz-hash",
  "mpz-vm-core",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "tlsn-key-exchange"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "async-trait",
  "derive_builder 0.12.0",
@@ -3299,10 +3310,10 @@ dependencies = [
  "mpz-share-conversion",
  "mpz-vm-core",
  "p256",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand06-compat",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3310,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "tlsn-mpc-tls"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -3331,10 +3342,10 @@ dependencies = [
  "opaque-debug",
  "p256",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.2",
  "serde",
  "serio",
- "thiserror",
+ "thiserror 1.0.69",
  "tlsn-cipher",
  "tlsn-core",
  "tlsn-hmac-sha256",
@@ -3357,7 +3368,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.2",
  "static_assertions",
  "web-time 1.1.0",
 ]
@@ -3365,7 +3376,7 @@ dependencies = [
 [[package]]
 name = "tlsn-tls-client"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3375,14 +3386,14 @@ dependencies = [
  "log",
  "mpz-common",
  "p256",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rand06-compat",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "sct",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tlsn-core",
  "tlsn-tls-core",
  "web-time 0.2.4",
@@ -3391,11 +3402,11 @@ dependencies = [
 [[package]]
 name = "tlsn-tls-core"
 version = "0.1.0-alpha.15-pre"
-source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#7bbe1eefbb2dec8ee33b1cf8e8568c327ab9e87f"
+source = "git+https://github.com/tlsnotary/tlsn.git?branch=main#15a7c5574145137a0e0696a6902e4133ad9786b3"
 dependencies = [
  "futures",
  "hmac",
- "rand 0.9.4",
+ "rand 0.9.2",
  "ring",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -3403,7 +3414,7 @@ dependencies = [
  "sct",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "web-time 0.2.4",
 ]
@@ -3412,7 +3423,6 @@ dependencies = [
 name = "tlsn-verifier-server"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "async-tungstenite",
  "axum",
  "base64 0.22.1",
@@ -3429,15 +3439,14 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "sha1",
  "tlsn",
  "tokio",
  "tokio-native-tls",
  "tokio-tungstenite",
  "tokio-util",
- "tower 0.4.13",
- "tower-http 0.5.2",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3494,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -3522,21 +3531,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
@@ -3553,22 +3547,6 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags",
- "bytes",
- "http",
- "http-body",
- "http-body-util",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
@@ -3580,7 +3558,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3667,20 +3645,19 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
  "native-tls",
- "rand 0.8.6",
+ "rand 0.9.2",
  "sha1",
- "thiserror",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -3805,11 +3782,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3818,14 +3795,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3836,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3846,9 +3823,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3856,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3869,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -3912,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4085,12 +4062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4177,9 +4148,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_tungstenite"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed39ff9f8b2eda91bf6390f9f49eee93d655489e15708e3bb638c1c4f07cecb4"
+checksum = "c3c9c55940d22313a53398bfeb9438c5f519de475fa37ed7ff068f8c1ca8eb45"
 dependencies = [
  "async-tungstenite",
  "async_io_stream",

--- a/packages/verifier/Cargo.toml
+++ b/packages/verifier/Cargo.toml
@@ -8,19 +8,17 @@ edition = "2021"
 tlsn = { git = "https://github.com/tlsnotary/tlsn.git", branch = "main", features = ["mozilla-certs"] }
 
 # HTTP server framework
-axum = { version = "0.7" }
+axum = { version = "0.8" }
 http = "1.0"
 hyper = "1.0"
 tokio = { version = "1", features = ["full"] }
-tower = { version = "0.4", features = ["util"] }
-tower-http = { version = "0.5", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 
 # WebSocket utilities
-ws_stream_tungstenite = "0.14"
-async-tungstenite = { version = "0.28", features = ["tokio-runtime"] }
+ws_stream_tungstenite = "0.15"
+async-tungstenite = { version = "0.29", features = ["tokio-runtime"] }
 futures-util = "0.3"
-async-trait = "0.1"
 
 # Cryptography
 sha1 = "0.10"
@@ -29,7 +27,7 @@ base64 = "0.22"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 
 # HTTP client (for webhooks)
 reqwest = { version = "0.12", features = ["json"] }
@@ -48,7 +46,7 @@ regex = "1.12.2"
 rangeset = "0.4.0"
 
 [dev-dependencies]
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["tokio", "http1"] }
 native-tls = "0.2"

--- a/packages/verifier/src/main.rs
+++ b/packages/verifier/src/main.rs
@@ -10,6 +10,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
     routing::get,
+    serve::ListenerExt,
     Router,
 };
 use futures_util::SinkExt;
@@ -79,6 +80,11 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("Failed to bind to address");
+    let listener = listener.tap_io(|tcp_stream| {
+        if let Err(err) = tcp_stream.set_nodelay(true) {
+            warn!("failed to set TCP_NODELAY on incoming connection: {err}");
+        }
+    });
 
     info!("Server listening on http://{}", addr);
     info!("Health endpoint: http://{}/health", addr);
@@ -91,7 +97,6 @@ async fn main() {
     info!("Proxy WebSocket endpoint: ws://{}/proxy?token=<host>", addr);
 
     axum::serve(listener, app)
-        .tcp_nodelay(true)
         .await
         .expect("Server error");
 }
@@ -282,7 +287,7 @@ impl Config {
     /// Load configuration from YAML file, returns default if file doesn't exist
     fn load(path: &Path) -> Self {
         match std::fs::read_to_string(path) {
-            Ok(contents) => match serde_yaml::from_str(&contents) {
+            Ok(contents) => match serde_yaml_ng::from_str(&contents) {
                 Ok(config) => {
                     info!("Loaded config from {:?}", path);
                     config
@@ -418,7 +423,7 @@ pub(crate) async fn session_ws_handler(
 /// Helper to send typed server messages
 async fn send_server_message(socket: &mut TungsteniteStream, message: &ServerMessage) -> bool {
     match socket
-        .send(Message::Text(serde_json::to_string(message).unwrap()))
+        .send(Message::Text(serde_json::to_string(message).unwrap().into()))
         .await
     {
         Ok(_) => true,
@@ -832,7 +837,7 @@ async fn handle_proxy_connection(ws: TungsteniteStream, host: String) {
                 }
                 Ok(n) => {
                     total_bytes += n as u64;
-                    let binary_msg = Message::Binary(buf[..n].to_vec());
+                    let binary_msg = Message::Binary(buf[..n].to_vec().into());
 
                     if let Err(e) = ws_sink.send(binary_msg).await {
                         error!("[{}] Failed to send to WebSocket: {}", proxy_id_clone, e);

--- a/packages/verifier/src/tests/integration_test.rs
+++ b/packages/verifier/src/tests/integration_test.rs
@@ -176,7 +176,7 @@ webhooks:
         webhook_port
     );
 
-    let config: crate::Config = serde_yaml::from_str(&config_yaml).unwrap();
+    let config: crate::Config = serde_yaml_ng::from_str(&config_yaml).unwrap();
 
     let app_state = Arc::new(crate::AppState {
         sessions: Arc::new(Mutex::new(HashMap::new())),

--- a/packages/verifier/src/ws.rs
+++ b/packages/verifier/src/ws.rs
@@ -6,7 +6,6 @@
 //! ws module to swap the backend, we implement just the upgrade handshake
 //! here and return the async-tungstenite stream directly.
 
-use async_trait::async_trait;
 use async_tungstenite::{
     tokio::TokioAdapter,
     tungstenite::protocol::{Role, WebSocketConfig},
@@ -110,7 +109,6 @@ impl IntoResponse for WsRejection {
     }
 }
 
-#[async_trait]
 impl<S: Send + Sync> FromRequestParts<S> for WsUpgrade {
     type Rejection = WsRejection;
 

--- a/packages/verifier/tests/proxy_test.rs
+++ b/packages/verifier/tests/proxy_test.rs
@@ -107,7 +107,7 @@ async fn test_proxy_endpoint_integration() {
         println!("  Client: sending {} bytes: {:?}", test_data.len(), String::from_utf8_lossy(test_data));
 
         // Send binary message
-        ws_write.send(Message::Binary(test_data.clone())).await.unwrap();
+        ws_write.send(Message::Binary(test_data.clone().into())).await.unwrap();
         println!("  Client: sent binary frame");
 
         // Receive echo back
@@ -176,7 +176,7 @@ async fn handle_proxy_test(ws: tokio_tungstenite::WebSocketStream<tokio::net::Tc
                 Ok(n) => {
                     count += 1;
                     println!("  Proxy: TCP->WS forwarding {} bytes (chunk #{})", n, count);
-                    let msg = Message::Binary(buf[..n].to_vec());
+                    let msg = Message::Binary(buf[..n].to_vec().into());
                     if ws_sink.send(msg).await.is_err() {
                         println!("  Proxy: TCP->WS write failed");
                         break;
@@ -255,7 +255,7 @@ async fn test_proxy_real_http_request() {
 
     // Send HTTP request as binary WebSocket message
     ws_write
-        .send(Message::Binary(http_request.as_bytes().to_vec()))
+        .send(Message::Binary(http_request.as_bytes().to_vec().into()))
         .await
         .unwrap();
 
@@ -385,7 +385,7 @@ async fn test_websocket_binary_frames() {
 
     // Send binary data
     let test_data = b"Binary data test";
-    write.send(Message::Binary(test_data.to_vec())).await.unwrap();
+    write.send(Message::Binary(test_data.to_vec().into())).await.unwrap();
     println!("WS Client: sent {} bytes", test_data.len());
 
     // Receive echo


### PR DESCRIPTION
## Summary

Stacked on top of #322. Refreshes non-tlsn Rust dependencies in the verifier crate.

- **axum 0.7 → 0.8**: drop `#[async_trait]` on `FromRequestParts` (native async-in-trait); move `TCP_NODELAY` from `Serve::tcp_nodelay` (removed in 0.8) to `ListenerExt::tap_io` on the listener.
- **tower-http 0.5 → 0.6**
- **tower** removed — only `tower-http` was used directly; `tower` was a leftover dep.
- **async-trait** removed — no longer needed after the axum 0.8 bump.
- **Tungstenite family**: `async-tungstenite 0.28 → 0.29`, `ws_stream_tungstenite 0.14 → 0.15`, `tokio-tungstenite 0.24 → 0.26` (dev). `ws_stream_tungstenite 0.15` pins `async-tungstenite ^0.29`, so everything stays on `tungstenite 0.26`. Adjusted `Message::Text`/`Message::Binary` call sites for the new `Utf8Bytes`/`Bytes` payload types (`.into()` conversions).
- **serde_yaml 0.9 (deprecated) → serde_yaml_ng 0.10**. Drop-in API; `serde_yaml` was officially marked unmaintained by dtolnay.
- `cargo update` for compatible patch bumps (tokio 1.50 → 1.52, rustls, hyper-rustls, uuid, rayon, openssl, etc.), explicitly excluding `tlsn` so this PR doesn't smuggle in a tlsn commit bump.

Based on the code review feedback on #322; that review called out axum 0.8 + the dead `axum-core` dep; this PR takes the broader dep-refresh pass.

## Test plan

- [x] `cargo check` on verifier crate
- [x] `cargo check --tests` on verifier crate
- [x] `cargo test` — all 9 tests pass (3 integration, 3 range-mapping, 2 proxy, 1 ignored as before)
- [ ] Verify against a running extension end-to-end before merge