### PR TITLE
perf(verifier): set TCP_NODELAY on outbound proxy connection

### DIFF
--- a/packages/verifier/src/main.rs
+++ b/packages/verifier/src/main.rs
@@ -760,6 +760,12 @@ async fn handle_proxy_connection(ws: TungsteniteStream, host: String) {
             return;
         }
     };
+    if let Err(err) = tcp_stream.set_nodelay(true) {
+        warn!(
+            "[{}] failed to set TCP_NODELAY on outbound proxy connection: {}",
+            proxy_id, err
+        );
+    }
 
     // Split WebSocket into sink and stream
     let (mut ws_sink, mut ws_stream) = ws.split();


### PR DESCRIPTION
## Summary
- The inbound axum listener already sets `TCP_NODELAY` on each accepted connection via `ListenerExt::tap_io` ([main.rs:83-87](packages/verifier/src/main.rs#L83-L87)).
- The proxy's **outbound** TCP socket to the remote TLS host (e.g. `api.x.com:443`) was missing the same setting, so Nagle's algorithm could buffer small TLS records and add up to ~200ms of latency on small writes during MPC-TLS handshakes and short request/response exchanges.
- This PR sets `set_nodelay(true)` on the outbound socket immediately after `TcpStream::connect`, with the same warn-and-continue error handling pattern used on the inbound side.

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Manual: run a plugin proof end-to-end through the proxy and confirm no regression