### PR TITLE
fix: use ./ instead of . for marketplace plugin source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "tlsn-create-plugin",
-      "source": ".",
+      "source": "./",
       "description": "Create TLSNotary plugins that prove data from web services using MPC-TLS",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary

- Claude Code rejects `"source": "."` in `.claude-plugin/marketplace.json` with `Invalid schema: plugins.0.source: Invalid input`
- Local plugin sources must use a path starting with `./` (matches the convention used in [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json))
- This unblocks `/plugin marketplace add tlsnotary/tlsn-extension`

## Test plan

- [ ] After merge to main: run `/plugin marketplace add tlsnotary/tlsn-extension` in Claude Code and verify the marketplace loads without the schema error
- [ ] Run `/plugin install tlsn-create-plugin@tlsnotary` and verify the `/create-plugin` command becomes available