### PR TITLE
perf(verifier): hot-path optimizations (oneshot, BytesMut, LTO)

### DIFF
--- a/packages/verifier/Cargo.lock
+++ b/packages/verifier/Cargo.lock
@@ -2935,16 +2935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,9 +3453,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/packages/verifier/Cargo.lock
+++ b/packages/verifier/Cargo.lock
@@ -3426,6 +3426,7 @@ dependencies = [
  "async-tungstenite",
  "axum",
  "base64 0.22.1",
+ "bytes",
  "either",
  "eyre",
  "futures-util",

--- a/packages/verifier/Cargo.toml
+++ b/packages/verifier/Cargo.toml
@@ -11,7 +11,7 @@ tlsn = { git = "https://github.com/tlsnotary/tlsn.git", branch = "main", feature
 axum = { version = "0.8" }
 http = "1.0"
 hyper = "1.0"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "time"] }
 tower-http = { version = "0.6", features = ["cors"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 

--- a/packages/verifier/Cargo.toml
+++ b/packages/verifier/Cargo.toml
@@ -44,6 +44,11 @@ tokio-util = { version = "0.7", features = ["compat"] }
 uuid = { version = "1.0", features = ["v4", "serde"] }
 regex = "1.12.2"
 rangeset = "0.4.0"
+bytes = "1"
+
+[profile.release]
+lto = true
+codegen-units = 1
 
 [dev-dependencies]
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }

--- a/packages/verifier/src/main.rs
+++ b/packages/verifier/src/main.rs
@@ -13,6 +13,7 @@ use axum::{
     serve::ListenerExt,
     Router,
 };
+use bytes::BytesMut;
 use futures_util::SinkExt;
 use rangeset::prelude::RangeSet;
 use serde::{Deserialize, Serialize};
@@ -515,12 +516,11 @@ async fn handle_session_websocket(mut socket: TungsteniteStream, state: Arc<AppS
 
     info!("[{}] Sent session_registered to client", session_id);
 
-    // Create channels for prover socket and results
+    // Create channels for prover socket, reveal config, and results
     let (prover_socket_tx, prover_socket_rx) = oneshot::channel::<TungsteniteStream>();
+    let (reveal_config_tx, reveal_config_rx) = oneshot::channel::<RevealConfig>();
     let (result_tx, result_rx) = oneshot::channel::<VerificationResult>();
 
-    // Create shared reveal config storage and session data storage
-    let reveal_config_storage = Arc::new(Mutex::new(None));
     let session_data_storage = Arc::new(session_data.clone());
 
     let session_config = SessionConfig {
@@ -542,14 +542,13 @@ async fn handle_session_websocket(mut socket: TungsteniteStream, state: Arc<AppS
     // Spawn the verifier task with the result sender
     let session_id_clone = session_id.clone();
     let state_clone = state.clone();
-    let reveal_config_storage_clone = reveal_config_storage.clone();
     let session_data_clone = session_data_storage.clone();
     tokio::spawn(async move {
         run_verifier_task(
             session_id_clone,
             session_config,
             (*session_data_clone).clone(),
-            reveal_config_storage_clone,
+            reveal_config_rx,
             prover_socket_rx,
             result_tx,
             state_clone,
@@ -613,14 +612,17 @@ async fn handle_session_websocket(mut socket: TungsteniteStream, state: Arc<AppS
         reveal_config.recv.len()
     );
 
-    // Store reveal config in shared storage
-    {
-        let mut storage = reveal_config_storage.lock().await;
-        *storage = Some(reveal_config);
+    // Forward reveal config to verifier task
+    if reveal_config_tx.send(reveal_config).is_err() {
+        error!(
+            "[{}] ❌ Verifier task dropped reveal config receiver",
+            session_id
+        );
+        return;
     }
 
     info!(
-        "[{}] ✅ Reveal config stored, verifier task can now proceed",
+        "[{}] ✅ Reveal config sent, verifier task can now proceed",
         session_id
     );
 
@@ -819,11 +821,13 @@ async fn handle_proxy_connection(ws: TungsteniteStream, host: String) {
     // Read from TCP and wrap in WebSocket Binary messages
     let proxy_id_clone = proxy_id.clone();
     let tcp_to_ws = tokio::spawn(async move {
-        let mut buf = vec![0u8; 8192];
+        const CHUNK: usize = 8192;
+        let mut buf = BytesMut::with_capacity(CHUNK);
         let mut total_bytes = 0u64;
 
         loop {
-            match tcp_read.read(&mut buf).await {
+            buf.reserve(CHUNK);
+            match tcp_read.read_buf(&mut buf).await {
                 Ok(0) => {
                     info!(
                         "[{}] TCP read EOF (server closed), forwarded {} bytes to WebSocket",
@@ -837,9 +841,9 @@ async fn handle_proxy_connection(ws: TungsteniteStream, host: String) {
                 }
                 Ok(n) => {
                     total_bytes += n as u64;
-                    let binary_msg = Message::Binary(buf[..n].to_vec().into());
+                    let chunk = buf.split().freeze();
 
-                    if let Err(e) = ws_sink.send(binary_msg).await {
+                    if let Err(e) = ws_sink.send(Message::Binary(chunk)).await {
                         error!("[{}] Failed to send to WebSocket: {}", proxy_id_clone, e);
                         break;
                     }
@@ -873,7 +877,7 @@ async fn run_verifier_task(
     session_id: String,
     config: SessionConfig,
     session_data: HashMap<String, String>,
-    reveal_config_storage: Arc<Mutex<Option<RevealConfig>>>,
+    reveal_config_rx: oneshot::Receiver<RevealConfig>,
     socket_rx: oneshot::Receiver<TungsteniteStream>,
     result_tx: oneshot::Sender<VerificationResult>,
     state: Arc<AppState>,
@@ -959,21 +963,22 @@ async fn run_verifier_task(
                 transcript.received_authed().len()
             );
 
-            // Wait for RevealConfig to be available (with polling and timeout)
+            // Wait for RevealConfig from the session handler (with timeout)
             let reveal_config_wait_timeout = Duration::from_secs(30);
-            let start_time = tokio::time::Instant::now();
-
-            let reveal_config = loop {
-                {
-                    let storage = reveal_config_storage.lock().await;
-                    if let Some(config) = storage.as_ref() {
-                        info!("[{}] ✅ RevealConfig found, mapping results", session_id);
-                        break config.clone();
-                    }
+            let reveal_config = match timeout(reveal_config_wait_timeout, reveal_config_rx).await {
+                Ok(Ok(config)) => {
+                    info!("[{}] ✅ RevealConfig received, mapping results", session_id);
+                    config
                 }
-
-                // Check timeout
-                if start_time.elapsed() > reveal_config_wait_timeout {
+                Ok(Err(_)) => {
+                    error!(
+                        "[{}] ❌ RevealConfig channel closed before delivery",
+                        session_id
+                    );
+                    cleanup_session(&state, &session_id).await;
+                    return;
+                }
+                Err(_) => {
                     error!(
                         "[{}] ❌ Timed out waiting for RevealConfig after verification",
                         session_id
@@ -981,10 +986,6 @@ async fn run_verifier_task(
                     cleanup_session(&state, &session_id).await;
                     return;
                 }
-
-                // RevealConfig not available yet, wait a bit
-                info!("[{}] Waiting for RevealConfig...", session_id);
-                tokio::time::sleep(Duration::from_millis(100)).await;
             };
 
             // Validate that reveal_config ranges match authenticated transcript


### PR DESCRIPTION
## Summary
Three independent perf improvements bundled together. Each is small and self-contained:

### 1. Replace 100ms polling loop for `RevealConfig` with a oneshot channel
- Before: the verifier task polled `Arc<Mutex<Option<RevealConfig>>>` every 100 ms after MPC-TLS verification finished, adding up to 100 ms (median ~50 ms) of latency per session and allocating a format string on every iteration via `info!`.
- After: a `tokio::sync::oneshot::Sender<RevealConfig>` from the session handler delivers the config directly to the verifier task; the receiver is awaited under `tokio::time::timeout` for the same 30-second cap.

### 2. Use `BytesMut` + `read_buf` for the proxy TCP→WebSocket bridge
- Before: each TCP read did `buf[..n].to_vec()` to copy into a fresh `Vec` before wrapping in `Message::Binary`.
- After: a single `BytesMut` is reused with `read_buf`, then `split().freeze()` hands the bytes to the `Message::Binary` with no extra memcpy. Roughly cuts memory bandwidth in half on sustained proxy throughput.

### 3. Enable LTO + `codegen-units = 1` for the release profile
- Before: no `[profile.release]` section, so cargo defaulted to `codegen-units = 16` and no LTO.
- After: `lto = true`, `codegen-units = 1`. Expected 5–15% release-build throughput improvement from cross-crate inlining in the proxy and verification hot paths. Trade-off is a slightly slower release build.

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all integration, proxy, and range-mapping tests pass
- [x] `cargo clippy` — only pre-existing warning unrelated to this change
- [x] Manual end-to-end run through extension to confirm no regression