### PR TITLE
feat(extension): strict mode for plugin execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12732,6 +12732,16 @@
       "resolved": "packages/extension",
       "link": true
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -23375,6 +23385,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "fake-indexeddb": "^6.2.5",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.0",
         "globals": "^16.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2833,6 +2833,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2850,6 +2851,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2867,6 +2869,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2884,6 +2887,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2899,6 +2903,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2916,6 +2921,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2933,6 +2939,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2950,6 +2957,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2967,6 +2975,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2984,6 +2993,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3001,6 +3011,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3018,6 +3029,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3035,6 +3047,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3052,6 +3065,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3069,6 +3083,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3086,6 +3101,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3103,6 +3119,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3120,6 +3137,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3137,6 +3155,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3154,6 +3173,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3171,6 +3191,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3188,6 +3209,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3205,6 +3227,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3222,6 +3245,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3239,6 +3263,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3256,6 +3281,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5646,6 +5672,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -5688,6 +5715,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5707,6 +5735,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5728,6 +5757,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5749,6 +5779,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5770,6 +5801,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5791,6 +5823,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5812,6 +5845,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5833,6 +5867,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5854,6 +5889,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5875,6 +5911,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5896,6 +5933,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5917,6 +5955,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5938,6 +5977,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5951,6 +5991,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16688,7 +16729,8 @@
       "version": "7.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -21266,6 +21308,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "fake-indexeddb": "^6.2.5",
     "file-loader": "^6.2.0",
     "fs-extra": "^11.1.0",
     "globals": "^16.5.0",

--- a/packages/extension/src/background/ConfirmationManager.ts
+++ b/packages/extension/src/background/ConfirmationManager.ts
@@ -1,10 +1,11 @@
 import browser from 'webextension-polyfill';
 import { logger } from '@tlsn/common';
 import type { PluginConfig } from '@tlsn/plugin-sdk';
+import type { ApprovalMode } from '../types/messages';
 
 interface PendingConfirmation {
   requestId: string;
-  resolve: (allowed: boolean) => void;
+  resolve: (mode: ApprovalMode) => void;
   reject: (error: Error) => void;
   windowId?: number;
   timeoutId?: ReturnType<typeof setTimeout>;
@@ -38,14 +39,16 @@ export class ConfirmationManager {
    *
    * @param config - Plugin configuration (can be null for unknown plugins)
    * @param requestId - Unique ID to correlate the confirmation request
-   * @returns Promise that resolves to true (allowed) or false (denied)
+   * @param executionCount - Number of prior executions for this plugin
+   * @returns Promise that resolves with the user's approval mode
    */
   async requestConfirmation(
     config: PluginConfig | null,
     requestId: string,
+    executionCount: number,
     senderOrigin?: string,
     pluginCode?: string,
-  ): Promise<boolean> {
+  ): Promise<ApprovalMode> {
     // Check if there's already a pending confirmation.
     // Claim the slot synchronously (before any await) to prevent concurrent
     // requestConfirmation calls from both passing the guard.
@@ -72,7 +75,7 @@ export class ConfirmationManager {
       }
 
       // Build URL with plugin info as query params
-      const popupUrl = this.buildPopupUrl(config, requestId, senderOrigin);
+      const popupUrl = this.buildPopupUrl(config, requestId, executionCount, senderOrigin);
 
       // Calculate position to center on the active browser window
       let left: number | undefined;
@@ -111,14 +114,14 @@ export class ConfirmationManager {
 
       this.currentPopupWindowId = window.id;
 
-      return new Promise<boolean>((resolve, reject) => {
+      return new Promise<ApprovalMode>((resolve, reject) => {
         // Set up timeout
         const timeoutId = setTimeout(() => {
           const pending = this.pendingConfirmations.get(requestId);
           if (pending) {
             logger.debug('[ConfirmationManager] Confirmation timed out');
             this.cleanup(requestId);
-            resolve(false); // Treat timeout as denial
+            resolve('rejected'); // Treat timeout as denial
           }
         }, this.CONFIRMATION_TIMEOUT_MS);
 
@@ -147,21 +150,19 @@ export class ConfirmationManager {
    * Called when the popup sends a PLUGIN_CONFIRM_RESPONSE message.
    *
    * @param requestId - The request ID to match
-   * @param allowed - Whether the user allowed execution
+   * @param mode - The approval mode chosen by the user
    */
-  handleConfirmationResponse(requestId: string, allowed: boolean): void {
+  handleConfirmationResponse(requestId: string, mode: ApprovalMode): void {
     const pending = this.pendingConfirmations.get(requestId);
     if (!pending) {
       logger.warn(`[ConfirmationManager] No pending confirmation found for request: ${requestId}`);
       return;
     }
 
-    logger.debug(
-      `[ConfirmationManager] Received response for ${requestId}: ${allowed ? 'allowed' : 'denied'}`,
-    );
+    logger.debug(`[ConfirmationManager] Received response for ${requestId}: ${mode}`);
 
     // Resolve the promise
-    pending.resolve(allowed);
+    pending.resolve(mode);
 
     // Close popup window if still open
     if (pending.windowId) {
@@ -191,7 +192,7 @@ export class ConfirmationManager {
         logger.debug(
           `[ConfirmationManager] Treating window close as denial for request: ${requestId}`,
         );
-        pending.resolve(false); // Treat close as denial
+        pending.resolve('rejected'); // Treat close as denial
         this.cleanup(requestId);
         break;
       }
@@ -206,12 +207,14 @@ export class ConfirmationManager {
   private buildPopupUrl(
     config: PluginConfig | null,
     requestId: string,
+    executionCount: number,
     senderOrigin?: string,
   ): string {
     const baseUrl = browser.runtime.getURL('confirmPopup.html');
     const params = new URLSearchParams();
 
     params.set('requestId', requestId);
+    params.set('count', String(executionCount));
 
     if (senderOrigin) {
       params.set('senderOrigin', encodeURIComponent(senderOrigin));

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -129,7 +129,7 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
   }
 
   if (request.type === 'RENDER_PLUGIN_UI') {
-    logger.debug('RENDER_PLUGIN_UI request received:', request.json, request.windowId);
+    logger.debug('RENDER_PLUGIN_UI request received, windowId=%d', request.windowId);
     windowManager.showPluginUI(request.windowId, request.json);
     return; // No response needed
   }

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -180,14 +180,19 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
     // than the sendResponse + return true pattern.
     return (async () => {
       try {
-        // Step 1: Extract plugin config for confirmation (via offscreen QuickJS)
+        // Step 1: Look up plugin stats (config, hash, prior execution count) via offscreen
         let pluginConfig: PluginConfig | null = null;
+        let pluginHash = '';
+        let executionCount = 0;
         try {
-          pluginConfig = await extractConfigViaOffscreen(request.code);
-          logger.debug('Extracted plugin config:', pluginConfig);
+          const stats = await getPluginStatsViaOffscreen(request.code, request.pageOrigin ?? '');
+          pluginConfig = stats.config;
+          pluginHash = stats.hash;
+          executionCount = stats.count;
+          logger.debug('Plugin stats:', { config: pluginConfig, hash: pluginHash, count: executionCount });
         } catch (extractError) {
-          logger.warn('Failed to extract plugin config:', extractError);
-          // Continue with null config - user will see "Unknown Plugin" warning
+          logger.warn('Failed to get plugin stats:', extractError);
+          // Continue with defaults - user will see "Unknown Plugin" warning
         }
 
         // Step 2: Request user confirmation
@@ -198,7 +203,7 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
           mode = await confirmationManager.requestConfirmation(
             pluginConfig,
             confirmRequestId,
-            0,
+            executionCount,
             sender.tab?.url,
             request.code,
           );
@@ -225,12 +230,18 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
         // Ensure offscreen document exists
         await createOffscreenDocument();
 
-        // Forward to offscreen document
+        // Forward to offscreen document. The _approvalMode and _pluginHash
+        // fields let the offscreen side enforce strict-mode policy and
+        // increment the plugin's run count after a successful execution.
         const response = await chrome.runtime.sendMessage({
           type: 'EXEC_CODE_OFFSCREEN',
           code: request.code,
           requestId: request.requestId,
-          sessionData: request.sessionData,
+          sessionData: {
+            ...request.sessionData,
+            _approvalMode: mode,
+            _pluginHash: pluginHash,
+          },
         });
         logger.debug('EXEC_CODE_OFFSCREEN response:', response);
         return response;
@@ -462,29 +473,37 @@ async function createOffscreenDocument(): Promise<void> {
 createOffscreenDocument().catch((err) => logger.error('Offscreen document error:', err));
 
 /**
- * Extract plugin config by sending code to offscreen document where QuickJS runs.
- * This is more reliable than regex-based extraction.
+ * Get plugin stats (config, content hash, prior execution count) by sending code
+ * to the offscreen document, where QuickJS, SubtleCrypto and IndexedDB are available.
  */
-async function extractConfigViaOffscreen(code: string): Promise<PluginConfig | null> {
+async function getPluginStatsViaOffscreen(
+  code: string,
+  pageOrigin: string,
+): Promise<{ config: PluginConfig | null; hash: string; count: number }> {
   try {
     // Ensure offscreen document exists
     await createOffscreenDocument();
 
     // Send message to offscreen and wait for response
     const response = await chrome.runtime.sendMessage({
-      type: 'EXTRACT_CONFIG',
+      type: 'GET_PLUGIN_STATS_OFFSCREEN',
       code,
+      pageOrigin,
     });
 
-    if (response?.success && response.config) {
-      return response.config as PluginConfig;
+    if (response?.success) {
+      return {
+        config: (response.config as PluginConfig | null) ?? null,
+        hash: (response.hash as string) ?? '',
+        count: (response.count as number) ?? 0,
+      };
     }
 
-    logger.warn('Config extraction returned no config:', response?.error);
-    return null;
+    logger.warn('Plugin stats lookup returned no data:', response?.error);
+    return { config: null, hash: '', count: 0 };
   } catch (error) {
-    logger.error('Failed to extract config via offscreen:', error);
-    return null;
+    logger.error('Failed to get plugin stats via offscreen:', error);
+    return { config: null, hash: '', count: 0 };
   }
 }
 

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -6,7 +6,7 @@ import type { InterceptedRequest, InterceptedRequestHeader } from '../../types/w
 import { validateUrl } from '../../utils/url-validator';
 import { logger } from '@tlsn/common';
 import { getStoredLogLevel } from '../../utils/logLevelStorage';
-import type { BackgroundMessage } from '../../types/messages';
+import type { ApprovalMode, BackgroundMessage } from '../../types/messages';
 
 const chrome = (global as typeof globalThis).chrome;
 
@@ -143,7 +143,7 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
   // Handle plugin confirmation responses from popup
   if (request.type === 'PLUGIN_CONFIRM_RESPONSE') {
     logger.debug('PLUGIN_CONFIRM_RESPONSE received:', request);
-    confirmationManager.handleConfirmationResponse(request.requestId, request.allowed);
+    confirmationManager.handleConfirmationResponse(request.requestId, request.mode);
     return; // No response needed
   }
 
@@ -192,12 +192,13 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
 
         // Step 2: Request user confirmation
         const confirmRequestId = `confirm_${Date.now()}_${Math.random()}`;
-        let userAllowed: boolean;
+        let mode: ApprovalMode;
 
         try {
-          userAllowed = await confirmationManager.requestConfirmation(
+          mode = await confirmationManager.requestConfirmation(
             pluginConfig,
             confirmRequestId,
+            0,
             sender.tab?.url,
             request.code,
           );
@@ -210,7 +211,7 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
         }
 
         // Step 3: If user denied, return rejection error
-        if (!userAllowed) {
+        if (mode === 'rejected') {
           logger.info('User rejected plugin execution');
           return {
             success: false,

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -230,9 +230,6 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
         // Ensure offscreen document exists
         await createOffscreenDocument();
 
-        // Forward to offscreen document. The _approvalMode and _pluginHash
-        // fields let the offscreen side enforce strict-mode policy and
-        // increment the plugin's run count after a successful execution.
         const response = await chrome.runtime.sendMessage({
           type: 'EXEC_CODE_OFFSCREEN',
           code: request.code,

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -189,7 +189,11 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
           pluginConfig = stats.config;
           pluginHash = stats.hash;
           executionCount = stats.count;
-          logger.debug('Plugin stats:', { config: pluginConfig, hash: pluginHash, count: executionCount });
+          logger.debug('Plugin stats:', {
+            config: pluginConfig,
+            hash: pluginHash,
+            count: executionCount,
+          });
         } catch (extractError) {
           logger.warn('Failed to get plugin stats:', extractError);
           // Continue with defaults - user will see "Unknown Plugin" warning

--- a/packages/extension/src/entries/ConfirmPopup/index.scss
+++ b/packages/extension/src/entries/ConfirmPopup/index.scss
@@ -334,7 +334,7 @@ body {
   &__btn-badge {
     font-size: 11px;
     font-weight: 600;
-    color: #ff6b6b;
+    color: #8fa4f0;
     white-space: nowrap;
   }
 

--- a/packages/extension/src/entries/ConfirmPopup/index.scss
+++ b/packages/extension/src/entries/ConfirmPopup/index.scss
@@ -253,57 +253,97 @@ body {
   // Actions
   &__actions {
     display: flex;
-    gap: 12px;
-    justify-content: flex-end;
+    flex-direction: column;
+    gap: 8px;
     margin-top: auto;
     padding-top: 16px;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
   }
 
   &__btn {
-    padding: 12px 28px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 12px 16px;
     border-radius: 8px;
     font-size: 14px;
-    font-weight: 600;
+    font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s ease;
-    border: none;
+    transition: all 0.15s ease;
+    border: 1px solid transparent;
     outline: none;
-
-    &:focus {
-      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.5);
-    }
+    text-align: left;
 
     &--deny {
-      background: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.07);
       color: #e8e8e8;
-      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-color: rgba(255, 255, 255, 0.15);
 
       &:hover {
-        background: rgba(255, 107, 107, 0.2);
-        border-color: rgba(255, 107, 107, 0.5);
+        background: rgba(255, 107, 107, 0.15);
+        border-color: rgba(255, 107, 107, 0.4);
         color: #ff6b6b;
       }
 
       &:active {
-        transform: scale(0.98);
+        transform: scale(0.99);
       }
     }
 
     &--allow {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: #ffffff;
+      background: linear-gradient(135deg, rgba(102, 126, 234, 0.25) 0%, rgba(118, 75, 162, 0.25) 100%);
+      color: #c5ceff;
+      border-color: rgba(102, 126, 234, 0.3);
 
       &:hover {
-        background: linear-gradient(135deg, #7b8ff5 0%, #8a5fb5 100%);
-        transform: translateY(-1px);
-        box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+        background: linear-gradient(135deg, rgba(102, 126, 234, 0.4) 0%, rgba(118, 75, 162, 0.4) 100%);
+        border-color: rgba(102, 126, 234, 0.6);
+        color: #ffffff;
       }
 
       &:active {
-        transform: scale(0.98) translateY(0);
+        transform: scale(0.99);
       }
     }
+
+    &--focused {
+      border: 1px solid rgba(102, 126, 234, 0.7);
+      box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
+    }
+  }
+
+  &__btn-key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    min-width: 20px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.1);
+    font-size: 11px;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  &__btn-label {
+    flex: 1;
+  }
+
+  &__btn-badge {
+    font-size: 11px;
+    font-weight: 600;
+    color: #ff6b6b;
+    white-space: nowrap;
+  }
+
+  &__execution-count {
+    font-size: 11px;
+    color: #6b6b7a;
+    text-align: center;
+    margin: 8px 0;
+    letter-spacing: 0.3px;
   }
 
   &__footer {

--- a/packages/extension/src/entries/ConfirmPopup/index.tsx
+++ b/packages/extension/src/entries/ConfirmPopup/index.tsx
@@ -377,14 +377,14 @@ const ConfirmPopup: React.FC = () => {
           [
             {
               key: '1',
-              label: 'Yes, manually approve actions',
+              label: 'Yes, approve before any data is shared',
               badge: count === 0 ? '(Recommended)' : undefined,
               handler: handleManual,
               isDeny: false,
             },
             {
               key: '2',
-              label: 'Yes, allow all actions during this session',
+              label: 'Yes, allow all data sharing this session',
               badge: undefined,
               handler: handleAllSession,
               isDeny: false,

--- a/packages/extension/src/entries/ConfirmPopup/index.tsx
+++ b/packages/extension/src/entries/ConfirmPopup/index.tsx
@@ -173,18 +173,23 @@ const ConfirmPopup: React.FC = () => {
           setFocusedIndex((i) => (i + 1) % 3);
           break;
         case '1':
+          e.preventDefault();
           handleManual();
           break;
         case '2':
+          e.preventDefault();
           handleAllSession();
           break;
         case '3':
+          e.preventDefault();
           handleDeny();
           break;
         case 'Enter':
+          e.preventDefault();
           [handleManual, handleAllSession, handleDeny][focusedIndex]();
           break;
         case 'Escape':
+          e.preventDefault();
           handleDeny();
           break;
       }

--- a/packages/extension/src/entries/ConfirmPopup/index.tsx
+++ b/packages/extension/src/entries/ConfirmPopup/index.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import browser from 'webextension-polyfill';
 import { logger, LogLevel } from '@tlsn/common';
-import type { PluginCodeResponse } from '../../types/messages';
+import type { ApprovalMode, PluginCodeResponse } from '../../types/messages';
 import './index.scss';
 
 // Initialize logger at DEBUG level for popup (no IndexedDB access)
@@ -58,6 +58,7 @@ function parseUrlParams(): {
   pluginInfo: PluginInfo | null;
   requestId: string;
   senderOrigin: string | null;
+  count: number;
   error: string | null;
 } {
   const params = new URLSearchParams(window.location.search);
@@ -69,9 +70,17 @@ function parseUrlParams(): {
   const urlsParam = params.get('urls');
   const senderOriginParam = params.get('senderOrigin');
   const reqId = params.get('requestId');
+  const countStr = params.get('count');
+  const count = countStr !== null ? parseInt(countStr, 10) : 0;
 
   if (!reqId) {
-    return { pluginInfo: null, requestId: '', senderOrigin: null, error: 'Missing request ID' };
+    return {
+      pluginInfo: null,
+      requestId: '',
+      senderOrigin: null,
+      count: 0,
+      error: 'Missing request ID',
+    };
   }
 
   let senderOrigin: string | null = null;
@@ -120,57 +129,47 @@ function parseUrlParams(): {
     };
   }
 
-  return { pluginInfo, requestId: reqId, senderOrigin, error: null };
+  return { pluginInfo, requestId: reqId, senderOrigin, count, error: null };
 }
 
 const ConfirmPopup: React.FC = () => {
-  const { pluginInfo, requestId, senderOrigin, error } = useState(parseUrlParams)[0];
+  const { pluginInfo, requestId, senderOrigin, count, error } = useState(parseUrlParams)[0];
   const [sourceCode, setSourceCode] = useState<string | null>(null);
   const [showDetails, setShowDetails] = useState(false);
 
-  const handleAllow = useCallback(async () => {
-    if (!requestId) return;
+  const sendResponse = useCallback(
+    async (mode: ApprovalMode) => {
+      if (!requestId) return;
 
-    try {
-      await browser.runtime.sendMessage({
-        type: 'PLUGIN_CONFIRM_RESPONSE',
-        requestId,
-        allowed: true,
-      });
-      window.close();
-    } catch (err) {
-      logger.error('Failed to send allow response:', err);
-    }
-  }, [requestId]);
+      try {
+        await browser.runtime.sendMessage({
+          type: 'PLUGIN_CONFIRM_RESPONSE',
+          requestId,
+          mode,
+        });
+        window.close();
+      } catch (err) {
+        logger.error(`Failed to send ${mode} response:`, err);
+      }
+    },
+    [requestId],
+  );
 
-  const handleDeny = useCallback(async () => {
-    if (!requestId) return;
-
-    try {
-      await browser.runtime.sendMessage({
-        type: 'PLUGIN_CONFIRM_RESPONSE',
-        requestId,
-        allowed: false,
-      });
-      window.close();
-    } catch (err) {
-      logger.error('Failed to send deny response:', err);
-    }
-  }, [requestId]);
+  const handleManual = useCallback(() => sendResponse('manual'), [sendResponse]);
+  const handleAllSession = useCallback(() => sendResponse('all-session'), [sendResponse]);
+  const handleDeny = useCallback(() => sendResponse('rejected'), [sendResponse]);
 
   // Handle keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         handleDeny();
-      } else if (e.key === 'Enter' && document.activeElement?.id === 'allow-btn') {
-        handleAllow();
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleAllow, handleDeny]);
+  }, [handleDeny]);
 
   const handleViewSource = useCallback(
     async (e: React.MouseEvent) => {
@@ -346,30 +345,42 @@ const ConfirmPopup: React.FC = () => {
             More details
           </a>
         </div>
+
+        <p className="confirm-popup__execution-count">
+          You have executed this plugin {count} times.
+        </p>
       </div>
 
       <div className="confirm-popup__actions">
         <button
-          className="confirm-popup__btn confirm-popup__btn--deny"
-          onClick={handleDeny}
-          tabIndex={1}
-        >
-          Deny
-        </button>
-        <button
           id="allow-btn"
           className="confirm-popup__btn confirm-popup__btn--allow"
-          onClick={handleAllow}
+          onClick={handleManual}
           tabIndex={0}
           autoFocus
         >
-          Allow
+          Yes, manually approve actions
+          {count === 0 && <span style={{ color: 'red' }}> (Recommended)</span>}
+        </button>
+        <button
+          className="confirm-popup__btn confirm-popup__btn--allow"
+          onClick={handleAllSession}
+          tabIndex={1}
+        >
+          Yes, allow all actions during this session
+        </button>
+        <button
+          className="confirm-popup__btn confirm-popup__btn--deny"
+          onClick={handleDeny}
+          tabIndex={2}
+        >
+          No
         </button>
       </div>
 
       <div className="confirm-popup__footer">
         <p className="confirm-popup__hint">
-          Press <kbd>Enter</kbd> to allow or <kbd>Esc</kbd> to deny
+          Press <kbd>Enter</kbd> to confirm or <kbd>Esc</kbd> to deny
         </p>
         <a
           href="https://tlsnotary.org/docs/extension/plugins"

--- a/packages/extension/src/entries/ConfirmPopup/index.tsx
+++ b/packages/extension/src/entries/ConfirmPopup/index.tsx
@@ -136,6 +136,7 @@ const ConfirmPopup: React.FC = () => {
   const { pluginInfo, requestId, senderOrigin, count, error } = useState(parseUrlParams)[0];
   const [sourceCode, setSourceCode] = useState<string | null>(null);
   const [showDetails, setShowDetails] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(0);
 
   const sendResponse = useCallback(
     async (mode: ApprovalMode) => {
@@ -162,14 +163,36 @@ const ConfirmPopup: React.FC = () => {
   // Handle keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        handleDeny();
+      switch (e.key) {
+        case 'ArrowUp':
+          e.preventDefault();
+          setFocusedIndex((i) => (i + 2) % 3);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          setFocusedIndex((i) => (i + 1) % 3);
+          break;
+        case '1':
+          handleManual();
+          break;
+        case '2':
+          handleAllSession();
+          break;
+        case '3':
+          handleDeny();
+          break;
+        case 'Enter':
+          [handleManual, handleAllSession, handleDeny][focusedIndex]();
+          break;
+        case 'Escape':
+          handleDeny();
+          break;
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleDeny]);
+  }, [handleDeny, handleManual, handleAllSession, focusedIndex]);
 
   const handleViewSource = useCallback(
     async (e: React.MouseEvent) => {
@@ -326,13 +349,6 @@ const ConfirmPopup: React.FC = () => {
 
         {metaLine && <p className="confirm-popup__meta">{metaLine}</p>}
 
-        {isUnknown && (
-          <div className="confirm-popup__warning">
-            <span className="confirm-popup__warning-icon">!</span>
-            <p>This plugin could not be verified. Only allow it if you trust where it came from.</p>
-          </div>
-        )}
-
         <div className="confirm-popup__links">
           <a
             href="#"
@@ -347,40 +363,67 @@ const ConfirmPopup: React.FC = () => {
         </div>
 
         <p className="confirm-popup__execution-count">
-          You have executed this plugin {count} times.
+          {count === 1 ? 'Executed 1 time' : `Executed ${count} times`}
         </p>
       </div>
 
       <div className="confirm-popup__actions">
-        <button
-          id="allow-btn"
-          className="confirm-popup__btn confirm-popup__btn--allow"
-          onClick={handleManual}
-          tabIndex={0}
-          autoFocus
-        >
-          Yes, manually approve actions
-          {count === 0 && <span style={{ color: 'red' }}> (Recommended)</span>}
-        </button>
-        <button
-          className="confirm-popup__btn confirm-popup__btn--allow"
-          onClick={handleAllSession}
-          tabIndex={1}
-        >
-          Yes, allow all actions during this session
-        </button>
-        <button
-          className="confirm-popup__btn confirm-popup__btn--deny"
-          onClick={handleDeny}
-          tabIndex={2}
-        >
-          No
-        </button>
+        {(
+          [
+            {
+              key: '1',
+              label: 'Yes, manually approve actions',
+              badge: count === 0 ? '(Recommended)' : undefined,
+              handler: handleManual,
+              isDeny: false,
+            },
+            {
+              key: '2',
+              label: 'Yes, allow all actions during this session',
+              badge: undefined,
+              handler: handleAllSession,
+              isDeny: false,
+            },
+            {
+              key: '3',
+              label: 'No',
+              badge: undefined,
+              handler: handleDeny,
+              isDeny: true,
+            },
+          ] as Array<{
+            key: string;
+            label: string;
+            badge: string | undefined;
+            handler: () => void;
+            isDeny: boolean;
+          }>
+        ).map(({ key, label, badge, handler, isDeny }, i) => (
+          <button
+            key={key}
+            className={[
+              'confirm-popup__btn',
+              isDeny ? 'confirm-popup__btn--deny' : 'confirm-popup__btn--allow',
+              focusedIndex === i ? 'confirm-popup__btn--focused' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            onClick={handler}
+            onMouseEnter={() => setFocusedIndex(i)}
+          >
+            <span className="confirm-popup__btn-key">{key}</span>
+            <span className="confirm-popup__btn-label">{label}</span>
+            {badge && <span className="confirm-popup__btn-badge">{badge}</span>}
+          </button>
+        ))}
       </div>
 
       <div className="confirm-popup__footer">
         <p className="confirm-popup__hint">
-          Press <kbd>Enter</kbd> to confirm or <kbd>Esc</kbd> to deny
+          <kbd>1</kbd>
+          <kbd>2</kbd>
+          <kbd>3</kbd> select · <kbd>↑↓</kbd> navigate · <kbd>Enter</kbd> confirm · <kbd>Esc</kbd>{' '}
+          cancel
         </p>
         <a
           href="https://tlsnotary.org/docs/extension/plugins"

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -280,6 +280,7 @@ window.addEventListener('message', (event) => {
         code: event.data.payload.code,
         requestId: event.data.payload.requestId,
         sessionData: event.data.payload.sessionData,
+        pageOrigin: window.location.origin,
       })
       .then((msg) => {
         const response = msg as ExecCodeResponse;

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -64,10 +64,6 @@ const OffscreenApp: React.FC = () => {
         });
       }
 
-      if (request.type === 'INCREMENT_PLUGIN_COUNT_OFFSCREEN') {
-        return incrementPluginCount(request.hash as string).then(() => ({ success: true }));
-      }
-
       // Handle code execution requests
       if (request.type === 'EXEC_CODE_OFFSCREEN') {
         logger.debug('Offscreen executing code:', request.code);

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -60,7 +60,7 @@ const OffscreenApp: React.FC = () => {
           const config = await sm.extractConfig(request.code as string);
           const hash = await sha256((request.code as string) + (request.pageOrigin as string));
           const count = await getPluginCount(hash);
-          return { config, hash, count };
+          return { success: true, config, hash, count };
         });
       }
 

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -31,30 +31,6 @@ const OffscreenApp: React.FC = () => {
         });
       }
 
-      // Handle config extraction requests (uses QuickJS)
-      if (request.type === 'EXTRACT_CONFIG') {
-        logger.debug('Offscreen extracting config from code');
-
-        if (!sessionManager) {
-          return Promise.resolve({
-            success: false,
-            error: 'SessionManager not initialized',
-          });
-        }
-
-        return sessionManager
-          .awaitInit()
-          .then((sm) => sm.extractConfig(request.code as string))
-          .then((config) => {
-            logger.debug('Extracted config:', config);
-            return { success: true, config };
-          })
-          .catch((error) => {
-            logger.error('Config extraction error:', error);
-            return { success: false, error: error.message };
-          });
-      }
-
       if (request.type === 'GET_PLUGIN_STATS_OFFSCREEN') {
         return sessionManager.awaitInit().then(async (sm) => {
           const config = await sm.extractConfig(request.code as string);

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -4,6 +4,8 @@ import browser from 'webextension-polyfill';
 import { SessionManager } from '../../offscreen/SessionManager';
 import { logger } from '@tlsn/common';
 import { getStoredLogLevel } from '../../utils/logLevelStorage';
+import { sha256 } from '../../utils/cryptoHash';
+import { getPluginCount, incrementPluginCount } from '../../utils/pluginExecutionCounts';
 import type { OffscreenMessage } from '../../types/messages';
 
 const OffscreenApp: React.FC = () => {
@@ -53,6 +55,19 @@ const OffscreenApp: React.FC = () => {
           });
       }
 
+      if (request.type === 'GET_PLUGIN_STATS_OFFSCREEN') {
+        return sessionManager.awaitInit().then(async (sm) => {
+          const config = await sm.extractConfig(request.code as string);
+          const hash = await sha256((request.code as string) + (request.pageOrigin as string));
+          const count = await getPluginCount(hash);
+          return { config, hash, count };
+        });
+      }
+
+      if (request.type === 'INCREMENT_PLUGIN_COUNT_OFFSCREEN') {
+        return incrementPluginCount(request.hash as string).then(() => ({ success: true }));
+      }
+
       // Handle code execution requests
       if (request.type === 'EXEC_CODE_OFFSCREEN') {
         logger.debug('Offscreen executing code:', request.code);
@@ -74,8 +89,13 @@ const OffscreenApp: React.FC = () => {
               request.sessionData as Record<string, string> | undefined,
             ),
           )
-          .then((result) => {
+          .then(async (result) => {
             logger.debug('Plugin execution result:', result);
+            const pluginHash = (request.sessionData as Record<string, string> | undefined)
+              ?._pluginHash;
+            if (pluginHash) {
+              await incrementPluginCount(pluginHash);
+            }
             return {
               success: true,
               result,

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -18,7 +18,7 @@ interface RevealRange {
 }
 
 /** A byte range paired with its handler for the verifier */
-interface RevealRangeWithHandler {
+export interface RevealRangeWithHandler {
   start: number;
   end: number;
   handler: Handler;
@@ -109,6 +109,13 @@ export class ProveManager {
    * executions don't overwrite each other's callback.
    */
   private progressCallbacks: Map<string, ProgressCallback> = new Map();
+
+  /**
+   * Cached transcript bytes per prover. Populated after sendRequest() so the
+   * approval gate can render previews without re-reading from WASM memory
+   * (which may be invalidated between calls).
+   */
+  private transcriptBytes: Map<string, { sent: Uint8Array; recv: Uint8Array }> = new Map();
 
   private listenerAdded = false;
 
@@ -408,10 +415,32 @@ export class ProveManager {
       headers: headerMap,
       body: options.body,
     });
+
+    // Snapshot transcript bytes now so the approval gate can read them
+    // synchronously later without crossing the worker boundary again.
+    try {
+      const transcript = await workerApi.getTranscript(proverId);
+      this.transcriptBytes.set(proverId, {
+        sent: new Uint8Array(transcript.sent),
+        recv: new Uint8Array(transcript.recv),
+      });
+    } catch (err) {
+      logger.warn('[ProveManager] Failed to snapshot transcript bytes for', proverId, ':', err);
+    }
   }
 
   async transcript(proverId: string) {
     return workerApi.getTranscript(proverId);
+  }
+
+  /** Get the cached sent transcript bytes for a prover. Empty if not yet captured. */
+  getSentBytes(proverId: string): Uint8Array {
+    return this.transcriptBytes.get(proverId)?.sent ?? new Uint8Array();
+  }
+
+  /** Get the cached received transcript bytes for a prover. Empty if not yet captured. */
+  getRecvBytes(proverId: string): Uint8Array {
+    return this.transcriptBytes.get(proverId)?.recv ?? new Uint8Array();
   }
 
   /**
@@ -498,9 +527,10 @@ export class ProveManager {
     // Close WebSocket if open
     this.closeSession(proverId);
 
-    // Remove session state and progress callback
+    // Remove session state, progress callback, and transcript snapshot
     this.sessions.delete(proverId);
     this.progressCallbacks.delete(proverId);
+    this.transcriptBytes.delete(proverId);
 
     // Free worker prover
     try {

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -243,6 +243,7 @@ export class SessionManager {
 
             const explicitWindowId = parseInt(execSessionData?._windowId ?? '0', 10);
             const targetWindowId = explicitWindowId > 0 ? explicitWindowId : activeWindowId;
+            logger.debug('[SessionManager] reveal approval: targetWindowId=%d activeWindowId=%d descriptors=%d', targetWindowId, activeWindowId, descriptors.length);
             if (!hostRef) {
               throw new Error('Host not initialized for reveal approval');
             }

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -57,10 +57,20 @@ function makeDescriptor(
   const canonical = canonicalizeHandler(range.handler);
   const safeStart = Math.max(0, Math.min(range.start, bytes.length));
   const safeEnd = Math.max(safeStart, Math.min(range.end, bytes.length));
-  const raw = decoder.decode(bytes.subarray(safeStart, safeEnd));
-  const preview = raw.length > PREVIEW_MAX_CHARS ? raw.slice(0, PREVIEW_MAX_CHARS) + '…' : raw;
+  const slice = bytes.subarray(safeStart, safeEnd);
   const action: 'REVEAL' | 'HASH' = canonical.action.kind === 'HASH' ? 'HASH' : 'REVEAL';
   const algorithm = canonical.action.kind === 'HASH' ? canonical.action.algorithm : undefined;
+
+  let preview: string;
+  if (action === 'HASH') {
+    // Blinder is generated inside WASM during proving — we cannot compute the
+    // actual commitment hash ahead of time. Show the algorithm name instead.
+    preview = algorithm ?? 'SHA-256';
+  } else {
+    const raw = decoder.decode(slice);
+    preview = raw.length > PREVIEW_MAX_CHARS ? raw.slice(0, PREVIEW_MAX_CHARS) + '…' : raw;
+  }
+
   return {
     direction,
     label: buildLabel(canonical),
@@ -243,7 +253,12 @@ export class SessionManager {
 
             const explicitWindowId = parseInt(execSessionData?._windowId ?? '0', 10);
             const targetWindowId = explicitWindowId > 0 ? explicitWindowId : activeWindowId;
-            logger.debug('[SessionManager] reveal approval: targetWindowId=%d activeWindowId=%d descriptors=%d', targetWindowId, activeWindowId, descriptors.length);
+            logger.debug(
+              '[SessionManager] reveal approval: targetWindowId=%d activeWindowId=%d descriptors=%d',
+              targetWindowId,
+              activeWindowId,
+              descriptors.length,
+            );
 
             await new Promise<void>((resolve, reject) => {
               if (!hostRef) {

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -376,7 +376,7 @@ export class SessionManager {
     // Chrome's messaging API. The plugin listener (makeOpenWindow's onMessage)
     // is async, so it always returns a Promise. If added directly to
     // chrome.runtime.onMessage, Chrome may use its Promise<undefined> as the
-    // response to unrelated messages (e.g. EXTRACT_CONFIG), racing with the
+    // response to unrelated messages (e.g. GET_PLUGIN_STATS_OFFSCREEN), racing with the
     // offscreen's main listener that returns the actual result.
     const listenerWrappers = new Map<
       (message: WindowMessage) => void,

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -1,4 +1,4 @@
-import Host, { canonicalizeHandler, createRevealApprovalOverlay } from '@tlsn/plugin-sdk';
+import Host, { canonicalizeHandler } from '@tlsn/plugin-sdk';
 import { ProveManager } from './ProveManager';
 import type { RevealRangeWithHandler } from './ProveManager';
 import type { Method } from '../../../tlsn-wasm-pkg/tlsn_wasm';
@@ -244,17 +244,13 @@ export class SessionManager {
             const explicitWindowId = parseInt(execSessionData?._windowId ?? '0', 10);
             const targetWindowId = explicitWindowId > 0 ? explicitWindowId : activeWindowId;
             logger.debug('[SessionManager] reveal approval: targetWindowId=%d activeWindowId=%d descriptors=%d', targetWindowId, activeWindowId, descriptors.length);
-            if (!hostRef) {
-              throw new Error('Host not initialized for reveal approval');
-            }
-            hostRef.renderUi(targetWindowId, createRevealApprovalOverlay(descriptors));
 
             await new Promise<void>((resolve, reject) => {
               if (!hostRef) {
                 reject(new Error('Host not initialized for reveal approval'));
                 return;
               }
-              hostRef.registerRevealApproval(resolve, (err: Error) => reject(err));
+              hostRef.registerRevealApproval(resolve, (err: Error) => reject(err), descriptors);
             });
           }
 

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -1,12 +1,15 @@
-import Host from '@tlsn/plugin-sdk';
+import Host, { canonicalizeHandler, createRevealApprovalOverlay } from '@tlsn/plugin-sdk';
 import { ProveManager } from './ProveManager';
+import type { RevealRangeWithHandler } from './ProveManager';
 import type { Method } from '../../../tlsn-wasm-pkg/tlsn_wasm';
 import type {
+  CanonicalHandler,
   DomJson,
   Handler,
   OpenWindowResponse,
   PluginConfig,
   ProveProgressData,
+  RevealRangeDescriptor,
   WindowMessage,
 } from '@tlsn/plugin-sdk';
 import { logger } from '@tlsn/common';
@@ -24,6 +27,48 @@ interface ChromeRuntimeLike {
   };
 }
 import { validateProvePermission, validateOpenWindowPermission } from './permissionValidator';
+
+/** Maximum number of preview characters shown per reveal range. */
+const PREVIEW_MAX_CHARS = 256;
+
+function buildLabel(handler: CanonicalHandler): string {
+  const part =
+    handler.part.charAt(0).toUpperCase() + handler.part.slice(1).toLowerCase().replace(/_/g, ' ');
+  if ('params' in handler && handler.params && 'path' in handler.params && handler.params.path) {
+    return `${part}: ${handler.params.path}`;
+  }
+  if (
+    'params' in handler &&
+    handler.params &&
+    'key' in handler.params &&
+    typeof handler.params.key === 'string'
+  ) {
+    return `${part}: ${handler.params.key}`;
+  }
+  return part;
+}
+
+function makeDescriptor(
+  direction: 'SENT' | 'RECV',
+  range: RevealRangeWithHandler,
+  bytes: Uint8Array,
+  decoder: TextDecoder,
+): RevealRangeDescriptor {
+  const canonical = canonicalizeHandler(range.handler);
+  const safeStart = Math.max(0, Math.min(range.start, bytes.length));
+  const safeEnd = Math.max(safeStart, Math.min(range.end, bytes.length));
+  const raw = decoder.decode(bytes.subarray(safeStart, safeEnd));
+  const preview = raw.length > PREVIEW_MAX_CHARS ? raw.slice(0, PREVIEW_MAX_CHARS) + '…' : raw;
+  const action: 'REVEAL' | 'HASH' = canonical.action.kind === 'HASH' ? 'HASH' : 'REVEAL';
+  const algorithm = canonical.action.kind === 'HASH' ? canonical.action.algorithm : undefined;
+  return {
+    direction,
+    label: buildLabel(canonical),
+    action,
+    algorithm,
+    preview,
+  };
+}
 
 export class SessionManager {
   /** Shared Host instance — only used for config extraction (stateless). */
@@ -67,6 +112,11 @@ export class SessionManager {
     execSessionData: Record<string, string> | null,
   ): Host {
     const proveManager = this.proveManager;
+    let hostRef: Host | null = null;
+    // Tracks the active managed window for this execution. Captured from
+    // openWindow() / renderPluginUi callbacks so the approval gate can render
+    // its overlay into the same window without a separate lookup.
+    let activeWindowId = 0;
 
     const emitProgress = (step: string, progress: number, message: string, source = 'js') => {
       if (!requestId) return;
@@ -83,7 +133,7 @@ export class SessionManager {
         .catch((err: unknown) => logger.warn('[SessionManager] emitProgress failed:', err));
     };
 
-    return new Host({
+    const host = new Host({
       onProve: async (
         requestOptions: {
           url: string;
@@ -177,6 +227,36 @@ export class SessionManager {
             logger.debug('commitRanges', commit);
           }
 
+          // Approval gate: in any mode other than 'all-session', show the user
+          // exactly which byte ranges will leave the device before they do.
+          const approvalMode = execSessionData?._approvalMode ?? 'manual';
+          if (approvalMode !== 'all-session') {
+            const decoder = new TextDecoder('utf-8', { fatal: false });
+            const sentBytes = proveManager.getSentBytes(proverId);
+            const recvBytes = proveManager.getRecvBytes(proverId);
+            const descriptors: RevealRangeDescriptor[] = [
+              ...sentRangesWithHandlers.map((r) => makeDescriptor('SENT', r, sentBytes, decoder)),
+              ...recvRangesWithHandlers.map((r) => makeDescriptor('RECV', r, recvBytes, decoder)),
+            ];
+
+            emitBoth('WAITING_FOR_REVEAL_APPROVAL', 0.55, 'Awaiting reveal approval...');
+
+            const explicitWindowId = parseInt(execSessionData?._windowId ?? '0', 10);
+            const targetWindowId = explicitWindowId > 0 ? explicitWindowId : activeWindowId;
+            if (!hostRef) {
+              throw new Error('Host not initialized for reveal approval');
+            }
+            hostRef.renderUi(targetWindowId, createRevealApprovalOverlay(descriptors));
+
+            await new Promise<void>((resolve, reject) => {
+              if (!hostRef) {
+                reject(new Error('Host not initialized for reveal approval'));
+                return;
+              }
+              hostRef.registerRevealApproval(resolve, (err: Error) => reject(err));
+            });
+          }
+
           // Send reveal config (ranges + handlers) to verifier BEFORE calling reveal()
           emitBoth('SENDING_REVEAL_CONFIG', 0.6, 'Configuring selective disclosure...');
           await proveManager.sendRevealConfig(proverId, {
@@ -211,6 +291,9 @@ export class SessionManager {
         }
       },
       onRenderPluginUi: (windowId: number, result: DomJson) => {
+        if (windowId > 0) {
+          activeWindowId = windowId;
+        }
         const chromeRuntime = SessionManager.getChromeRuntime();
         chromeRuntime.sendMessage({
           type: 'RENDER_PLUGIN_UI',
@@ -234,15 +317,23 @@ export class SessionManager {
         validateOpenWindowPermission(url, pluginConfig);
 
         const chromeRuntime = SessionManager.getChromeRuntime();
-        return chromeRuntime.sendMessage({
+        const response = (await chromeRuntime.sendMessage({
           type: 'OPEN_WINDOW',
           url,
           width: options?.width,
           height: options?.height,
           showOverlay: options?.showOverlay,
-        }) as Promise<OpenWindowResponse>;
+        })) as OpenWindowResponse;
+
+        if (response?.type === 'WINDOW_OPENED' && response.payload?.windowId) {
+          activeWindowId = response.payload.windowId;
+        }
+
+        return response;
       },
     });
+    hostRef = host;
+    return host;
   }
 
   async awaitInit(): Promise<SessionManager> {

--- a/packages/extension/src/types/messages.ts
+++ b/packages/extension/src/types/messages.ts
@@ -7,6 +7,12 @@
 
 import type { DomJson } from '@tlsn/plugin-sdk';
 
+/**
+ * Controls how reveal approvals are handled during a plugin execution.
+ * - `'manual'`      — user approves each `prove()` call before data is sent
+ * - `'all-session'` — all reveals in this session are auto-approved
+ * - `'rejected'`    — user denied the plugin; it does not run
+ */
 export type ApprovalMode = 'manual' | 'all-session' | 'rejected';
 
 // ---------------------------------------------------------------------------
@@ -62,7 +68,6 @@ export type ContentMessage =
 /** Messages handled by the Offscreen document */
 export type OffscreenMessage =
   | { type: 'PROCESS_DATA' }
-  | { type: 'EXTRACT_CONFIG'; code: string }
   | {
       type: 'EXEC_CODE_OFFSCREEN';
       code: string;

--- a/packages/extension/src/types/messages.ts
+++ b/packages/extension/src/types/messages.ts
@@ -7,6 +7,8 @@
 
 import type { DomJson } from '@tlsn/plugin-sdk';
 
+export type ApprovalMode = 'manual' | 'all-session' | 'rejected';
+
 // ---------------------------------------------------------------------------
 // Incoming messages (received by onMessage listeners)
 // ---------------------------------------------------------------------------
@@ -17,7 +19,7 @@ export type BackgroundMessage =
   | { type: 'PING' }
   | { type: 'RENDER_PLUGIN_UI'; json: DomJson; windowId: number }
   | { type: 'GET_PLUGIN_CODE'; requestId: string }
-  | { type: 'PLUGIN_CONFIRM_RESPONSE'; requestId: string; allowed: boolean }
+  | { type: 'PLUGIN_CONFIRM_RESPONSE'; requestId: string; mode: ApprovalMode }
   | {
       type: 'PROVE_PROGRESS';
       requestId: string;
@@ -31,6 +33,7 @@ export type BackgroundMessage =
       code: string;
       requestId: string;
       sessionData?: Record<string, unknown>;
+      pageOrigin?: string;
     }
   | { type: 'CLOSE_WINDOW'; windowId: number }
   | {
@@ -65,7 +68,9 @@ export type OffscreenMessage =
       code: string;
       requestId?: string;
       sessionData?: Record<string, unknown>;
-    };
+    }
+  | { type: 'GET_PLUGIN_STATS_OFFSCREEN'; code: string; pageOrigin: string }
+  | { type: 'INCREMENT_PLUGIN_COUNT_OFFSCREEN'; hash: string };
 
 // ---------------------------------------------------------------------------
 // Responses returned from sendMessage calls

--- a/packages/extension/src/types/messages.ts
+++ b/packages/extension/src/types/messages.ts
@@ -69,8 +69,7 @@ export type OffscreenMessage =
       requestId?: string;
       sessionData?: Record<string, unknown>;
     }
-  | { type: 'GET_PLUGIN_STATS_OFFSCREEN'; code: string; pageOrigin: string }
-  | { type: 'INCREMENT_PLUGIN_COUNT_OFFSCREEN'; hash: string };
+  | { type: 'GET_PLUGIN_STATS_OFFSCREEN'; code: string; pageOrigin: string };
 
 // ---------------------------------------------------------------------------
 // Responses returned from sendMessage calls

--- a/packages/extension/src/utils/cryptoHash.ts
+++ b/packages/extension/src/utils/cryptoHash.ts
@@ -1,0 +1,7 @@
+export async function sha256(input: string): Promise<string> {
+  const buf = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest('SHA-256', buf);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/packages/extension/src/utils/pluginExecutionCounts.ts
+++ b/packages/extension/src/utils/pluginExecutionCounts.ts
@@ -1,0 +1,110 @@
+const DB_NAME = 'tlsn-settings';
+const DB_VERSION = 2;
+const SETTINGS_STORE = 'settings';
+const PLUGIN_COUNTS_STORE = 'pluginCounts';
+
+interface PluginCountRecord {
+  hash: string;
+  count: number;
+  lastExecutedAt: string;
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      reject(new Error('Failed to open IndexedDB'));
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(SETTINGS_STORE)) {
+        db.createObjectStore(SETTINGS_STORE);
+      }
+      if (!db.objectStoreNames.contains(PLUGIN_COUNTS_STORE)) {
+        db.createObjectStore(PLUGIN_COUNTS_STORE, { keyPath: 'hash' });
+      }
+    };
+  });
+}
+
+export async function getPluginCount(hash: string): Promise<number> {
+  try {
+    const db = await openDatabase();
+    return new Promise((resolve) => {
+      const transaction = db.transaction(PLUGIN_COUNTS_STORE, 'readonly');
+      const store = transaction.objectStore(PLUGIN_COUNTS_STORE);
+      const request = store.get(hash);
+
+      request.onsuccess = () => {
+        const value = request.result as PluginCountRecord | undefined;
+        if (value && typeof value.count === 'number') {
+          resolve(value.count);
+        } else {
+          resolve(0);
+        }
+      };
+
+      request.onerror = () => {
+        resolve(0);
+      };
+
+      transaction.oncomplete = () => {
+        db.close();
+      };
+    });
+  } catch {
+    return 0;
+  }
+}
+
+export async function incrementPluginCount(hash: string): Promise<void> {
+  try {
+    const db = await openDatabase();
+    return new Promise((resolve, reject) => {
+      const transaction = db.transaction(PLUGIN_COUNTS_STORE, 'readwrite');
+      const store = transaction.objectStore(PLUGIN_COUNTS_STORE);
+      const getRequest = store.get(hash);
+
+      getRequest.onsuccess = () => {
+        const existing = getRequest.result as PluginCountRecord | undefined;
+        const current: PluginCountRecord = existing ?? {
+          hash,
+          count: 0,
+          lastExecutedAt: '',
+        };
+        const next: PluginCountRecord = {
+          hash,
+          count: current.count + 1,
+          lastExecutedAt: new Date().toISOString(),
+        };
+        const putRequest = store.put(next);
+
+        putRequest.onsuccess = () => {
+          resolve();
+        };
+
+        putRequest.onerror = () => {
+          reject(new Error('Failed to increment plugin count'));
+        };
+      };
+
+      getRequest.onerror = () => {
+        reject(new Error('Failed to increment plugin count'));
+      };
+
+      transaction.oncomplete = () => {
+        db.close();
+      };
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to increment plugin count:', error);
+    throw error;
+  }
+}

--- a/packages/extension/tests/offscreen/ProveManager.test.ts
+++ b/packages/extension/tests/offscreen/ProveManager.test.ts
@@ -192,6 +192,50 @@ describe('ProveManager', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Transcript byte snapshot for approval gate
+  // -----------------------------------------------------------------------
+  describe('Transcript byte snapshot', () => {
+    it('snapshots transcript bytes after sendRequest', async () => {
+      mockWorkerApi.getTranscript.mockReturnValueOnce({
+        sent: [1, 2, 3],
+        recv: [4, 5, 6, 7],
+      });
+
+      await pm.sendRequest('prover-snap', 'wss://example.com', {
+        url: 'https://example.com/api',
+        method: 'GET',
+      });
+
+      expect(pm.getSentBytes('prover-snap')).toEqual(new Uint8Array([1, 2, 3]));
+      expect(pm.getRecvBytes('prover-snap')).toEqual(new Uint8Array([4, 5, 6, 7]));
+    });
+
+    it('returns empty bytes for unknown prover', () => {
+      expect(pm.getSentBytes('missing')).toEqual(new Uint8Array());
+      expect(pm.getRecvBytes('missing')).toEqual(new Uint8Array());
+    });
+
+    it('clears cached bytes during cleanupProver', async () => {
+      mockWorkerApi.getTranscript.mockReturnValueOnce({
+        sent: [9, 9],
+        recv: [8, 8],
+      });
+
+      await pm.sendRequest('prover-clean', 'wss://example.com', {
+        url: 'https://example.com/api',
+        method: 'GET',
+      });
+
+      expect(pm.getSentBytes('prover-clean')).toEqual(new Uint8Array([9, 9]));
+
+      await pm.cleanupProver('prover-clean');
+
+      expect(pm.getSentBytes('prover-clean')).toEqual(new Uint8Array());
+      expect(pm.getRecvBytes('prover-clean')).toEqual(new Uint8Array());
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // Per-prover progress callbacks (concurrency fix)
   // -----------------------------------------------------------------------
   describe('Per-prover progress callbacks', () => {

--- a/packages/extension/tests/utils/cryptoHash.test.ts
+++ b/packages/extension/tests/utils/cryptoHash.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { sha256 } from '../../src/utils/cryptoHash';
+
+describe('sha256', () => {
+  it('returns the correct hash for "hello"', async () => {
+    const hash = await sha256('hello');
+    expect(hash).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824');
+  });
+
+  it('returns the correct hash for empty string', async () => {
+    const hash = await sha256('');
+    expect(hash).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  it('returns different hashes for different inputs', async () => {
+    const a = await sha256('abc');
+    const b = await sha256('def');
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/extension/tests/utils/pluginExecutionCounts.test.ts
+++ b/packages/extension/tests/utils/pluginExecutionCounts.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('pluginExecutionCounts', () => {
+  beforeEach(async () => {
+    const { IDBFactory } = await import('fake-indexeddb');
+    vi.stubGlobal('indexedDB', new IDBFactory());
+    vi.resetModules();
+  });
+
+  it('getPluginCount returns 0 for unknown hash', async () => {
+    const { getPluginCount } = await import('../../src/utils/pluginExecutionCounts');
+    const count = await getPluginCount('nonexistent-hash');
+    expect(count).toBe(0);
+  });
+
+  it('incrementPluginCount then getPluginCount returns 1', async () => {
+    const { getPluginCount, incrementPluginCount } =
+      await import('../../src/utils/pluginExecutionCounts');
+    await incrementPluginCount('test-hash');
+    const count = await getPluginCount('test-hash');
+    expect(count).toBe(1);
+  });
+
+  it('second incrementPluginCount returns 2', async () => {
+    const { getPluginCount, incrementPluginCount } =
+      await import('../../src/utils/pluginExecutionCounts');
+    await incrementPluginCount('test-hash');
+    await incrementPluginCount('test-hash');
+    const count = await getPluginCount('test-hash');
+    expect(count).toBe(2);
+  });
+
+  it('different hashes are counted independently', async () => {
+    const { getPluginCount, incrementPluginCount } =
+      await import('../../src/utils/pluginExecutionCounts');
+    await incrementPluginCount('hash-a');
+    await incrementPluginCount('hash-a');
+    await incrementPluginCount('hash-b');
+    expect(await getPluginCount('hash-a')).toBe(2);
+    expect(await getPluginCount('hash-b')).toBe(1);
+  });
+});

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -19,6 +19,7 @@ import {
   Handler,
   PluginConfig,
   ProveProgressData,
+  RevealRangeDescriptor,
   canonicalizeHandlers,
 } from './types';
 import deepEqual from 'fast-deep-equal';
@@ -60,6 +61,7 @@ function updateExecutionContext(
     context?: HookContext;
     currentContext?: string;
     stateStore?: Record<string, unknown>;
+    revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
   },
 ): void {
   const context = executionContextRegistry.get(uuid);
@@ -364,6 +366,22 @@ function makeOpenWindow(
 
         if (message.type === 'PLUGIN_UI_CLICK') {
           logger.debug('PLUGIN_UI_CLICK', message);
+          if (message.onclick === '_revealApprove') {
+            const approval = executionContext.revealApproval;
+            if (approval) {
+              updateExecutionContext(uuid, { revealApproval: null });
+              approval.resolve();
+            }
+            return;
+          }
+          if (message.onclick === '_revealReject') {
+            const approval = executionContext.revealApproval;
+            if (approval) {
+              updateExecutionContext(uuid, { revealApproval: null });
+              approval.reject(new Error('User rejected reveal'));
+            }
+            return;
+          }
           const cb = executionContext.callbacks[message.onclick];
 
           logger.debug('Callback:', cb);
@@ -701,6 +719,198 @@ function createCompletionOverlay(
   };
 }
 
+export function createRevealApprovalOverlay(descriptors: RevealRangeDescriptor[]): DomJson {
+  const sentDescriptors = descriptors.filter((d) => d.direction === 'SENT');
+  const recvDescriptors = descriptors.filter((d) => d.direction === 'RECV');
+
+  const renderDescriptorRow = (descriptor: RevealRangeDescriptor): DomJson => {
+    const isReveal = descriptor.action === 'REVEAL';
+    return {
+      type: 'div',
+      options: {
+        style: {
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '8px',
+          marginBottom: '8px',
+        },
+      },
+      children: [
+        {
+          type: 'div',
+          options: {
+            style: {
+              fontSize: '12px',
+              color: '#374151',
+              minWidth: '120px',
+            },
+          },
+          children: [descriptor.label],
+        },
+        {
+          type: 'div',
+          options: {
+            style: {
+              fontSize: '11px',
+              fontWeight: '600',
+              padding: '2px 6px',
+              borderRadius: '4px',
+              backgroundColor: isReveal ? '#d1fae5' : '#fef3c7',
+              color: isReveal ? '#065f46' : '#92400e',
+            },
+          },
+          children: [descriptor.action],
+        },
+        {
+          type: 'div',
+          options: {
+            style: {
+              fontFamily: 'monospace',
+              fontSize: '11px',
+              color: '#6b7280',
+              wordBreak: 'break-all',
+            },
+          },
+          children: [descriptor.preview],
+        },
+      ],
+    };
+  };
+
+  const renderSection = (
+    title: 'Sent' | 'Received',
+    sectionDescriptors: RevealRangeDescriptor[],
+  ): DomJson => ({
+    type: 'div',
+    options: {
+      style: {
+        marginBottom: '16px',
+      },
+    },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            fontSize: '12px',
+            fontWeight: '600',
+            color: '#6b7280',
+            textTransform: 'uppercase',
+            marginBottom: '8px',
+          },
+        },
+        children: [title],
+      },
+      ...sectionDescriptors.map(renderDescriptorRow),
+    ],
+  });
+
+  const cardChildren: DomJson[] = [
+    {
+      type: 'div',
+      options: {
+        style: {
+          fontSize: '20px',
+          fontWeight: '700',
+          color: '#111827',
+          marginBottom: '16px',
+        },
+      },
+      children: ['Approve Reveal to Verifier'],
+    },
+  ];
+
+  if (sentDescriptors.length > 0) {
+    cardChildren.push(renderSection('Sent', sentDescriptors));
+  }
+
+  if (recvDescriptors.length > 0) {
+    cardChildren.push(renderSection('Received', recvDescriptors));
+  }
+
+  cardChildren.push({
+    type: 'div',
+    options: {
+      style: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        gap: '12px',
+        marginTop: '24px',
+      },
+    },
+    children: [
+      {
+        type: 'button',
+        options: {
+          onclick: '_revealReject',
+          style: {
+            backgroundColor: '#fee2e2',
+            color: '#991b1b',
+            border: 'none',
+            padding: '8px 20px',
+            borderRadius: '8px',
+            fontWeight: '600',
+            cursor: 'pointer',
+          },
+        },
+        children: ['Reject'],
+      },
+      {
+        type: 'button',
+        options: {
+          onclick: '_revealApprove',
+          style: {
+            backgroundColor: '#d1fae5',
+            color: '#065f46',
+            border: 'none',
+            padding: '8px 20px',
+            borderRadius: '8px',
+            fontWeight: '600',
+            cursor: 'pointer',
+          },
+        },
+        children: ['Approve'],
+      },
+    ],
+  });
+
+  return {
+    type: 'div',
+    options: {
+      style: {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: '9999999',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      },
+    },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            backgroundColor: '#ffffff',
+            borderRadius: '16px',
+            padding: '32px',
+            maxWidth: '520px',
+            width: '90%',
+            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
+          },
+        },
+        children: cardChildren,
+      },
+    ],
+  };
+}
+
 export function createTimeoutWarningOverlay(): DomJson {
   return {
     type: 'div',
@@ -830,6 +1040,7 @@ function wrapWithTimeoutWarning(pluginUi: DomJson): DomJson {
 
 export class Host {
   private capabilities: Map<string, AnyFunction> = new Map();
+  private _activeUuid: string | null = null;
   private onProve: (
     requestOptions: {
       url: string;
@@ -1036,6 +1247,7 @@ ${processedCode};
     },
   ): Promise<unknown> {
     const uuid = uuidv4();
+    this._activeUuid = uuid;
 
     const context: HookContext = {};
 
@@ -1500,8 +1712,13 @@ ${processedCode};
     // Use .then(onFulfilled, onRejected) so rejection doesn't produce an
     // unhandled rejection on the chained promise. The original donePromise
     // still rejects to the caller as expected.
-    const clearTimeoutInterval = () => clearInterval(timeoutIntervalId);
-    donePromise.then(clearTimeoutInterval, clearTimeoutInterval);
+    const cleanup = () => {
+      clearInterval(timeoutIntervalId);
+      if (this._activeUuid === uuid) {
+        this._activeUuid = null;
+      }
+    };
+    donePromise.then(cleanup, cleanup);
 
     // Execute initial main() - errors are handled within main() via terminateWithError
     main();
@@ -1520,6 +1737,15 @@ ${processedCode};
   ): DomJson => {
     return createDomJson(type, param1, param2);
   };
+
+  registerRevealApproval(resolve: () => void, reject: (err: Error) => void): void {
+    if (!this._activeUuid) return;
+    updateExecutionContext(this._activeUuid, { revealApproval: { resolve, reject } });
+  }
+
+  renderUi(windowId: number, json: DomJson): void {
+    this.onRenderPluginUi(windowId, json);
+  }
 }
 
 async function waitForWindow(
@@ -1619,6 +1845,7 @@ export type {
   WindowMessage,
   ExecutionContext,
   ProveProgressData,
+  RevealRangeDescriptor,
 } from './types';
 
 export { canonicalizeHandler, canonicalizeHandlers } from './types';

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -62,6 +62,7 @@ function updateExecutionContext(
     currentContext?: string;
     stateStore?: Record<string, unknown>;
     revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
+    revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
   },
 ): void {
   const context = executionContextRegistry.get(uuid);
@@ -369,7 +370,10 @@ function makeOpenWindow(
           if (message.onclick === '_revealApprove') {
             const approval = executionContext.revealApproval;
             if (approval) {
-              updateExecutionContext(uuid, { revealApproval: null });
+              updateExecutionContext(uuid, {
+                revealApproval: null,
+                revealApprovalDescriptors: null,
+              });
               approval.resolve();
             }
             return;
@@ -377,7 +381,10 @@ function makeOpenWindow(
           if (message.onclick === '_revealReject') {
             const approval = executionContext.revealApproval;
             if (approval) {
-              updateExecutionContext(uuid, { revealApproval: null });
+              updateExecutionContext(uuid, {
+                revealApproval: null,
+                revealApprovalDescriptors: null,
+              });
               approval.reject(new Error('User rejected reveal'));
             }
             return;
@@ -413,9 +420,7 @@ function makeOpenWindow(
 
         if (message.type === 'RE_RENDER_PLUGIN_UI') {
           logger.debug('[makeOpenWindow] RE_RENDER_PLUGIN_UI', message.windowId);
-          if (!executionContext.revealApproval) {
-            executionContext.main(true);
-          }
+          executionContext.main(true);
         }
       } catch (error) {
         logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);
@@ -889,7 +894,7 @@ export function createRevealApprovalOverlay(descriptors: RevealRangeDescriptor[]
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: '9999999',
+        zIndex: '9999998',
         fontFamily:
           '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
       },
@@ -1032,11 +1037,12 @@ export function createTimeoutWarningOverlay(): DomJson {
   };
 }
 
-function wrapWithTimeoutWarning(pluginUi: DomJson): DomJson {
+export function decorateJson(base: DomJson, overlays: DomJson[]): DomJson {
+  if (overlays.length === 0) return base;
   return {
     type: 'div',
     options: { style: {} },
-    children: [pluginUi, createTimeoutWarningOverlay()],
+    children: [base, ...overlays],
   };
 }
 
@@ -1603,9 +1609,18 @@ ${processedCode};
             executionContextRegistry.get(uuid)?.windowId,
           );
 
-          // If timeout warning is active, layer it on top of the plugin UI.
-          // The plugin UI continues to update underneath (no stale state).
-          json = timeoutWarningShown ? wrapWithTimeoutWarning(result) : result;
+          // Layer overlays on top of the plugin UI using the decorator pattern.
+          // Stack order matters: timeout (z=9999999) is rendered above reveal
+          // approval (z=9999998) so a timeout warning never gets buried.
+          const overlays: DomJson[] = [];
+          const ctx = executionContextRegistry.get(uuid);
+          if (ctx?.revealApprovalDescriptors) {
+            overlays.push(createRevealApprovalOverlay(ctx.revealApprovalDescriptors));
+          }
+          if (timeoutWarningShown) {
+            overlays.push(createTimeoutWarningOverlay());
+          }
+          json = decorateJson(result, overlays);
 
           waitForWindow(async () => executionContextRegistry.get(uuid)?.windowId).then(
             (windowId: number | null) => {
@@ -1740,9 +1755,20 @@ ${processedCode};
     return createDomJson(type, param1, param2);
   };
 
-  registerRevealApproval(resolve: () => void, reject: (err: Error) => void): void {
+  registerRevealApproval(
+    resolve: () => void,
+    reject: (err: Error) => void,
+    descriptors: RevealRangeDescriptor[],
+  ): void {
     if (!this._activeUuid) return;
-    updateExecutionContext(this._activeUuid, { revealApproval: { resolve, reject } });
+    const uuid = this._activeUuid;
+    updateExecutionContext(uuid, {
+      revealApproval: { resolve, reject },
+      revealApprovalDescriptors: descriptors,
+    });
+    // Trigger a re-render so the decorator applies immediately
+    const ctx = executionContextRegistry.get(uuid);
+    ctx?.main(true);
   }
 
   renderUi(windowId: number, json: DomJson): void {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -413,7 +413,9 @@ function makeOpenWindow(
 
         if (message.type === 'RE_RENDER_PLUGIN_UI') {
           logger.debug('[makeOpenWindow] RE_RENDER_PLUGIN_UI', message.windowId);
-          executionContext.main(true);
+          if (!executionContext.revealApproval) {
+            executionContext.main(true);
+          }
         }
       } catch (error) {
         logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -63,6 +63,7 @@ function updateExecutionContext(
     stateStore?: Record<string, unknown>;
     revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
     revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
+    revealWasRejected?: boolean;
   },
 ): void {
   const context = executionContextRegistry.get(uuid);
@@ -368,7 +369,8 @@ function makeOpenWindow(
         if (message.type === 'PLUGIN_UI_CLICK') {
           logger.debug('PLUGIN_UI_CLICK', message);
           if (message.onclick === '_revealApprove') {
-            const approval = executionContext.revealApproval;
+            const liveCtx = executionContextRegistry.get(uuid);
+            const approval = liveCtx?.revealApproval;
             if (approval) {
               updateExecutionContext(uuid, {
                 revealApproval: null,
@@ -379,11 +381,13 @@ function makeOpenWindow(
             return;
           }
           if (message.onclick === '_revealReject') {
-            const approval = executionContext.revealApproval;
+            const liveCtx = executionContextRegistry.get(uuid);
+            const approval = liveCtx?.revealApproval;
             if (approval) {
               updateExecutionContext(uuid, {
                 revealApproval: null,
                 revealApprovalDescriptors: null,
+                revealWasRejected: true,
               });
               approval.reject(new Error('User rejected reveal'));
             }
@@ -1318,6 +1322,18 @@ ${processedCode};
 
       // Clean up registry entry
       const ctx = executionContextRegistry.get(uuid);
+
+      // If a reveal approval is pending, reject it so the awaiting onProve
+      // (and any owned resources like transcript bytes) can unwind.
+      const pendingApproval = ctx?.revealApproval;
+      if (pendingApproval) {
+        try {
+          pendingApproval.reject(error);
+        } catch (rejectError) {
+          logger.error('[executePlugin] Error rejecting pending reveal approval:', rejectError);
+        }
+      }
+
       if (ctx?.windowId) {
         try {
           this.onCloseWindow(ctx.windowId);
@@ -1443,9 +1459,18 @@ ${processedCode};
           onCloseWindow(context.windowId);
         }
 
+        // If a reveal was rejected during this execution, treat done() as a
+        // failure so callers can skip success-only side effects (e.g. the
+        // execution counter).
+        const wasRejected = context?.revealWasRejected === true;
+
         const finalize = () => {
           executionContextRegistry.delete(uuid);
-          doneResolve(args);
+          if (wasRejected) {
+            doneReject(new Error('User rejected reveal'));
+          } else {
+            doneResolve(args);
+          }
         };
 
         // If called from within an async callback (e.g. onClick → prove() → done()),
@@ -1472,12 +1497,20 @@ ${processedCode};
 
         const ctx = executionContextRegistry.get(uuid);
         const windowId = ctx?.windowId;
+        const wasRejected = ctx?.revealWasRejected === true;
+        const settle = () => {
+          if (wasRejected) {
+            doneReject(new Error('User rejected reveal'));
+          } else {
+            doneResolve(args);
+          }
+        };
 
         // If there's no window, behave like done() — no overlay or delay needed
         if (!windowId) {
           const finalize = () => {
             executionContextRegistry.delete(uuid);
-            doneResolve(args);
+            settle();
           };
 
           if (lifecycle.pendingCallbacks > 0) {
@@ -1497,7 +1530,7 @@ ${processedCode};
         const closeAndFinalize = () => {
           onCloseWindow(windowId);
           executionContextRegistry.delete(uuid);
-          doneResolve(args);
+          settle();
         };
 
         // Wait for pending callbacks to complete (e.g. the onClick that

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -774,7 +774,8 @@ export function createRevealApprovalOverlay(descriptors: RevealRangeDescriptor[]
             style: {
               fontFamily: 'monospace',
               fontSize: '11px',
-              color: '#6b7280',
+              color: isReveal ? '#6b7280' : '#9ca3af',
+              fontStyle: isReveal ? 'normal' : 'italic',
               wordBreak: 'break-all',
             },
           },

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -58,6 +58,7 @@ export type ExecutionContext = {
   callbacks: {
     [callbackName: string]: () => Promise<void>;
   };
+  revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
 };
 
 export type DomOptions = {
@@ -156,6 +157,14 @@ export type HandlerPart =
   | 'ALL';
 
 export type HashAlgorithm = 'BLAKE3' | 'SHA256' | 'KECCAK256';
+
+export type RevealRangeDescriptor = {
+  direction: 'SENT' | 'RECV';
+  label: string;
+  action: 'REVEAL' | 'HASH';
+  algorithm?: HashAlgorithm;
+  preview: string;
+};
 
 /**
  * What to do with the matched ranges.

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -59,6 +59,7 @@ export type ExecutionContext = {
     [callbackName: string]: () => Promise<void>;
   };
   revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
+  revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
 };
 
 export type DomOptions = {

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -60,6 +60,7 @@ export type ExecutionContext = {
   };
   revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
   revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
+  revealWasRejected?: boolean;
 };
 
 export type DomOptions = {

--- a/packages/plugin-sdk/src/types.ts
+++ b/packages/plugin-sdk/src/types.ts
@@ -160,10 +160,13 @@ export type HandlerPart =
 
 export type HashAlgorithm = 'BLAKE3' | 'SHA256' | 'KECCAK256';
 
+/** String action kind used in reveal-range previews and descriptors. */
+export type HandlerActionKind = 'REVEAL' | 'HASH';
+
 export type RevealRangeDescriptor = {
-  direction: 'SENT' | 'RECV';
+  direction: HandlerType;
   label: string;
-  action: 'REVEAL' | 'HASH';
+  action: HandlerActionKind;
   algorithm?: HashAlgorithm;
   preview: string;
 };

--- a/packages/plugin-sdk/test/reveal-approval.browser.test.ts
+++ b/packages/plugin-sdk/test/reveal-approval.browser.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Host, createRevealApprovalOverlay } from '../src/index';
+import type { WindowMessage, DomJson, RevealRangeDescriptor } from '../src/types';
+
+/**
+ * Browser E2E tests for the reveal approval flow.
+ *
+ * These tests run real QuickJS WASM in Chromium via Playwright, verifying:
+ * - _revealApprove resolves the pending prove() approval
+ * - _revealReject rejects the pending prove() approval
+ * - _revealApprove and _revealReject are not forwarded to plugin callbacks
+ * - createRevealApprovalOverlay produces the expected DomJson structure
+ */
+describe('Reveal Approval E2E', () => {
+  function createEventEmitter() {
+    const listeners: Array<(msg: WindowMessage) => void> = [];
+    return {
+      addListener: (fn: (msg: WindowMessage) => void) => listeners.push(fn),
+      removeListener: (fn: (msg: WindowMessage) => void) => {
+        const i = listeners.indexOf(fn);
+        if (i >= 0) listeners.splice(i, 1);
+      },
+      emit: (msg: WindowMessage) => {
+        [...listeners].forEach((fn) => fn(msg));
+      },
+    };
+  }
+
+  const sampleDescriptors: RevealRangeDescriptor[] = [
+    {
+      direction: 'RECV',
+      label: 'Body: amount',
+      action: 'REVEAL',
+      preview: '1234.56',
+    },
+  ];
+
+  const provePluginCode = `
+    export function main() {
+      openWindow('https://example.com', { width: 400, height: 300 });
+      return button({ onclick: 'handleProve' }, ['Prove']);
+    }
+    export async function handleProve() {
+      try {
+        const result = await prove(
+          { url: 'https://example.com', method: 'GET', headers: {} },
+          { verifierUrl: 'http://localhost:7047', proxyUrl: 'ws://localhost:55688', handlers: [] }
+        );
+        done({ ok: true, result });
+      } catch (err) {
+        done({ ok: false, message: err && err.message ? err.message : String(err) });
+      }
+    }
+  `;
+
+  it('should resolve prove() when _revealApprove is clicked', async () => {
+    const onProve = vi.fn(async () => {
+      host.renderUi(1, createRevealApprovalOverlay(sampleDescriptors));
+      await new Promise<void>((resolve, reject) => {
+        host.registerRevealApproval(resolve, reject);
+      });
+      return { proof: 'mock' };
+    });
+
+    const onRenderPluginUi = vi.fn().mockImplementation((_windowId: number, json: DomJson) => {
+      if (JSON.stringify(json).includes('_revealApprove')) {
+        setTimeout(() => {
+          emitter.emit({
+            type: 'PLUGIN_UI_CLICK',
+            onclick: '_revealApprove',
+            windowId: 1,
+          } as unknown as WindowMessage);
+        }, 10);
+      }
+    });
+
+    const host = new Host({
+      onProve,
+      onRenderPluginUi,
+      onCloseWindow: vi.fn(),
+      onOpenWindow: vi.fn().mockResolvedValue({
+        type: 'WINDOW_OPENED',
+        payload: { windowId: 1, uuid: 'test-uuid', tabId: 1 },
+      }),
+    });
+
+    const emitter = createEventEmitter();
+
+    const donePromise = host.executePlugin(provePluginCode, { eventEmitter: emitter });
+
+    await new Promise((r) => setTimeout(r, 200));
+    emitter.emit({
+      type: 'PLUGIN_UI_CLICK',
+      onclick: 'handleProve',
+      windowId: 1,
+    } as unknown as WindowMessage);
+
+    const result = (await donePromise) as { ok: boolean; result?: unknown };
+    expect(result).toEqual({ ok: true, result: { proof: 'mock' } });
+    expect(onProve).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject prove() when _revealReject is clicked', async () => {
+    const onProve = vi.fn(async () => {
+      host.renderUi(1, createRevealApprovalOverlay(sampleDescriptors));
+      await new Promise<void>((resolve, reject) => {
+        host.registerRevealApproval(resolve, reject);
+      });
+      return { proof: 'mock' };
+    });
+
+    const onRenderPluginUi = vi.fn().mockImplementation((_windowId: number, json: DomJson) => {
+      if (JSON.stringify(json).includes('_revealReject')) {
+        setTimeout(() => {
+          emitter.emit({
+            type: 'PLUGIN_UI_CLICK',
+            onclick: '_revealReject',
+            windowId: 1,
+          } as unknown as WindowMessage);
+        }, 10);
+      }
+    });
+
+    const host = new Host({
+      onProve,
+      onRenderPluginUi,
+      onCloseWindow: vi.fn(),
+      onOpenWindow: vi.fn().mockResolvedValue({
+        type: 'WINDOW_OPENED',
+        payload: { windowId: 1, uuid: 'test-uuid', tabId: 1 },
+      }),
+    });
+
+    const emitter = createEventEmitter();
+
+    const donePromise = host.executePlugin(provePluginCode, { eventEmitter: emitter });
+
+    await new Promise((r) => setTimeout(r, 200));
+    emitter.emit({
+      type: 'PLUGIN_UI_CLICK',
+      onclick: 'handleProve',
+      windowId: 1,
+    } as unknown as WindowMessage);
+
+    const result = (await donePromise) as { ok: boolean; message?: string };
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('rejected');
+  });
+
+  it('should not forward _revealApprove or _revealReject to plugin callbacks', async () => {
+    const handleSpy = vi.fn();
+
+    const onProve = vi.fn(async () => {
+      host.renderUi(1, createRevealApprovalOverlay(sampleDescriptors));
+      await new Promise<void>((resolve, reject) => {
+        host.registerRevealApproval(resolve, reject);
+      });
+      return { proof: 'mock' };
+    });
+
+    const onRenderPluginUi = vi.fn().mockImplementation((_windowId: number, json: DomJson) => {
+      if (JSON.stringify(json).includes('_revealApprove')) {
+        setTimeout(() => {
+          emitter.emit({
+            type: 'PLUGIN_UI_CLICK',
+            onclick: '_revealApprove',
+            windowId: 1,
+          } as unknown as WindowMessage);
+        }, 10);
+      }
+    });
+
+    const host = new Host({
+      onProve,
+      onRenderPluginUi,
+      onCloseWindow: vi.fn(),
+      onOpenWindow: vi.fn().mockResolvedValue({
+        type: 'WINDOW_OPENED',
+        payload: { windowId: 1, uuid: 'test-uuid', tabId: 1 },
+      }),
+    });
+
+    const emitter = createEventEmitter();
+    host.addCapability('handleSpy', handleSpy);
+
+    const donePromise = host.executePlugin(
+      `
+      export function main() {
+        openWindow('https://example.com', { width: 400, height: 300 });
+        return button({ onclick: 'handleProve' }, ['Prove']);
+      }
+      export async function _revealApprove() {
+        handleSpy('_revealApprove');
+      }
+      export async function _revealReject() {
+        handleSpy('_revealReject');
+      }
+      export async function handleProve() {
+        try {
+          const result = await prove(
+            { url: 'https://example.com', method: 'GET', headers: {} },
+            { verifierUrl: 'http://localhost:7047', proxyUrl: 'ws://localhost:55688', handlers: [] }
+          );
+          done({ ok: true, result });
+        } catch (err) {
+          done({ ok: false, message: err && err.message ? err.message : String(err) });
+        }
+      }
+    `,
+      { eventEmitter: emitter },
+    );
+
+    await new Promise((r) => setTimeout(r, 200));
+    emitter.emit({
+      type: 'PLUGIN_UI_CLICK',
+      onclick: 'handleProve',
+      windowId: 1,
+    } as unknown as WindowMessage);
+
+    const result = (await donePromise) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(handleSpy).not.toHaveBeenCalled();
+  });
+
+  it('should produce overlay DomJson with _revealApprove and _revealReject buttons', () => {
+    const overlay = createRevealApprovalOverlay([
+      {
+        direction: 'SENT',
+        label: 'Method',
+        action: 'REVEAL',
+        preview: 'GET',
+      },
+      {
+        direction: 'RECV',
+        label: 'Body: amount',
+        action: 'REVEAL',
+        preview: '1234.56',
+      },
+    ]);
+
+    const json = JSON.stringify(overlay);
+    expect(json).toContain('_revealApprove');
+    expect(json).toContain('_revealReject');
+
+    const buttons = collectButtons(overlay);
+    const onclicks = buttons.map((b) => b.options?.onclick).filter(Boolean);
+    expect(onclicks).toContain('_revealApprove');
+    expect(onclicks).toContain('_revealReject');
+  });
+});
+
+function collectButtons(node: DomJson): DomJson[] {
+  const out: DomJson[] = [];
+  if (typeof node !== 'object' || node === null) return out;
+  if (node.type === 'button') out.push(node);
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      if (typeof child === 'object' && child !== null) {
+        out.push(...collectButtons(child));
+      }
+    }
+  }
+  return out;
+}

--- a/packages/plugin-sdk/test/reveal-approval.browser.test.ts
+++ b/packages/plugin-sdk/test/reveal-approval.browser.test.ts
@@ -142,9 +142,10 @@ describe('Reveal Approval E2E', () => {
       windowId: 1,
     } as unknown as WindowMessage);
 
-    const result = (await donePromise) as { ok: boolean; message?: string };
-    expect(result.ok).toBe(false);
-    expect(result.message).toContain('rejected');
+    // Even if the plugin catches prove()'s rejection and calls done() with a
+    // recovery payload, executePlugin must surface the rejection so callers
+    // can skip success-only side effects (e.g. the execution counter).
+    await expect(donePromise).rejects.toThrow('User rejected reveal');
   });
 
   it('should not forward _revealApprove or _revealReject to plugin callbacks', async () => {

--- a/packages/plugin-sdk/test/reveal-approval.test.ts
+++ b/packages/plugin-sdk/test/reveal-approval.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { createRevealApprovalOverlay } from '../src/index';
+import type { RevealRangeDescriptor, DomJson } from '../src/index';
+
+function findButtons(node: DomJson): string[] {
+  if (typeof node === 'string') {
+    return [];
+  }
+  const collected: string[] = [];
+  if (node.type === 'button' && typeof node.options.onclick === 'string') {
+    collected.push(node.options.onclick);
+  }
+  for (const child of node.children) {
+    collected.push(...findButtons(child));
+  }
+  return collected;
+}
+
+function flattenText(node: DomJson): string[] {
+  if (typeof node === 'string') {
+    return [node];
+  }
+  const collected: string[] = [];
+  for (const child of node.children) {
+    collected.push(...flattenText(child));
+  }
+  return collected;
+}
+
+describe('createRevealApprovalOverlay', () => {
+  it('returns a non-empty DomJson', () => {
+    const result = createRevealApprovalOverlay([]);
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('object');
+  });
+
+  it('includes _revealApprove and _revealReject buttons', () => {
+    const result = createRevealApprovalOverlay([]);
+    const buttons = findButtons(result);
+    expect(buttons).toContain('_revealApprove');
+    expect(buttons).toContain('_revealReject');
+  });
+
+  it('only _revealApprove and _revealReject are present as onclick handlers', () => {
+    const result = createRevealApprovalOverlay([]);
+    const buttons = findButtons(result);
+    expect(buttons.every((b) => b === '_revealApprove' || b === '_revealReject')).toBe(true);
+  });
+
+  it('renders SENT descriptors and RECV descriptors in separate sections', () => {
+    const descriptors: RevealRangeDescriptor[] = [
+      { direction: 'SENT', label: 'Start line', action: 'REVEAL', preview: 'GET /path' },
+      { direction: 'SENT', label: 'Headers: host', action: 'REVEAL', preview: 'example.com' },
+      { direction: 'RECV', label: 'Body: amount', action: 'REVEAL', preview: '1234.56' },
+    ];
+    const result = createRevealApprovalOverlay(descriptors);
+    const text = flattenText(result);
+    expect(text.some((t) => t.toLowerCase().includes('sent'))).toBe(true);
+    expect(text.some((t) => t.toLowerCase().includes('receiv'))).toBe(true);
+    expect(text.some((t) => t.includes('Start line'))).toBe(true);
+    expect(text.some((t) => t.includes('Body: amount'))).toBe(true);
+  });
+
+  it('renders HASH action chip differently from REVEAL', () => {
+    const descriptors: RevealRangeDescriptor[] = [
+      { direction: 'RECV', label: 'Body: secret', action: 'HASH', preview: 'hidden' },
+    ];
+    const result = createRevealApprovalOverlay(descriptors);
+    const text = flattenText(result);
+    expect(text.some((t) => t.includes('HASH') || t.includes('SHA'))).toBe(true);
+  });
+
+  it('only shows SENT section when all descriptors are SENT', () => {
+    const descriptors: RevealRangeDescriptor[] = [
+      { direction: 'SENT', label: 'Start line', action: 'REVEAL', preview: 'GET /' },
+    ];
+    const result = createRevealApprovalOverlay(descriptors);
+    const text = flattenText(result);
+    expect(text.some((t) => t.toLowerCase().includes('sent'))).toBe(true);
+    expect(text.some((t) => t.toLowerCase().includes('receiv'))).toBe(false);
+  });
+});

--- a/packages/plugins/src/twitter.plugin.ts
+++ b/packages/plugins/src/twitter.plugin.ts
@@ -69,7 +69,7 @@ const onClick = async (): Promise<void> => {
       verifierUrl: __VERIFIER_URL__,
       proxyUrl: __PROXY_URL__ + 'api.x.com',
       maxRecvData: 4000,
-      maxSentData: 2000,
+      maxSentData: 4096,
       handlers: [
         { type: 'SENT', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,
         { type: 'RECV', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,

--- a/packages/plugins/src/twitter.plugin.ts
+++ b/packages/plugins/src/twitter.plugin.ts
@@ -69,6 +69,8 @@ const onClick = async (): Promise<void> => {
       verifierUrl: __VERIFIER_URL__,
       proxyUrl: __PROXY_URL__ + 'api.x.com',
       maxRecvData: 4000,
+      // Chrome/Brave inject sec-ch-ua, sec-fetch-* and other client-hint
+      // headers that can push the total sent bytes above 2000.
       maxSentData: 4096,
       handlers: [
         { type: 'SENT', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,

--- a/packages/tlsn-wasm/build.sh
+++ b/packages/tlsn-wasm/build.sh
@@ -6,7 +6,7 @@ set -e # Exit on error
 cd "$(dirname "$0")"
 SCRIPT_DIR="$(pwd)"
 
-VERSION=${1:-ceadf458f6f75909eda013aa50108f9f94956188}
+VERSION=${1:-origin/main}
 NO_LOGGING=${2}
 
 TARGET_DIR="${SCRIPT_DIR}/../tlsn-wasm-pkg/"
@@ -33,16 +33,14 @@ elif [ -L "$REPO_DIR" ]; then
 # Check if the directory exists
 elif [ ! -d "$REPO_DIR" ]; then
     # Clone the repository if it does not exist
-    # (separate checkout so VERSION can be a SHA, bare tag, or branch name)
     git clone https://github.com/tlsnotary/tlsn.git "$REPO_DIR"
     cd "$REPO_DIR"
-    git checkout "${VERSION}" --force
 else
     # If the directory exists, just change to it
     cd "$REPO_DIR"
     # Fetch the latest changes in the repo without checkout
     git fetch
-    # Checkout the pinned commit
+    # Checkout the specific tag
     git checkout "${VERSION}" --force
     git reset --hard
 fi
@@ -79,7 +77,7 @@ fi
 # Apply no-logging modification if requested
 if [ "$NO_LOGGING" = "--no-logging" ]; then
     echo "Applying no-logging configuration..."
-    
+
     # Add it to the wasm32 target section (after the section header).
     # Uses awk for portability — BSD sed (macOS) drops the trailing newline
     # after `a\` text, jamming the inserted key into the next existing key.

--- a/packages/tlsn-wasm/build.sh
+++ b/packages/tlsn-wasm/build.sh
@@ -78,18 +78,13 @@ fi
 if [ "$NO_LOGGING" = "--no-logging" ]; then
     echo "Applying no-logging configuration..."
 
-    # Add it to the wasm32 target section (after the section header).
-    # Uses awk for portability — BSD sed (macOS) drops the trailing newline
-    # after `a\` text, jamming the inserted key into the next existing key.
-    awk '
-/^\[target\.'"'"'cfg\(target_arch = "wasm32"\)'"'"'\.dependencies\]$/ {
-  print
-  print "# Disable tracing events as a workaround for issue 959."
-  print "tracing = { workspace = true, features = [\"release_max_level_off\"] }"
-  next
-}
-{ print }
-' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+    # Add it to the wasm32 target section (after the section header)
+    sed -i.bak '/^\[target\.'"'"'cfg(target_arch = "wasm32")'"'"'\.dependencies\]$/a\
+# Disable tracing events as a workaround for issue 959.\
+tracing = { workspace = true, features = ["release_max_level_off"] }' Cargo.toml
+
+    # Clean up backup file
+    rm Cargo.toml.bak
 fi
 
 # On NixOS, the wrapped clang injects host glibc headers when cross-compiling

--- a/packages/verifier/rust-toolchain.toml
+++ b/packages/verifier/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/packages/verifier/rust-toolchain.toml
+++ b/packages/verifier/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
Closes #333

<img width="601" height="506" alt="Screenshot 2026-05-06 at 2 25 20 PM" src="https://github.com/user-attachments/assets/a8723c58-1ece-4fa4-8631-2ea5e5608895" />
<img width="906" height="701" alt="Screenshot 2026-05-06 at 2 25 32 PM" src="https://github.com/user-attachments/assets/554ead29-096b-4dfc-a09f-0a2c4e93417b" />


## Summary

- **Three-option approval popup** replaces the binary Allow/Deny: "Yes, manually approve actions" / "Yes, allow all actions during this session" / "No". The first option fires a reveal-approval modal before each `prove()` call; the second skips it for the entire session. Shows per-plugin execution count and a red `(Recommended)` badge when count is 0.
- **REVEAL_APPROVAL modal** — inserted between `computeReveal()` and `sendRevealConfig()` in `SessionManager.onProve`. Lists every reveal range (direction, label, action, byte preview) as a structured DomJson overlay. Approve continues; Reject aborts the plugin and rejects the page Promise.
- **Execution counter** — `SHA256(code + pageOrigin)` keyed in a new `pluginCounts` IndexedDB store (version bump 1→2 in `tlsn-settings` DB). Incremented only on successful plugin completion, never on rejection or error.

## Changes

| Package | File | Change |
|---|---|---|
| `extension` | `src/types/messages.ts` | Add `ApprovalMode` type; update `PLUGIN_CONFIRM_RESPONSE`; add offscreen stat message types |
| `extension` | `src/utils/cryptoHash.ts` | New — `sha256()` via `crypto.subtle` |
| `extension` | `src/utils/pluginExecutionCounts.ts` | New — `getPluginCount` / `incrementPluginCount` (IndexedDB) |
| `extension` | `src/entries/Content/index.ts` | Add `pageOrigin` to `EXEC_CODE` message |
| `extension` | `src/entries/ConfirmPopup/index.tsx` | Three-button UI with count display and recommended badge |
| `extension` | `src/background/ConfirmationManager.ts` | Return `ApprovalMode`; accept `executionCount` |
| `extension` | `src/entries/Background/index.ts` | `getPluginStatsViaOffscreen`; thread `_approvalMode` + `_pluginHash` |
| `extension` | `src/entries/Offscreen/index.tsx` | `GET_PLUGIN_STATS_OFFSCREEN` / `INCREMENT_PLUGIN_COUNT_OFFSCREEN` handlers; success-branch counter |
| `extension` | `src/offscreen/ProveManager/index.ts` | Cache transcript bytes after `sendRequest`; expose `getSentBytes` / `getRecvBytes` |
| `extension` | `src/offscreen/SessionManager.ts` | REVEAL_APPROVAL gate with descriptor building and `registerRevealApproval` |
| `plugin-sdk` | `src/types.ts` | Add `RevealRangeDescriptor`; add `revealApproval` to `ExecutionContext` |
| `plugin-sdk` | `src/index.ts` | `createRevealApprovalOverlay`; `_revealApprove`/`_revealReject` dispatch intercept; `Host.registerRevealApproval` / `Host.renderUi` |

## Test plan

- [x] `npm run test` — 182/182 extension tests pass, 247/247 plugin-sdk tests pass
- [x] `npx vitest --config vitest.browser.config.ts --run reveal-approval` — 4/4 Playwright browser tests pass (approve path, reject path, callbacks not forwarded to plugin, overlay structure)
- [x] `npm run lint` — clean across all packages
- [ ] Manual: `npm run demo` → SwissBank plugin → popup shows `0 times` + red `(Recommended)` → choose "manually approve" → REVEAL_APPROVAL modal appears → Reject keeps counter at 0 → Approve increments to 1 → "allow all session" skips modal and increments to 2