### PR TITLE
feat(demo): storytelling pass for demo.tlsnotary.org

### DIFF
--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -273,6 +273,9 @@ export function PluginScreen({
       .finally(() => {
         setIsRunning(false);
       });
+    // isRunning is intentionally omitted: it guards against double-starts,
+    // and re-running when it flips back to false would start the plugin twice.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [proverReady, pluginCode, eventEmitter, host, onComplete, onError]);
 
   return (

--- a/packages/demo/src/App.css
+++ b/packages/demo/src/App.css
@@ -93,6 +93,66 @@ body {
   font-weight: 400;
 }
 
+.hero-ctas {
+  display: flex;
+  gap: var(--spacing-md);
+  justify-content: center;
+  margin-top: var(--spacing-lg);
+  flex-wrap: wrap;
+}
+.hero-cta {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  text-decoration: none;
+  font-size: 1rem;
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+.hero-cta-secondary {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+.hero-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+}
+
+/* What and Why */
+.what-and-why {
+  padding: var(--spacing-xl) 0 var(--spacing-2xl);
+  scroll-margin-top: 1rem;
+}
+
+.what-and-why-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-xl);
+}
+
+.what-and-why-card h3 {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: white;
+  margin: 0 0 var(--spacing-sm) 0;
+}
+
+.what-and-why-card p {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.what-and-why-card em {
+  color: white;
+  font-style: italic;
+  font-weight: 600;
+}
+
 /* Content Card */
 .content-card {
   background: white;
@@ -318,9 +378,31 @@ body {
   border: 1px solid var(--gray-200);
   background: white;
   display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  transition: all 0.2s ease;
+}
+
+.check-item-row {
+  display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  transition: all 0.2s ease;
+}
+
+.check-item-link {
+  padding-left: 1.75rem;
+  font-size: 0.85rem;
+}
+
+.check-item-link a {
+  color: var(--gray-500);
+  text-decoration: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.check-item-link a:hover {
+  color: var(--primary);
+  text-decoration: underline;
 }
 
 .check-item.checking {
@@ -374,34 +456,37 @@ body {
 
 /* Console Section */
 .console-section {
-  margin: var(--spacing-xl) 0;
-  border-radius: var(--radius-lg);
   background: var(--gray-900);
-  overflow: hidden;
+}
+
+/* Dark variant of CollapsibleSection (used by the console) */
+.console-collapsible {
+  background: var(--gray-900);
   box-shadow: var(--shadow-lg);
 }
 
-.console-header {
+.console-collapsible .collapsible-header {
   background: var(--gray-800);
-  color: white;
-  padding: var(--spacing-md) var(--spacing-lg);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   border-bottom: 1px solid var(--gray-700);
 }
 
-.console-title {
-  font-weight: 600;
-  font-size: 0.9375rem;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
+.console-collapsible .collapsible-header:hover {
+  background: var(--gray-700);
 }
 
-.console-title::before {
-  content: '⚡';
-  font-size: 1.125rem;
+.console-collapsible .collapsible-toggle {
+  color: white;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: 0.9375rem;
+}
+
+.console-collapsible .collapsible-icon {
+  color: var(--gray-400);
+}
+
+.console-collapsible .collapsible-content {
+  padding: 0;
+  animation: none;
 }
 
 .console-output {
@@ -528,6 +613,10 @@ body {
     font-size: 1rem;
   }
 
+  .what-and-why-grid {
+    grid-template-columns: 1fr;
+  }
+
   .content-card {
     padding: var(--spacing-lg);
   }
@@ -536,10 +625,14 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .console-header {
-    flex-direction: column;
-    gap: var(--spacing-sm);
-    align-items: stretch;
+  .collapsible-header {
+    flex-wrap: wrap;
+  }
+
+  .collapsible-actions {
+    padding: 0 var(--spacing-lg) var(--spacing-md);
+    width: 100%;
+    justify-content: flex-end;
   }
 }
 
@@ -733,23 +826,35 @@ body {
 }
 
 .collapsible-header {
-  width: 100%;
-  padding: var(--spacing-md) var(--spacing-lg);
+  display: flex;
+  align-items: center;
   background: var(--gray-50);
+  transition: background 0.2s ease;
+}
+
+.collapsible-header:hover {
+  background: var(--gray-100);
+}
+
+.collapsible-toggle {
+  flex: 1;
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: transparent;
   border: none;
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
   cursor: pointer;
-  transition: all 0.2s ease;
   font-size: 1rem;
   font-weight: 600;
   color: var(--gray-900);
   text-align: left;
 }
 
-.collapsible-header:hover {
-  background: var(--gray-100);
+.collapsible-actions {
+  display: flex;
+  gap: 10px;
+  padding-right: var(--spacing-lg);
 }
 
 .collapsible-icon {
@@ -1174,10 +1279,10 @@ body {
   box-shadow: var(--shadow-lg);
 }
 
-.cta-content {
+.byo-header {
   text-align: center;
   max-width: 700px;
-  margin: 0 auto;
+  margin: 0 auto var(--spacing-xl);
 }
 
 .cta-title {
@@ -1194,93 +1299,100 @@ body {
   margin: 0 0 var(--spacing-xl) 0;
 }
 
-.cta-buttons {
-  display: flex;
+.tif-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: var(--spacing-md);
-  justify-content: center;
-  flex-wrap: wrap;
   margin-bottom: var(--spacing-xl);
 }
 
-.cta-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  padding: 1rem 1.75rem;
-  font-size: 1rem;
-  font-weight: 600;
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  transition: all 0.2s ease;
-}
-
-.cta-btn-primary {
-  background: white;
-  color: var(--primary-dark);
-}
-
-.cta-btn-primary:hover {
-  background: var(--gray-100);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-md);
-}
-
-.cta-btn-secondary {
-  background: rgba(255, 255, 255, 0.15);
-  color: white;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-}
-
-.cta-btn-secondary:hover {
-  background: rgba(255, 255, 255, 0.25);
-  border-color: rgba(255, 255, 255, 0.5);
-  transform: translateY(-2px);
-}
-
-.cta-resources {
+.tif-card {
+  display: block;
   background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: var(--radius-lg);
   padding: var(--spacing-lg);
   text-align: left;
+  text-decoration: none;
+  color: white;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
 }
 
-.cta-resources-title {
-  font-size: 0.875rem;
+.tif-card:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-2px);
+}
+
+.tif-card-disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.tif-card-disabled:hover {
+  background: rgba(255, 255, 255, 0.1);
+  transform: none;
+}
+
+.tif-icon {
+  font-size: 1.75rem;
+  margin-bottom: var(--spacing-sm);
+}
+
+.tif-card-title {
+  font-size: 1.05rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.8);
+  color: white;
+  margin: 0 0 var(--spacing-xs) 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  flex-wrap: wrap;
+}
+
+.tif-badge {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  font-size: 0.65rem;
+  font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin: 0 0 var(--spacing-md) 0;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  color: white;
 }
 
-.cta-resources-list {
-  list-style: none;
-  padding: 0;
+.tif-card-description {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.9rem;
+  line-height: 1.5;
   margin: 0;
 }
 
-.cta-resources-list li {
-  padding: var(--spacing-sm) 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+.tif-footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.7);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
 }
 
-.cta-resources-list li:last-child {
-  border-bottom: none;
-}
-
-.cta-resources-list a {
+.tif-footer a {
   color: white;
   text-decoration: none;
-  font-weight: 500;
 }
 
-.cta-resources-list a:hover {
+.tif-footer a:hover {
   text-decoration: underline;
 }
 
-.resource-desc {
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.875rem;
+.tif-footer-sep {
+  color: rgba(255, 255, 255, 0.4);
 }
 
 /* App Footer */

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react';
 import { SystemChecks } from './components/SystemChecks';
-import { ConsoleOutput } from './components/Console';
+import { ConsoleOutput, ConsoleActions } from './components/Console';
 import { PluginButtons } from './components/PluginButtons';
 import { StatusBar } from './components/StatusBar';
 import { CollapsibleSection } from './components/CollapsibleSection';
 import { HowItWorks } from './components/HowItWorks';
+import { WhatAndWhy } from './components/WhatAndWhy';
 import { WhyPlugins } from './components/WhyPlugins';
 import { BuildYourOwn } from './components/BuildYourOwn';
 import { OnchainDemo } from './components/OnchainDemo';
@@ -301,11 +302,29 @@ export function App() {
   return (
     <div className="app-container">
       <div className="hero-section">
-        <h1 className="hero-title">TLSNotary Plugin Demo</h1>
+        <h1 className="hero-title">Prove anything from the web. Privacy on your terms.</h1>
         <p className="hero-subtitle">
-          zkTLS in action — secure, private data verification from any website
+          TLSNotary lets users prove facts from any HTTPS site, like a bank balance, a paid
+          subscription, or an age. They share only the fields the plugin discloses, or use
+          zero-knowledge proofs to prove a fact without revealing any data.
         </p>
+        <div className="hero-ctas">
+          <a href="#what-and-why" className="hero-cta hero-cta-secondary">
+            How it works →
+          </a>
+          <a href="#try-it" className="hero-cta hero-cta-secondary">
+            Try a plugin →
+          </a>
+          <a href="#onchain-demo" className="hero-cta hero-cta-secondary">
+            Onchain demo →
+          </a>
+          <a href="#build-your-own" className="hero-cta hero-cta-secondary">
+            Build your own →
+          </a>
+        </div>
       </div>
+
+      <WhatAndWhy />
 
       <HowItWorks />
 
@@ -315,22 +334,19 @@ export function App() {
         verifierOk={verifierCheck.status === 'success'}
         onRecheck={handleRecheck}
         detailsContent={
-          <div className="checks-section">
-            <div className="checks-title">System Status Details</div>
-            <SystemChecks
-              checks={{
-                browser: browserCheck,
-                extension: extensionCheck,
-                verifier: verifierCheck,
-              }}
-              onRecheck={handleRecheck}
-              showBrowserWarning={showBrowserWarning}
-            />
-          </div>
+          <SystemChecks
+            checks={{
+              browser: browserCheck,
+              extension: extensionCheck,
+              verifier: verifierCheck,
+            }}
+            onRecheck={handleRecheck}
+            showBrowserWarning={showBrowserWarning}
+          />
         }
       />
 
-      <div className="content-card">
+      <div id="try-it" className="content-card">
         <h2 className="section-title">Try It: Demo Plugins</h2>
         <p className="section-subtitle">
           Run a plugin to see TLSNotary in action. Click "View Source" to see how each plugin works.
@@ -359,12 +375,19 @@ export function App() {
 
       <BuildYourOwn />
 
-      <CollapsibleSection title="Console Output" expanded={consoleExpanded}>
-        <ConsoleOutput
-          entries={consoleEntries}
-          onClear={handleClearConsole}
-          onOpenExtensionLogs={handleOpenExtensionLogs}
-        />
+      <CollapsibleSection
+        title="Console Output"
+        className="console-collapsible"
+        expanded={consoleExpanded}
+        onToggle={setConsoleExpanded}
+        actions={
+          <ConsoleActions
+            onClear={handleClearConsole}
+            onOpenExtensionLogs={handleOpenExtensionLogs}
+          />
+        }
+      >
+        <ConsoleOutput entries={consoleEntries} />
       </CollapsibleSection>
 
       <footer className="app-footer">

--- a/packages/demo/src/components/BuildYourOwn.tsx
+++ b/packages/demo/src/components/BuildYourOwn.tsx
@@ -1,85 +1,104 @@
 import { trackOutboundClick } from '../analytics';
 
+const TUTORIAL_URL = 'https://demo.tlsnotary.org/tutorial/';
+const DOCS_URL = 'https://tlsnotary.org/docs/extension/plugins';
+const DISCORD_URL = 'https://discord.com/invite/9XwESXtcN7';
+const GITHUB_URL = 'https://github.com/tlsnotary/tlsn-extension';
+const PLUGIN_SOURCES_URL =
+  'https://github.com/tlsnotary/tlsn-extension/tree/main/packages/plugins/src';
+const TLSNOTARY_URL = 'https://tlsnotary.org';
+
 export function BuildYourOwn() {
   return (
-    <div className="build-your-own">
-      <div className="cta-content">
-        <h2 className="cta-title">Ready to Build Your Own Plugin?</h2>
+    <div id="build-your-own" className="build-your-own">
+      <div className="byo-header">
+        <h2 className="cta-title">Build your own plugin</h2>
         <p className="cta-description">
-          Create custom plugins to prove data from any website. Our SDK and documentation will help
-          you get started in minutes.
+          Learn the basics, ship your first plugin, and connect with other builders.
         </p>
+      </div>
 
-        <div className="cta-buttons">
-          <a
-            href="https://tlsnotary.org/docs/extension/plugins"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="cta-btn cta-btn-primary"
-            onClick={() => trackOutboundClick('docs')}
-          >
-            📚 Read the Docs
-          </a>
-          <a
-            href="https://github.com/tlsnotary/tlsn-extension/tree/main/packages/demo/src/plugins"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="cta-btn cta-btn-secondary"
-            onClick={() => trackOutboundClick('plugin_sources')}
-          >
-            💻 View Plugin Sources
-          </a>
+      <div className="tif-grid">
+        <a
+          href={TUTORIAL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tif-card"
+          onClick={() => trackOutboundClick('tutorial')}
+        >
+          <div className="tif-icon">📚</div>
+          <h3 className="tif-card-title">Learn</h3>
+          <p className="tif-card-description">
+            Build your first plugin in 10 minutes. Step-by-step interactive tutorial.
+          </p>
+        </a>
+
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tif-card"
+          onClick={() => trackOutboundClick('docs')}
+        >
+          <div className="tif-icon">💻</div>
+          <h3 className="tif-card-title">SDK &amp; docs</h3>
+          <p className="tif-card-description">
+            API reference, handler types, and the source for every plugin in this demo.
+          </p>
+        </a>
+
+        <div className="tif-card tif-card-disabled" aria-disabled="true">
+          <div className="tif-icon">📱</div>
+          <h3 className="tif-card-title">
+            Mobile <span className="tif-badge">Coming soon</span>
+          </h3>
+          <p className="tif-card-description">
+            iOS and Android apps that run the same plugins. Get notified on Discord.
+          </p>
         </div>
 
-        <div className="cta-resources">
-          <h4 className="cta-resources-title">Resources</h4>
-          <ul className="cta-resources-list">
-            <li>
-              <a
-                href="https://github.com/tlsnotary/tlsn-extension"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackOutboundClick('github')}
-              >
-                GitHub Repository
-                <span className="resource-desc">— Extension source code and examples</span>
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://tlsnotary.org/docs/extension/plugins"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackOutboundClick('docs')}
-              >
-                TLSNotary Plugin Documentation
-                <span className="resource-desc">— Complete protocol and API reference</span>
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://tlsnotary.org"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackOutboundClick('tlsnotary_home')}
-              >
-                TLSNotary
-                <span className="resource-desc">— TLSNotary landing page</span>
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://discord.com/invite/9XwESXtcN7"
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackOutboundClick('discord')}
-              >
-                Discord Community
-                <span className="resource-desc">— Get help and share your plugins</span>
-              </a>
-            </li>
-          </ul>
-        </div>
+        <a
+          href={DISCORD_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tif-card"
+          onClick={() => trackOutboundClick('discord')}
+        >
+          <div className="tif-icon">💬</div>
+          <h3 className="tif-card-title">Community</h3>
+          <p className="tif-card-description">
+            Get help, share your plugins, and follow what TLSNotary contributors are building.
+          </p>
+        </a>
+      </div>
+
+      <div className="tif-footer">
+        <a
+          href={TLSNOTARY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackOutboundClick('tlsnotary_home')}
+        >
+          tlsnotary.org
+        </a>
+        <span className="tif-footer-sep">·</span>
+        <a
+          href={GITHUB_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackOutboundClick('github')}
+        >
+          GitHub
+        </a>
+        <span className="tif-footer-sep">·</span>
+        <a
+          href={PLUGIN_SOURCES_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => trackOutboundClick('plugin_sources')}
+        >
+          Plugin sources
+        </a>
       </div>
     </div>
   );

--- a/packages/demo/src/components/CollapsibleSection.tsx
+++ b/packages/demo/src/components/CollapsibleSection.tsx
@@ -1,27 +1,46 @@
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 
 interface CollapsibleSectionProps {
   title: string;
   defaultExpanded?: boolean;
   expanded?: boolean;
-  children: React.ReactNode;
+  onToggle?: (expanded: boolean) => void;
+  actions?: ReactNode;
+  className?: string;
+  children: ReactNode;
 }
 
 export function CollapsibleSection({
   title,
   defaultExpanded = false,
   expanded,
+  onToggle,
+  actions,
+  className,
   children,
 }: CollapsibleSectionProps) {
   const [localExpanded, setLocalExpanded] = useState(defaultExpanded);
-  const isExpanded = expanded !== undefined ? expanded : localExpanded;
+  const isControlled = expanded !== undefined;
+  const isExpanded = isControlled ? expanded : localExpanded;
+
+  const handleToggle = () => {
+    const next = !isExpanded;
+    if (isControlled) {
+      onToggle?.(next);
+    } else {
+      setLocalExpanded(next);
+    }
+  };
 
   return (
-    <div className="collapsible-section">
-      <button className="collapsible-header" onClick={() => setLocalExpanded(!isExpanded)}>
-        <span className="collapsible-icon">{isExpanded ? '▼' : '▶'}</span>
-        <span className="collapsible-title">{title}</span>
-      </button>
+    <div className={className ? `collapsible-section ${className}` : 'collapsible-section'}>
+      <div className="collapsible-header">
+        <button className="collapsible-toggle" onClick={handleToggle}>
+          <span className="collapsible-icon">{isExpanded ? '▼' : '▶'}</span>
+          <span className="collapsible-title">{title}</span>
+        </button>
+        {actions && isExpanded && <div className="collapsible-actions">{actions}</div>}
+      </div>
       {isExpanded && <div className="collapsible-content">{children}</div>}
     </div>
   );

--- a/packages/demo/src/components/Console.tsx
+++ b/packages/demo/src/components/Console.tsx
@@ -15,33 +15,38 @@ export function ConsoleEntry({ timestamp, message, type }: ConsoleEntryProps) {
 
 interface ConsoleOutputProps {
   entries: ConsoleEntryProps[];
-  onClear: () => void;
-  onOpenExtensionLogs: () => void;
 }
 
-export function ConsoleOutput({ entries, onClear, onOpenExtensionLogs }: ConsoleOutputProps) {
+export function ConsoleOutput({ entries }: ConsoleOutputProps) {
   return (
     <div className="console-section">
-      <div className="console-header">
-        <div className="console-title">Console Output</div>
-        <div style={{ display: 'flex', gap: '10px' }}>
-          <button
-            className="btn-console"
-            onClick={onOpenExtensionLogs}
-            style={{ background: '#6c757d' }}
-          >
-            View Extension Logs
-          </button>
-          <button className="btn-console" onClick={onClear}>
-            Clear
-          </button>
-        </div>
-      </div>
       <div className="console-output" id="consoleOutput">
         {entries.map((entry, index) => (
           <ConsoleEntry key={index} {...entry} />
         ))}
       </div>
     </div>
+  );
+}
+
+interface ConsoleActionsProps {
+  onClear: () => void;
+  onOpenExtensionLogs: () => void;
+}
+
+export function ConsoleActions({ onClear, onOpenExtensionLogs }: ConsoleActionsProps) {
+  return (
+    <>
+      <button
+        className="btn-console"
+        onClick={onOpenExtensionLogs}
+        style={{ background: '#6c757d' }}
+      >
+        View Extension Logs
+      </button>
+      <button className="btn-console" onClick={onClear}>
+        Clear
+      </button>
+    </>
   );
 }

--- a/packages/demo/src/components/HowItWorks.tsx
+++ b/packages/demo/src/components/HowItWorks.tsx
@@ -3,16 +3,17 @@ export function HowItWorks() {
     <div className="how-it-works">
       <h2 className="how-it-works-title">How It Works</h2>
       <p className="how-it-works-subtitle">
-        Experience cryptographic proof generation in three simple steps
+        From a normal TLS session to a verifiable proof, in three steps.
       </p>
 
       <div className="steps-container">
         <div className="step">
           <div className="step-number">1</div>
-          <div className="step-icon">🔌</div>
-          <h3 className="step-title">Run a Plugin</h3>
+          <div className="step-icon">🔒</div>
+          <h3 className="step-title">You browse normally</h3>
           <p className="step-description">
-            Select a plugin and click "Run". A new browser window opens to the target website.
+            The plugin opens the target website (Spotify, X, Duolingo, …). You log in as you would
+            any day. The server sees a normal TLS connection and changes nothing on its side.
           </p>
         </div>
 
@@ -20,11 +21,12 @@ export function HowItWorks() {
 
         <div className="step">
           <div className="step-number">2</div>
-          <div className="step-icon">🔐</div>
-          <h3 className="step-title">Create Proof</h3>
+          <div className="step-icon">🤝</div>
+          <h3 className="step-title">The verifier joins via MPC</h3>
           <p className="step-description">
-            Log in if needed, then click "Prove". TLSNotary creates a cryptographic proof of your
-            data.
+            Your browser and the verifier jointly operate the TLS connection using multi-party
+            computation. The verifier never sees your plaintext, but its participation locks the
+            session: the data sent and received cannot be forged afterwards.
           </p>
         </div>
 
@@ -33,18 +35,21 @@ export function HowItWorks() {
         <div className="step">
           <div className="step-number">3</div>
           <div className="step-icon">✅</div>
-          <h3 className="step-title">Verify Result</h3>
+          <h3 className="step-title">The plugin reveals what it discloses</h3>
           <p className="step-description">
-            The proof is verified by the server. Only the data you chose to reveal is shared.
+            The plugin shows the verifier only the bytes it was written to disclose, or runs a
+            zero-knowledge proof for sensitive fields. The verifier checks the disclosure against
+            the MPC-committed transcript.
           </p>
         </div>
       </div>
 
       <div className="how-it-works-note">
-        <span className="note-icon">💡</span>
+        <span className="note-icon">🔐</span>
         <span>
-          <strong>Your data stays private:</strong> Plugins run inside the TLSNotary extension's
-          secure sandbox. Data flows through your browser — never through third-party servers.
+          <strong>Why no notary?</strong> The verifier was part of the TLS session, so it doesn't
+          need to take anyone's word for the data afterwards. The only trust assumption is the
+          server's TLS certificate, the same one your browser already validates.
         </span>
       </div>
     </div>

--- a/packages/demo/src/components/OnchainDemo.tsx
+++ b/packages/demo/src/components/OnchainDemo.tsx
@@ -162,11 +162,14 @@ export function OnchainDemo({ allChecksPass, addConsoleEntry }: Props) {
     allChecksPass && walletAddress && walletSignature && !isRunning && serviceAvailable;
 
   return (
-    <div className="content-card">
+    <div id="onchain-demo" className="content-card">
       <h2 className="section-title">Onchain Demo: Prove &amp; Attest on Ethereum</h2>
       <p className="section-subtitle">
-        Prove your favorite Spotify artist and get an EAS attestation on Ethereum Testnet (Sepolia)
-        — powered by the verifier's webhook system.
+        From web data to onchain truth. Portable, verifiable claims for smart contracts
+      </p>
+      <p className="section-subtitle">
+        Prove your favorite Spotify artist and get an EAS attestation on Ethereum Testnet (Sepolia),
+        powered by the verifier's webhook system.
       </p>
 
       {serviceAvailable === false && (

--- a/packages/demo/src/components/SystemChecks.tsx
+++ b/packages/demo/src/components/SystemChecks.tsx
@@ -1,4 +1,13 @@
 import { CheckStatus } from '../types';
+import { config } from '../config';
+
+const CHROME_STORE_URL =
+  'https://chromewebstore.google.com/detail/tlsnotary/gnoglgpcamodhflknhmafmjdahcejcgg';
+
+interface CheckLink {
+  href: string;
+  label: string;
+}
 
 interface CheckItemProps {
   id: string;
@@ -8,6 +17,7 @@ interface CheckItemProps {
   message: string;
   showInstructions?: boolean;
   onRecheck?: () => void;
+  link?: CheckLink;
 }
 
 export function CheckItem({
@@ -17,10 +27,20 @@ export function CheckItem({
   message,
   showInstructions,
   onRecheck,
+  link,
 }: CheckItemProps) {
   return (
     <div className={`check-item ${status}`}>
-      {icon} {label}: <span className={`status ${status}`}>{message}</span>
+      <div className="check-item-row">
+        {icon} {label}: <span className={`status ${status}`}>{message}</span>
+      </div>
+      {link && (
+        <div className="check-item-link">
+          <a href={link.href} target="_blank" rel="noopener noreferrer">
+            {link.label} →
+          </a>
+        </div>
+      )}
       {showInstructions && (
         <div style={{ marginTop: '10px', fontSize: '14px' }}>
           <p>Start the verifier server:</p>
@@ -61,7 +81,6 @@ export function SystemChecks({ checks, onRecheck, showBrowserWarning }: SystemCh
       )}
 
       <div>
-        <strong>System Checks:</strong>
         <CheckItem
           id="check-browser"
           icon="🌐"
@@ -75,6 +94,7 @@ export function SystemChecks({ checks, onRecheck, showBrowserWarning }: SystemCh
           label="Extension"
           status={checks.extension.status}
           message={checks.extension.message}
+          link={{ href: CHROME_STORE_URL, label: 'View in Chrome Web Store' }}
         />
         <CheckItem
           id="check-verifier"
@@ -84,6 +104,7 @@ export function SystemChecks({ checks, onRecheck, showBrowserWarning }: SystemCh
           message={checks.verifier.message}
           showInstructions={checks.verifier.showInstructions}
           onRecheck={onRecheck}
+          link={{ href: `${config.verifierUrl}/info`, label: `${config.verifierUrl}/info` }}
         />
       </div>
     </>

--- a/packages/demo/src/components/WhatAndWhy.tsx
+++ b/packages/demo/src/components/WhatAndWhy.tsx
@@ -1,0 +1,31 @@
+export function WhatAndWhy() {
+  return (
+    <section id="what-and-why" className="what-and-why">
+      <div className="what-and-why-grid">
+        <div className="what-and-why-card">
+          <h3>Today, web data is locked in.</h3>
+          <p>
+            TLS protects your connection to a server, but it doesn't give you anything you can show
+            someone else. Screenshots are forgeable. APIs require permission from the platform.
+          </p>
+        </div>
+        <div className="what-and-why-card">
+          <h3>TLSNotary changes that.</h3>
+          <p>
+            A <em>verifier</em> joins your TLS session using multi-party computation. They never see
+            your plaintext during the session, but their participation means the data you show them
+            afterwards can't be faked.
+          </p>
+        </div>
+        <div className="what-and-why-card">
+          <h3>Privacy on your terms.</h3>
+          <p>
+            Reveal a single field, redact the rest, or use zero-knowledge proofs to prove a fact
+            without revealing any data. The plugin defines what's disclosed; you decide whether to
+            run it, and the code is open for inspection.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/demo/src/components/WhyPlugins.tsx
+++ b/packages/demo/src/components/WhyPlugins.tsx
@@ -1,9 +1,9 @@
 export function WhyPlugins() {
   return (
     <div className="why-plugins">
-      <h2 className="why-plugins-title">Why Plugins?</h2>
+      <h2 className="why-plugins-title">Why a plugin system?</h2>
       <p className="why-plugins-subtitle">
-        TLSNotary plugins provide a secure, flexible way to prove and verify web data
+        TLSNotary is a protocol, not a product. Plugins are how applications securely use it.
       </p>
 
       <div className="benefits-grid">


### PR DESCRIPTION
## Summary

The demo page on `demo.tlsnotary.org` now leads with the user-facing
value (prove anything from the web, privacy on your terms) instead of
the developer-facing "Plugin Demo" framing, so cold visitors landing
from social or search learn what TLSNotary is before reaching the
system-check setup. Funneled visitors who already know the protocol can
jump straight to whichever section they came for via the new hero
navigation.

The narrative arc top-to-bottom is now:
hero → "Why this matters" / "How it works" → status check → demos →
onchain demo → why a plugin system → build your own.

## What changed

- **Hero** — new title and subtitle, four-button anchor nav (How it
  works · Try a plugin · Onchain demo · Build your own).
- **`<WhatAndWhy />`** — new section between hero and HowItWorks
  covering today's locked-in web data, the MPC mechanism, and the
  privacy story. Transparent over the page gradient so it doesn't break
  flow into the white HowItWorks card.
- **`<HowItWorks />`** — rewritten from UI clicks to the three actors:
  user browses normally → verifier joins via MPC → plugin reveals what
  it discloses. New "Why no notary?" trust note at the bottom.
- **OnchainDemo** — new "From web data to onchain truth" lead above the
  Spotify subtitle.
- **`<WhyPlugins />`** — reframed as "Why a plugin system?" with a
  protocol-vs-product subtitle that ties back to the rest of the page.
- **`<BuildYourOwn />`** — restructured from CTA buttons + flat
  resource list into a four-card grid (Learn · SDK & docs · Mobile
  coming soon · Community) with a slim secondary footer row.

Bonus fixes shipped along the way:

- Details panel: drops the "System Status Details" / "System Checks"
  redundant headers; each check now stacks vertically with an optional
  sub-link (Chrome Web Store install URL on Extension, `/info` URL on
  Verifier).
- `CollapsibleSection` was half-controlled — clicking the toggle did
  nothing once the parent passed `expanded`. Now accepts `onToggle`.
- Plugin sources link points at `packages/plugins/src` (the workspace
  moved out of `packages/demo/src/plugins`).

## Test plan

- [x] Visual: open `demo.tlsnotary.org` (or `npm run demo` locally) and
      walk the page top-to-bottom — hero, WhatAndWhy, HowItWorks, status
      bar, demos, onchain demo, WhyPlugins, BuildYourOwn.
- [x] Anchor jumps: click each of the four hero CTAs (How it works,
      Try a plugin, Onchain demo, Build your own) and confirm each one
      scrolls to the matching section.
- [x] Details panel: expand the StatusBar's "Details" and confirm the
      Extension and Verifier checks each show a working sub-link.
- [x] Console fold: click the "Console Output" header and confirm it
      collapses; click again and confirm it expands.
- [ ] Mobile breakpoint: resize below 768px and confirm WhatAndWhy
      collapses to one column and the hero CTAs wrap cleanly.