### PR TITLE
chore(mobile): add ADI registration plugin for Play Console package verification

### DIFF
--- a/app/mobile/app.json
+++ b/app/mobile/app.json
@@ -33,7 +33,7 @@
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
-    "plugins": ["expo-router", "./plugins/exclude-x86_64"],
+    "plugins": ["expo-router", "./plugins/exclude-x86_64", "./plugins/adi-registration"],
     "experiments": {
       "typedRoutes": true
     },

--- a/app/mobile/plugins/adi-registration.js
+++ b/app/mobile/plugins/adi-registration.js
@@ -1,0 +1,20 @@
+const { withDangerousMod } = require('expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+// Google Play Console anti-impersonation token (ADI). Tied to the tlsnotary
+// developer account; useless without the matching upload key. Public-by-design
+// — it's bundled into every shipped APK in assets.
+const ADI_TOKEN = 'DSBMHGT4FZT3EAAAAAAAAAAAAA';
+
+module.exports = function adiRegistration(config) {
+  return withDangerousMod(config, [
+    'android',
+    (config) => {
+      const assetsDir = path.join(config.modRequest.platformProjectRoot, 'app/src/main/assets');
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(path.join(assetsDir, 'adi-registration.properties'), ADI_TOKEN + '\n');
+      return config;
+    },
+  ]);
+};


### PR DESCRIPTION
Required for one-time package-name registration with Play Console.