### PR TITLE
fix(tutorial): raise swissbank maxRecvData to 520

### DIFF
--- a/packages/tutorial/build-plugins.js
+++ b/packages/tutorial/build-plugins.js
@@ -68,7 +68,7 @@ const onClick = async () => {
     {
       verifierUrl: '${VERIFIER_URL}',
       proxyUrl: '${PROXY_URL_BASE}swissbank.tlsnotary.org',
-      maxRecvData: 460,
+      maxRecvData: 520,
       maxSentData: 180,
       handlers: [
         { type: 'SENT', part: 'START_LINE', action: 'REVEAL' },

--- a/packages/tutorial/swissbank.js
+++ b/packages/tutorial/swissbank.js
@@ -37,7 +37,7 @@ const onClick = async () => {
       verifierUrl: 'http://localhost:7047',
       proxyUrl: 'wss://notary.pse.dev/proxy?token=swissbank.tlsnotary.org',
       // proxyUrl: 'ws://localhost:55688',
-      maxRecvData: 460, // Maximum bytes to receive from server (response size limit)
+      maxRecvData: 520, // Maximum bytes to receive from server (response size limit)
       maxSentData: 180, // Maximum bytes to send to server (request size limit)
 
       // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The Swiss Bank `/balances` response now exceeds 460 bytes, so the prover truncates the transcript and the tutorial proof fails.
- Bump `maxRecvData` from 460 → 520 in both the standalone tutorial source (`swissbank.js`) and the plugin generator (`build-plugins.js`), keeping the starter and solution plugins in sync.

## Test plan
- [x] `node packages/tutorial/build-plugins.js` regenerates `swissbank-starter.js` and `swissbank-solution.js` with `maxRecvData: 520`
- [x] Run the tutorial against the Swiss Bank demo and confirm a proof is generated end-to-end