### PR TITLE
refactor(plugin-sdk): extract platform-agnostic HostCore from Host

### DIFF
--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -1,3 +1,4 @@
+import 'react-native-get-random-values';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -6,6 +6,7 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { useColorScheme } from '@/components/useColorScheme';
 
@@ -50,12 +51,14 @@ function RootLayoutNav() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Plugins' }} />
-        <Stack.Screen name="plugin/[id]" options={{ presentation: 'card' }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
-      </Stack>
-    </ThemeProvider>
+    <SafeAreaProvider>
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Plugins' }} />
+          <Stack.Screen name="plugin/[id]" options={{ presentation: 'card' }} />
+          <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+        </Stack>
+      </ThemeProvider>
+    </SafeAreaProvider>
   );
 }

--- a/app/mobile/components/tlsn/BottomSheetCard.tsx
+++ b/app/mobile/components/tlsn/BottomSheetCard.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+  Animated,
+  Dimensions,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+interface BottomSheetCardProps {
+  /** When true, the sheet slides up; when false, it slides down and unmounts after the animation. */
+  visible: boolean;
+  /** Called when the user taps the backdrop or completes a swipe-down dismiss. Not called for programmatic close. */
+  onClose?: () => void;
+  /** When false, the backdrop is non-interactive and swipe-down is disabled. Default: true. */
+  dismissible?: boolean;
+  /** Sheet body. */
+  children: React.ReactNode;
+  /** Optional style overrides on the inner card. */
+  cardStyle?: ViewStyle;
+}
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
+const SPRING_CONFIG = { tension: 60, friction: 11, useNativeDriver: true };
+const SWIPE_DISMISS_THRESHOLD = 80;
+
+/**
+ * A slide-up bottom card with a tappable backdrop and optional swipe-down dismiss.
+ *
+ * Uses the legacy `Animated` + `PanResponder` API (matching the existing
+ * `DraggableView` in PluginRenderer) rather than Reanimated worklets — simpler
+ * context, no worklet boundaries, sufficient for this UI.
+ */
+export function BottomSheetCard({
+  visible,
+  onClose,
+  dismissible = true,
+  children,
+  cardStyle,
+}: BottomSheetCardProps) {
+  const insets = useSafeAreaInsets();
+  const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const cardHeight = useRef(0);
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.spring(translateY, { ...SPRING_CONFIG, toValue: 0 }),
+        Animated.timing(backdropOpacity, {
+          toValue: 1,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    } else {
+      Animated.parallel([
+        Animated.timing(translateY, {
+          toValue: cardHeight.current || SCREEN_HEIGHT,
+          duration: 220,
+          useNativeDriver: true,
+        }),
+        Animated.timing(backdropOpacity, {
+          toValue: 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    }
+  }, [visible, translateY, backdropOpacity]);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => false,
+        onMoveShouldSetPanResponder: (_e, g) => dismissible && g.dy > 5 && Math.abs(g.dy) > Math.abs(g.dx),
+        onPanResponderMove: (_e, g) => {
+          if (g.dy > 0) translateY.setValue(g.dy);
+        },
+        onPanResponderRelease: (_e, g) => {
+          if (g.dy > SWIPE_DISMISS_THRESHOLD) {
+            onClose?.();
+          } else {
+            Animated.spring(translateY, { ...SPRING_CONFIG, toValue: 0 }).start();
+          }
+        },
+        onPanResponderTerminate: () => {
+          Animated.spring(translateY, { ...SPRING_CONFIG, toValue: 0 }).start();
+        },
+      }),
+    [dismissible, onClose, translateY],
+  );
+
+  if (!visible) {
+    // Keep mounted briefly during exit animation by checking translateY's resting state isn't reached.
+    // Simplification: unmount immediately when visible flips false. The exit animation runs but the
+    // tree disappears once visible=false because parent stops rendering the component. Acceptable trade-off.
+  }
+
+  return (
+    <View style={styles.fill} pointerEvents={visible ? 'auto' : 'none'}>
+      <Animated.View
+        style={[styles.backdrop, { opacity: backdropOpacity }]}
+        pointerEvents={dismissible ? 'auto' : 'none'}
+      >
+        {dismissible ? (
+          <Pressable style={styles.fill} onPress={onClose} accessibilityLabel="Dismiss" />
+        ) : null}
+      </Animated.View>
+
+      <Animated.View
+        style={[
+          styles.card,
+          { paddingBottom: Math.max(insets.bottom, 16), transform: [{ translateY }] },
+          cardStyle,
+        ]}
+        onLayout={(e) => {
+          cardHeight.current = e.nativeEvent.layout.height;
+        }}
+        {...panResponder.panHandlers}
+      >
+        {dismissible ? <View style={styles.handle} /> : null}
+        {children}
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  fill: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  card: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#ffffff',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingTop: 8,
+    paddingHorizontal: 20,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -8 },
+    shadowOpacity: 0.18,
+    shadowRadius: 24,
+    elevation: 16,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#d1d5db',
+    marginBottom: 12,
+    marginTop: 4,
+  },
+});

--- a/app/mobile/components/tlsn/BottomSheetCard.tsx
+++ b/app/mobile/components/tlsn/BottomSheetCard.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable react-hooks/refs --
+ * Animated.Value refs are captured at mount and intentionally read by the
+ * animation driver and PanResponder. They never change identity across
+ * renders, so React's "refs during render" guidance doesn't apply.
+ */
 import React, { useEffect, useMemo, useRef } from 'react';
 import {
   Animated,
@@ -80,7 +85,8 @@ export function BottomSheetCard({
     () =>
       PanResponder.create({
         onStartShouldSetPanResponder: () => false,
-        onMoveShouldSetPanResponder: (_e, g) => dismissible && g.dy > 5 && Math.abs(g.dy) > Math.abs(g.dx),
+        onMoveShouldSetPanResponder: (_e, g) =>
+          dismissible && g.dy > 5 && Math.abs(g.dy) > Math.abs(g.dx),
         onPanResponderMove: (_e, g) => {
           if (g.dy > 0) translateY.setValue(g.dy);
         },

--- a/app/mobile/components/tlsn/BottomSheetCard.tsx
+++ b/app/mobile/components/tlsn/BottomSheetCard.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import {
   Animated,
   Dimensions,
-  Modal,
   PanResponder,
   Pressable,
   StyleSheet,
@@ -31,8 +30,10 @@ const SWIPE_DISMISS_THRESHOLD = 80;
 /**
  * A slide-up bottom card with a tappable backdrop and optional swipe-down dismiss.
  *
- * Rendered inside a React Native Modal so it always sits above the entire view
- * hierarchy — plugin DomJson z-index values cannot overlap it.
+ * Rendered as an absolute-positioned overlay (not a Modal) so it never creates
+ * a new UIWindow — no interference with WebView loading. The caller is
+ * responsible for not rendering competing absolute content while the sheet is
+ * visible (PluginScreen hides the plugin UI overlay when any sheet is active).
  *
  * Uses the legacy `Animated` + `PanResponder` API (matching the existing
  * `DraggableView` in PluginRenderer) rather than Reanimated worklets.
@@ -49,14 +50,8 @@ export function BottomSheetCard({
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const cardHeight = useRef(0);
 
-  // Keep the Modal mounted until the exit animation finishes so the slide-down
-  // plays before the Modal disappears. Set true immediately when visible becomes
-  // true; set false only in the exit animation's completion callback.
-  const [modalMounted, setModalMounted] = useState(visible);
-
   useEffect(() => {
     if (visible) {
-      setModalMounted(true);
       Animated.parallel([
         Animated.spring(translateY, { ...SPRING_CONFIG, toValue: 0 }),
         Animated.timing(backdropOpacity, {
@@ -77,7 +72,7 @@ export function BottomSheetCard({
           duration: 200,
           useNativeDriver: true,
         }),
-      ]).start(() => setModalMounted(false));
+      ]).start();
     }
   }, [visible, translateY, backdropOpacity]);
 
@@ -104,44 +99,43 @@ export function BottomSheetCard({
   );
 
   return (
-    <Modal
-      transparent
-      visible={modalMounted}
-      onRequestClose={dismissible ? onClose : undefined}
-      statusBarTranslucent
-    >
-      <View style={styles.fill}>
-        <Animated.View
-          style={[styles.backdrop, { opacity: backdropOpacity }]}
-          pointerEvents={dismissible ? 'auto' : 'none'}
-        >
-          {dismissible ? (
-            <Pressable style={styles.fill} onPress={onClose} accessibilityLabel="Dismiss" />
-          ) : null}
-        </Animated.View>
+    <View style={styles.fill} pointerEvents={visible ? 'auto' : 'none'}>
+      <Animated.View
+        style={[styles.backdrop, { opacity: backdropOpacity }]}
+        pointerEvents={dismissible ? 'auto' : 'none'}
+      >
+        {dismissible ? (
+          <Pressable style={styles.fill} onPress={onClose} accessibilityLabel="Dismiss" />
+        ) : null}
+      </Animated.View>
 
-        <Animated.View
-          style={[
-            styles.card,
-            { paddingBottom: Math.max(insets.bottom, 16), transform: [{ translateY }] },
-            cardStyle,
-          ]}
-          onLayout={(e) => {
-            cardHeight.current = e.nativeEvent.layout.height;
-          }}
-          {...panResponder.panHandlers}
-        >
-          {dismissible ? <View style={styles.handle} /> : null}
-          {children}
-        </Animated.View>
-      </View>
-    </Modal>
+      <Animated.View
+        style={[
+          styles.card,
+          { paddingBottom: Math.max(insets.bottom, 16), transform: [{ translateY }] },
+          cardStyle,
+        ]}
+        onLayout={(e) => {
+          cardHeight.current = e.nativeEvent.layout.height;
+        }}
+        {...panResponder.panHandlers}
+      >
+        {dismissible ? <View style={styles.handle} /> : null}
+        {children}
+      </Animated.View>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
   fill: {
-    flex: 1,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 99999,
+    elevation: 100,
   },
   backdrop: {
     position: 'absolute',

--- a/app/mobile/components/tlsn/BottomSheetCard.tsx
+++ b/app/mobile/components/tlsn/BottomSheetCard.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
+  Modal,
   PanResponder,
   Pressable,
   StyleSheet,
@@ -30,9 +31,11 @@ const SWIPE_DISMISS_THRESHOLD = 80;
 /**
  * A slide-up bottom card with a tappable backdrop and optional swipe-down dismiss.
  *
+ * Rendered inside a React Native Modal so it always sits above the entire view
+ * hierarchy — plugin DomJson z-index values cannot overlap it.
+ *
  * Uses the legacy `Animated` + `PanResponder` API (matching the existing
- * `DraggableView` in PluginRenderer) rather than Reanimated worklets — simpler
- * context, no worklet boundaries, sufficient for this UI.
+ * `DraggableView` in PluginRenderer) rather than Reanimated worklets.
  */
 export function BottomSheetCard({
   visible,
@@ -46,8 +49,14 @@ export function BottomSheetCard({
   const backdropOpacity = useRef(new Animated.Value(0)).current;
   const cardHeight = useRef(0);
 
+  // Keep the Modal mounted until the exit animation finishes so the slide-down
+  // plays before the Modal disappears. Set true immediately when visible becomes
+  // true; set false only in the exit animation's completion callback.
+  const [modalMounted, setModalMounted] = useState(visible);
+
   useEffect(() => {
     if (visible) {
+      setModalMounted(true);
       Animated.parallel([
         Animated.spring(translateY, { ...SPRING_CONFIG, toValue: 0 }),
         Animated.timing(backdropOpacity, {
@@ -68,7 +77,7 @@ export function BottomSheetCard({
           duration: 200,
           useNativeDriver: true,
         }),
-      ]).start();
+      ]).start(() => setModalMounted(false));
     }
   }, [visible, translateY, backdropOpacity]);
 
@@ -94,50 +103,45 @@ export function BottomSheetCard({
     [dismissible, onClose, translateY],
   );
 
-  if (!visible) {
-    // Keep mounted briefly during exit animation by checking translateY's resting state isn't reached.
-    // Simplification: unmount immediately when visible flips false. The exit animation runs but the
-    // tree disappears once visible=false because parent stops rendering the component. Acceptable trade-off.
-  }
-
   return (
-    <View style={styles.fill} pointerEvents={visible ? 'auto' : 'none'}>
-      <Animated.View
-        style={[styles.backdrop, { opacity: backdropOpacity }]}
-        pointerEvents={dismissible ? 'auto' : 'none'}
-      >
-        {dismissible ? (
-          <Pressable style={styles.fill} onPress={onClose} accessibilityLabel="Dismiss" />
-        ) : null}
-      </Animated.View>
+    <Modal
+      transparent
+      visible={modalMounted}
+      onRequestClose={dismissible ? onClose : undefined}
+      statusBarTranslucent
+    >
+      <View style={styles.fill}>
+        <Animated.View
+          style={[styles.backdrop, { opacity: backdropOpacity }]}
+          pointerEvents={dismissible ? 'auto' : 'none'}
+        >
+          {dismissible ? (
+            <Pressable style={styles.fill} onPress={onClose} accessibilityLabel="Dismiss" />
+          ) : null}
+        </Animated.View>
 
-      <Animated.View
-        style={[
-          styles.card,
-          { paddingBottom: Math.max(insets.bottom, 16), transform: [{ translateY }] },
-          cardStyle,
-        ]}
-        onLayout={(e) => {
-          cardHeight.current = e.nativeEvent.layout.height;
-        }}
-        {...panResponder.panHandlers}
-      >
-        {dismissible ? <View style={styles.handle} /> : null}
-        {children}
-      </Animated.View>
-    </View>
+        <Animated.View
+          style={[
+            styles.card,
+            { paddingBottom: Math.max(insets.bottom, 16), transform: [{ translateY }] },
+            cardStyle,
+          ]}
+          onLayout={(e) => {
+            cardHeight.current = e.nativeEvent.layout.height;
+          }}
+          {...panResponder.panHandlers}
+        >
+          {dismissible ? <View style={styles.handle} /> : null}
+          {children}
+        </Animated.View>
+      </View>
+    </Modal>
   );
 }
 
 const styles = StyleSheet.create({
   fill: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: 99999,
-    elevation: 100,
+    flex: 1,
   },
   backdrop: {
     position: 'absolute',

--- a/app/mobile/components/tlsn/BottomSheetCard.tsx
+++ b/app/mobile/components/tlsn/BottomSheetCard.tsx
@@ -136,6 +136,8 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+    zIndex: 99999,
+    elevation: 100,
   },
   backdrop: {
     position: 'absolute',

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -19,9 +19,20 @@ import type {
   ProverOptions,
   ProveResult,
   ProveProgress,
+  RevealPreparation,
+  RevealRangeDescriptor,
 } from '../../modules/tlsn-native/src';
 
-export type { HandlerType, HandlerPart, HandlerAction, HandlerParams, Handler, ProveProgress };
+export type {
+  HandlerType,
+  HandlerPart,
+  HandlerAction,
+  HandlerParams,
+  Handler,
+  ProveProgress,
+  RevealPreparation,
+  RevealRangeDescriptor,
+};
 
 export interface NativeProveParams {
   url: string;
@@ -37,7 +48,20 @@ export interface NativeProveParams {
 }
 
 export interface NativeProverHandle {
+  /**
+   * Legacy one-shot prove (auto-approves the reveal). Kept for callers that
+   * don't need the user-approval gate.
+   */
   prove: (params: NativeProveParams) => Promise<ProveResult>;
+  /**
+   * Phase A: run the protocol up through `compute_reveal`, return descriptors
+   * with real byte previews. Pair with `finalizeReveal`.
+   */
+  prepareReveal: (params: NativeProveParams) => Promise<RevealPreparation>;
+  /**
+   * Phase B: complete or drop the prepared session.
+   */
+  finalizeReveal: (sessionId: string, approved: boolean) => Promise<ProveResult>;
   isReady: boolean;
 }
 
@@ -51,6 +75,11 @@ interface NativeProverProps {
 let TlsnNative: {
   initialize: () => void;
   prove: (request: ProveRequest, options: ProverOptions) => Promise<ProveResult>;
+  proveUntilReveal: (
+    request: ProveRequest,
+    options: ProverOptions,
+  ) => Promise<RevealPreparation>;
+  proveFinalize: (sessionId: string, approved: boolean) => Promise<ProveResult>;
   isAvailable: () => boolean;
   addProgressListener: (callback: (event: ProveProgress) => void) => { remove: () => void };
 } | null = null;
@@ -126,6 +155,22 @@ function NativeProverComponent(
     return () => subscription.remove();
   }, []);
 
+  const buildRequestAndOptions = useCallback((params: NativeProveParams) => {
+    const request: ProveRequest = {
+      url: params.url,
+      method: params.method,
+      headers: params.headers,
+    };
+    const options: ProverOptions = {
+      verifierUrl: params.proverOptions.verifierUrl,
+      maxSentData: params.proverOptions.maxSentData,
+      maxRecvData: params.proverOptions.maxRecvData,
+      handlers: params.proverOptions.handlers || [],
+      mode: params.proverOptions.mode,
+    };
+    return { request, options };
+  }, []);
+
   const prove = useCallback(
     async (params: NativeProveParams): Promise<ProveResult> => {
       const module = getNativeModule();
@@ -133,40 +178,58 @@ function NativeProverComponent(
         throw new Error('Native prover not ready');
       }
 
-      console.log('[NativeProver] Starting proof generation...');
-      console.log('[NativeProver] URL:', params.url);
-
-      const request: ProveRequest = {
-        url: params.url,
-        method: params.method,
-        headers: params.headers,
-      };
-
-      const options: ProverOptions = {
-        verifierUrl: params.proverOptions.verifierUrl,
-        maxSentData: params.proverOptions.maxSentData,
-        maxRecvData: params.proverOptions.maxRecvData,
-        handlers: params.proverOptions.handlers || [],
-        mode: params.proverOptions.mode,
-      };
-
-      console.log(
-        '[NativeProver] Handlers being passed to native:',
-        JSON.stringify(options.handlers, null, 2),
-      );
-      console.log('[NativeProver] Full options:', JSON.stringify(options, null, 2));
-
+      console.log('[NativeProver] Starting one-shot proof for', params.url);
+      const { request, options } = buildRequestAndOptions(params);
       try {
         const result = await module.prove(request, options);
         console.log('[NativeProver] Proof generation complete');
-        console.log('[NativeProver] Transcript:', JSON.stringify(result.transcript));
-        console.log(
-          '[NativeProver] Debug info:',
-          JSON.stringify((result as { debug?: unknown }).debug),
-        );
         return result;
       } catch (e) {
         console.error('[NativeProver] Proof generation failed:', e);
+        throw e;
+      }
+    },
+    [isReady, buildRequestAndOptions],
+  );
+
+  const prepareReveal = useCallback(
+    async (params: NativeProveParams): Promise<RevealPreparation> => {
+      const module = getNativeModule();
+      if (!module || !isReady) {
+        throw new Error('Native prover not ready');
+      }
+
+      console.log('[NativeProver] proveUntilReveal for', params.url);
+      const { request, options } = buildRequestAndOptions(params);
+      try {
+        const prep = await module.proveUntilReveal(request, options);
+        console.log(
+          '[NativeProver] Prepared reveal: session=',
+          prep.sessionId,
+          'descriptors=',
+          prep.descriptors.length,
+        );
+        return prep;
+      } catch (e) {
+        console.error('[NativeProver] proveUntilReveal failed:', e);
+        throw e;
+      }
+    },
+    [isReady, buildRequestAndOptions],
+  );
+
+  const finalizeReveal = useCallback(
+    async (sessionId: string, approved: boolean): Promise<ProveResult> => {
+      const module = getNativeModule();
+      if (!module || !isReady) {
+        throw new Error('Native prover not ready');
+      }
+
+      console.log('[NativeProver] proveFinalize session=', sessionId, 'approved=', approved);
+      try {
+        return await module.proveFinalize(sessionId, approved);
+      } catch (e) {
+        console.error('[NativeProver] proveFinalize failed:', e);
         throw e;
       }
     },
@@ -177,9 +240,11 @@ function NativeProverComponent(
     ref,
     () => ({
       prove,
+      prepareReveal,
+      finalizeReveal,
       isReady,
     }),
-    [prove, isReady],
+    [prove, prepareReveal, finalizeReveal, isReady],
   );
 
   // This component has no UI

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -75,10 +75,7 @@ interface NativeProverProps {
 let TlsnNative: {
   initialize: () => void;
   prove: (request: ProveRequest, options: ProverOptions) => Promise<ProveResult>;
-  proveUntilReveal: (
-    request: ProveRequest,
-    options: ProverOptions,
-  ) => Promise<RevealPreparation>;
+  proveUntilReveal: (request: ProveRequest, options: ProverOptions) => Promise<RevealPreparation>;
   proveFinalize: (sessionId: string, approved: boolean) => Promise<ProveResult>;
   isAvailable: () => boolean;
   addProgressListener: (callback: (event: ProveProgress) => void) => { remove: () => void };

--- a/app/mobile/components/tlsn/PluginApprovalSheet.tsx
+++ b/app/mobile/components/tlsn/PluginApprovalSheet.tsx
@@ -1,11 +1,5 @@
 import React, { useState } from 'react';
-import {
-  ScrollView,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { PluginConfig } from '@tlsn/plugin-sdk';
 import { BottomSheetCard } from './BottomSheetCard';
 
@@ -69,10 +63,7 @@ export function PluginApprovalSheet({
           </View>
         ) : null}
 
-        <TouchableOpacity
-          style={styles.sourceToggle}
-          onPress={() => setSourceExpanded((v) => !v)}
-        >
+        <TouchableOpacity style={styles.sourceToggle} onPress={() => setSourceExpanded((v) => !v)}>
           <Text style={styles.sourceToggleText}>
             {sourceExpanded ? '▾ Hide source' : '▸ View source'}
           </Text>
@@ -80,11 +71,7 @@ export function PluginApprovalSheet({
 
         {sourceExpanded ? (
           <View style={styles.sourceBox}>
-            <ScrollView
-              horizontal
-              style={styles.sourceScroll}
-              showsHorizontalScrollIndicator
-            >
+            <ScrollView horizontal style={styles.sourceScroll} showsHorizontalScrollIndicator>
               <Text style={styles.sourceText}>{pluginCode}</Text>
             </ScrollView>
           </View>
@@ -92,27 +79,20 @@ export function PluginApprovalSheet({
       </ScrollView>
 
       <View style={styles.footer}>
-        <TouchableOpacity
-          style={[styles.button, styles.buttonReject]}
-          onPress={onReject}
-        >
+        <TouchableOpacity style={[styles.button, styles.buttonReject]} onPress={onReject}>
           <Text style={[styles.buttonText, styles.buttonTextReject]}>Reject</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.button, styles.buttonManual]}
           onPress={() => onApprove('manual')}
         >
-          <Text style={[styles.buttonText, styles.buttonTextManual]}>
-            Approve each reveal
-          </Text>
+          <Text style={[styles.buttonText, styles.buttonTextManual]}>Approve each reveal</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={[styles.button, styles.buttonAllSession]}
           onPress={() => onApprove('all-session')}
         >
-          <Text style={[styles.buttonText, styles.buttonTextAllSession]}>
-            Approve all reveals
-          </Text>
+          <Text style={[styles.buttonText, styles.buttonTextAllSession]}>Approve all reveals</Text>
         </TouchableOpacity>
       </View>
     </BottomSheetCard>

--- a/app/mobile/components/tlsn/PluginApprovalSheet.tsx
+++ b/app/mobile/components/tlsn/PluginApprovalSheet.tsx
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import type { PluginConfig } from '@tlsn/plugin-sdk';
+import { BottomSheetCard } from './BottomSheetCard';
+
+/**
+ * Pre-execution approval modes — mirrors the extension's `ApprovalMode`.
+ *
+ * - `manual`     every prove() call shows the reveal-approval sheet
+ * - `all-session` first prove() call shows the sheet; subsequent calls auto-approve
+ * - `rejected`   plugin does not run
+ */
+export type ApprovalMode = 'manual' | 'all-session' | 'rejected';
+
+interface PluginApprovalSheetProps {
+  visible: boolean;
+  pluginConfig: PluginConfig;
+  pluginCode: string;
+  onApprove: (mode: 'manual' | 'all-session') => void;
+  onReject: () => void;
+}
+
+/**
+ * Bottom-sheet card shown before a plugin starts running. The user reviews
+ * name / description / permissions / source and chooses an approval mode.
+ */
+export function PluginApprovalSheet({
+  visible,
+  pluginConfig,
+  pluginCode,
+  onApprove,
+  onReject,
+}: PluginApprovalSheetProps) {
+  const [sourceExpanded, setSourceExpanded] = useState(false);
+
+  const requests = pluginConfig.requests ?? [];
+
+  return (
+    <BottomSheetCard visible={visible} onClose={onReject} dismissible>
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>{pluginConfig.name}</Text>
+        {pluginConfig.version || pluginConfig.author ? (
+          <Text style={styles.byline}>
+            {[pluginConfig.author, pluginConfig.version && `v${pluginConfig.version}`]
+              .filter(Boolean)
+              .join(' • ')}
+          </Text>
+        ) : null}
+        <Text style={styles.description}>{pluginConfig.description}</Text>
+
+        {requests.length > 0 ? (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Will request data from</Text>
+            {requests.map((r, idx) => (
+              <View key={`${r.host}-${idx}`} style={styles.permissionRow}>
+                <Text style={styles.method}>{r.method}</Text>
+                <Text style={styles.host}>
+                  {r.host}
+                  <Text style={styles.path}>{r.pathname}</Text>
+                </Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        <TouchableOpacity
+          style={styles.sourceToggle}
+          onPress={() => setSourceExpanded((v) => !v)}
+        >
+          <Text style={styles.sourceToggleText}>
+            {sourceExpanded ? '▾ Hide source' : '▸ View source'}
+          </Text>
+        </TouchableOpacity>
+
+        {sourceExpanded ? (
+          <View style={styles.sourceBox}>
+            <ScrollView
+              horizontal
+              style={styles.sourceScroll}
+              showsHorizontalScrollIndicator
+            >
+              <Text style={styles.sourceText}>{pluginCode}</Text>
+            </ScrollView>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonReject]}
+          onPress={onReject}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextReject]}>Reject</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonManual]}
+          onPress={() => onApprove('manual')}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextManual]}>
+            Approve each reveal
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonAllSession]}
+          onPress={() => onApprove('all-session')}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextAllSession]}>
+            Approve all reveals
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </BottomSheetCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { maxHeight: 400 },
+  scrollContent: { paddingBottom: 12 },
+  title: { fontSize: 22, fontWeight: '700', color: '#111827' },
+  byline: { fontSize: 13, color: '#6b7280', marginTop: 2 },
+  description: {
+    fontSize: 15,
+    color: '#374151',
+    marginTop: 12,
+    lineHeight: 21,
+  },
+  section: { marginTop: 20 },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  permissionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  method: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#1e40af',
+    backgroundColor: '#dbeafe',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    marginRight: 8,
+    minWidth: 44,
+    textAlign: 'center',
+  },
+  host: { fontSize: 13, color: '#111827', flex: 1 },
+  path: { color: '#6b7280' },
+  sourceToggle: { marginTop: 16, paddingVertical: 6 },
+  sourceToggleText: { fontSize: 14, color: '#2563eb', fontWeight: '500' },
+  sourceBox: {
+    marginTop: 8,
+    backgroundColor: '#f3f4f6',
+    borderRadius: 8,
+    maxHeight: 200,
+  },
+  sourceScroll: { padding: 12 },
+  sourceText: { fontFamily: 'SpaceMono', fontSize: 11, color: '#1f2937' },
+  footer: {
+    flexDirection: 'column',
+    paddingTop: 16,
+    gap: 8,
+  },
+  button: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  buttonText: { fontSize: 15, fontWeight: '600' },
+  buttonReject: { backgroundColor: '#fee2e2' },
+  buttonTextReject: { color: '#991b1b' },
+  buttonManual: { backgroundColor: '#dbeafe' },
+  buttonTextManual: { color: '#1e40af' },
+  buttonAllSession: { backgroundColor: '#d1fae5' },
+  buttonTextAllSession: { color: '#065f46' },
+});

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -2,17 +2,11 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { PluginWebView, InterceptedRequestHeader } from './PluginWebView';
 import { PluginRenderer, DomJson } from './PluginRenderer';
-import {
-  NativeProver,
-  NativeProverHandle,
-  Handler as NativeHandler,
-  ProveProgress,
-} from './NativeProver';
+import { NativeProver, NativeProverHandle, ProveProgress } from './NativeProver';
 import {
   MobilePluginHost,
   PluginConfig,
-  PluginHandler,
-  translateHandlers,
+  NativeHandler,
   EventEmitter,
   WindowMessage,
 } from '../../lib/MobilePluginHost';
@@ -34,28 +28,38 @@ function extractJsonPath(obj: unknown, path: string): string {
 /**
  * Transform native prover result into extension-compatible { results: [{value}] }
  * by applying each handler to extract specific values from the response.
+ *
+ * Operates on handlers in the *native* (PascalCase) format — the same format
+ * that was forwarded to the tlsn-native module to produce `nativeResult`.
  */
 function buildHandlerResults(
-  handlers: PluginHandler[],
+  handlers: NativeHandler[],
   nativeResult: { status: number; headers?: { name: string; value: string }[]; body: unknown },
-): { results: { value: string }[] } {
+): {
+  results: { value: string }[];
+  response: {
+    status: number;
+    headers?: { name: string; value: string }[];
+    body: unknown;
+  };
+} {
   const results: { value: string }[] = [];
 
   for (const handler of handlers) {
-    if (handler.action !== 'REVEAL') continue;
+    if (handler.action.type !== 'Reveal') continue;
     let value = '';
 
-    if (handler.type === 'RECV') {
-      if (handler.part === 'START_LINE') {
+    if (handler.handlerType === 'Recv') {
+      if (handler.part === 'StartLine') {
         value = `HTTP/1.1 ${nativeResult.status}`;
-      } else if (handler.part === 'HEADERS' && handler.params?.key) {
+      } else if (handler.part === 'Headers' && handler.params?.key) {
         const h = nativeResult.headers?.find(
-          (hdr) => hdr.name.toLowerCase() === (handler.params!.key as string).toLowerCase(),
+          (hdr) => hdr.name.toLowerCase() === handler.params!.key!.toLowerCase(),
         );
         if (h) value = `${h.name}: ${h.value}`;
-      } else if (handler.part === 'BODY') {
-        if (handler.params?.type === 'json' && handler.params?.path) {
-          value = extractJsonPath(nativeResult.body, handler.params.path as string);
+      } else if (handler.part === 'Body') {
+        if (handler.params?.contentType === 'json' && handler.params?.path) {
+          value = extractJsonPath(nativeResult.body, handler.params.path);
         } else {
           value =
             typeof nativeResult.body === 'string'
@@ -63,7 +67,7 @@ function buildHandlerResults(
               : JSON.stringify(nativeResult.body);
         }
       }
-    } else if (handler.type === 'SENT' && handler.part === 'START_LINE') {
+    } else if (handler.handlerType === 'Sent' && handler.part === 'StartLine') {
       // Sent start line not available from native result; skip
     }
 
@@ -172,15 +176,9 @@ export function PluginScreen({
           throw new Error('Native prover not ready');
         }
 
-        // Translate handlers from plugin format to native format
-        const nativeHandlers: NativeHandler[] = translateHandlers(proverOptions.handlers || []).map(
-          (h) => ({
-            handlerType: h.handlerType,
-            part: h.part,
-            action: h.action,
-            params: h.params,
-          }),
-        ) as NativeHandler[];
+        // Handlers arrive already translated to the native (PascalCase) format
+        // by MobilePluginHost; forward them as-is.
+        const nativeHandlers = proverOptions.handlers ?? [];
 
         const nativeResult = await proverRef.current.prove({
           url: requestOptions.url,
@@ -190,17 +188,24 @@ export function PluginScreen({
             verifierUrl: verifierUrlRef.current || proverOptions.verifierUrl,
             maxSentData: proverOptions.maxSentData ?? 4096,
             maxRecvData: proverOptions.maxRecvData ?? 16384,
-            handlers: nativeHandlers,
+            // The tlsn-native Handler type is narrower than the broader
+            // shape MobilePluginHost emits, but the native module accepts
+            // the superset — cast through unknown to bridge.
+            handlers: nativeHandlers as unknown as Parameters<
+              typeof proverRef.current.prove
+            >[0]['proverOptions']['handlers'],
             mode: modeRef.current,
           },
         });
 
         // Transform native result into extension-compatible format
-        return buildHandlerResults(proverOptions.handlers || [], nativeResult);
+        return buildHandlerResults(nativeHandlers, nativeResult);
       },
 
       onRenderPluginUi: (_windowId, json) => {
-        setDomJson(json);
+        // Plugin-sdk's DomJson permits 'input' nodes; PluginRenderer renders
+        // only div/button/strings, so unsupported nodes degrade gracefully.
+        setDomJson(json as DomJson);
       },
 
       onOpenWindow: async (url, _options) => {

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -384,9 +384,7 @@ export function PluginScreen({
       {approvalMode === 'rejected' && (
         <View style={styles.rejectedContainer}>
           <Text style={styles.rejectedTitle}>Plugin not running</Text>
-          <Text style={styles.rejectedSubtitle}>
-            You rejected this plugin. No data was sent.
-          </Text>
+          <Text style={styles.rejectedSubtitle}>You rejected this plugin. No data was sent.</Text>
         </View>
       )}
 

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -3,12 +3,16 @@ import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { PluginWebView, InterceptedRequestHeader } from './PluginWebView';
 import { PluginRenderer, DomJson } from './PluginRenderer';
 import { NativeProver, NativeProverHandle, ProveProgress } from './NativeProver';
+import { PluginApprovalSheet, ApprovalMode } from './PluginApprovalSheet';
+import { TimeoutWarningSheet } from './TimeoutWarningSheet';
+import { RevealApprovalSheet } from './RevealApprovalSheet';
 import {
   MobilePluginHost,
   PluginConfig,
   NativeHandler,
   EventEmitter,
   WindowMessage,
+  RevealRangeDescriptor,
 } from '../../lib/MobilePluginHost';
 
 /**
@@ -135,6 +139,22 @@ export function PluginScreen({
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Pre-execution approval gate: null until the user picks a mode.
+  const [approvalMode, setApprovalMode] = useState<ApprovalMode | null>(null);
+
+  // Timeout warning sheet state. Set when HostCore fires onTimeoutWarning.
+  const [timeoutWarning, setTimeoutWarning] = useState<{
+    extend: () => void;
+    dismiss: () => void;
+  } | null>(null);
+
+  // Reveal approval sheet state. Set when wrappedOnProve calls onRevealApproval.
+  const [revealApproval, setRevealApproval] = useState<{
+    descriptors: RevealRangeDescriptor[];
+    approve: () => void;
+    reject: (err: Error) => void;
+  } | null>(null);
+
   const proverRef = useRef<NativeProverHandle>(null);
   const eventEmitterRef = useRef<EventEmitter | null>(null);
   const hostRef = useRef<MobilePluginHost | null>(null);
@@ -167,20 +187,22 @@ export function PluginScreen({
     return emitter;
   }, []);
 
+  // Held across the wrappedOnProve split so the resolved handlers can be
+  // re-applied to the response when phase B returns.
+  const lastNativeHandlersRef = useRef<NativeHandler[]>([]);
+
   // Create host
 
   const host = useMemo(() => {
     const h = new MobilePluginHost({
-      onProve: async (requestOptions, proverOptions) => {
+      onProveUntilReveal: async (requestOptions, proverOptions) => {
         if (!proverRef.current?.isReady) {
           throw new Error('Native prover not ready');
         }
-
-        // Handlers arrive already translated to the native (PascalCase) format
-        // by MobilePluginHost; forward them as-is.
         const nativeHandlers = proverOptions.handlers ?? [];
+        lastNativeHandlersRef.current = nativeHandlers;
 
-        const nativeResult = await proverRef.current.prove({
+        const prep = await proverRef.current.prepareReveal({
           url: requestOptions.url,
           method: requestOptions.method,
           headers: requestOptions.headers,
@@ -188,18 +210,29 @@ export function PluginScreen({
             verifierUrl: verifierUrlRef.current || proverOptions.verifierUrl,
             maxSentData: proverOptions.maxSentData ?? 4096,
             maxRecvData: proverOptions.maxRecvData ?? 16384,
-            // The tlsn-native Handler type is narrower than the broader
-            // shape MobilePluginHost emits, but the native module accepts
-            // the superset — cast through unknown to bridge.
             handlers: nativeHandlers as unknown as Parameters<
-              typeof proverRef.current.prove
+              typeof proverRef.current.prepareReveal
             >[0]['proverOptions']['handlers'],
             mode: modeRef.current,
           },
         });
+        return { sessionId: prep.sessionId, descriptors: prep.descriptors };
+      },
 
-        // Transform native result into extension-compatible format
-        return buildHandlerResults(nativeHandlers, nativeResult);
+      onProveFinalize: async (sessionId, approved) => {
+        if (!proverRef.current?.isReady) {
+          throw new Error('Native prover not ready');
+        }
+        const nativeResult = await proverRef.current.finalizeReveal(sessionId, approved);
+        return buildHandlerResults(lastNativeHandlersRef.current, nativeResult);
+      },
+
+      onRevealApproval: ({ descriptors, approve, reject }) => {
+        setRevealApproval({ descriptors, approve, reject });
+      },
+
+      onTimeoutWarning: (callbacks) => {
+        setTimeoutWarning(callbacks);
       },
 
       onRenderPluginUi: (_windowId, json) => {
@@ -264,10 +297,14 @@ export function PluginScreen({
     [host],
   );
 
-  // Start plugin execution when prover is ready
+  // Start plugin execution once the prover is ready AND the user has approved
+  // execution via the pre-execution approval sheet (modes 'manual' or
+  // 'all-session'). 'rejected' or unset blocks execution.
   useEffect(() => {
     if (!proverReady || isRunning) return;
+    if (approvalMode == null || approvalMode === 'rejected') return;
 
+    host.setApprovalMode(approvalMode);
     setIsRunning(true);
     setError(null);
 
@@ -289,7 +326,7 @@ export function PluginScreen({
     // isRunning is intentionally omitted: it guards against double-starts,
     // and re-running when it flips back to false would start the plugin twice.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [proverReady, pluginCode, eventEmitter, host, onComplete, onError]);
+  }, [proverReady, approvalMode, pluginCode, eventEmitter, host, onComplete, onError]);
 
   return (
     <View style={styles.container}>
@@ -339,6 +376,56 @@ export function PluginScreen({
           <Text style={styles.errorText}>{error}</Text>
         </View>
       )}
+
+      {/* "Plugin rejected" surface — shown after the user picks Reject on the
+          pre-execution approval sheet, in lieu of running the plugin. */}
+      {approvalMode === 'rejected' && (
+        <View style={styles.rejectedContainer}>
+          <Text style={styles.rejectedTitle}>Plugin not running</Text>
+          <Text style={styles.rejectedSubtitle}>
+            You rejected this plugin. No data was sent.
+          </Text>
+        </View>
+      )}
+
+      {/* Pre-execution approval sheet — visible until the user picks a mode.
+          Rendered last so it stacks above the rest. */}
+      <PluginApprovalSheet
+        visible={proverReady && approvalMode == null}
+        pluginConfig={pluginConfig}
+        pluginCode={pluginCode}
+        onApprove={(mode) => setApprovalMode(mode)}
+        onReject={() => setApprovalMode('rejected')}
+      />
+
+      {/* Reveal approval sheet — visible when wrappedOnProve is awaiting user
+          consent for the bytes about to be revealed. */}
+      <RevealApprovalSheet
+        visible={revealApproval != null}
+        descriptors={revealApproval?.descriptors ?? []}
+        onApprove={() => {
+          revealApproval?.approve();
+          setRevealApproval(null);
+        }}
+        onReject={() => {
+          revealApproval?.reject(new Error('User rejected reveal'));
+          setRevealApproval(null);
+        }}
+      />
+
+      {/* Timeout warning sheet — fires ~60s before plugin deadline. */}
+      <TimeoutWarningSheet
+        visible={timeoutWarning != null}
+        initialRemainingMs={60_000}
+        onExtend={() => {
+          timeoutWarning?.extend();
+          setTimeoutWarning(null);
+        }}
+        onDismiss={() => {
+          timeoutWarning?.dismiss();
+          setTimeoutWarning(null);
+        }}
+      />
     </View>
   );
 }
@@ -366,6 +453,28 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: 'rgba(255,255,255,0.9)',
+  },
+  rejectedContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f9fafb',
+    paddingHorizontal: 32,
+  },
+  rejectedTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  rejectedSubtitle: {
+    fontSize: 14,
+    color: '#6b7280',
+    textAlign: 'center',
   },
   loadingText: {
     marginTop: 12,

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -355,8 +355,10 @@ export function PluginScreen({
         </View>
       )}
 
-      {/* Plugin UI overlay */}
-      {domJson && (
+      {/* Plugin UI overlay — hidden while any bottom-sheet gate is active so
+          the sheet (absolute-positioned) is always visually on top without
+          relying on z-index competition against plugin CSS. */}
+      {domJson && revealApproval == null && timeoutWarning == null && (
         <View style={styles.pluginUiContainer}>
           <PluginRenderer domJson={domJson} onPluginAction={handlePluginAction} />
         </View>

--- a/app/mobile/components/tlsn/RevealApprovalSheet.tsx
+++ b/app/mobile/components/tlsn/RevealApprovalSheet.tsx
@@ -46,16 +46,10 @@ export function RevealApprovalSheet({
       </ScrollView>
 
       <View style={styles.footer}>
-        <TouchableOpacity
-          style={[styles.button, styles.buttonReject]}
-          onPress={onReject}
-        >
+        <TouchableOpacity style={[styles.button, styles.buttonReject]} onPress={onReject}>
           <Text style={[styles.buttonText, styles.buttonTextReject]}>Reject</Text>
         </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.button, styles.buttonApprove]}
-          onPress={onApprove}
-        >
+        <TouchableOpacity style={[styles.button, styles.buttonApprove]} onPress={onApprove}>
           <Text style={[styles.buttonText, styles.buttonTextApprove]}>Approve</Text>
         </TouchableOpacity>
       </View>
@@ -63,13 +57,7 @@ export function RevealApprovalSheet({
   );
 }
 
-function DescriptorSection({
-  label,
-  items,
-}: {
-  label: string;
-  items: RevealRangeDescriptor[];
-}) {
+function DescriptorSection({ label, items }: { label: string; items: RevealRangeDescriptor[] }) {
   return (
     <View style={styles.section}>
       <Text style={styles.sectionLabel}>{label}</Text>
@@ -91,26 +79,17 @@ function DescriptorRow({ descriptor }: { descriptor: RevealRangeDescriptor }) {
     <View style={styles.row}>
       <View style={styles.rowHeader}>
         <Text style={styles.rowLabel}>{descriptor.label}</Text>
-        <View
-          style={[
-            styles.badge,
-            isReveal ? styles.badgeReveal : styles.badgeHash,
-          ]}
-        >
+        <View style={[styles.badge, isReveal ? styles.badgeReveal : styles.badgeHash]}>
           <Text
-            style={[
-              styles.badgeText,
-              isReveal ? styles.badgeTextReveal : styles.badgeTextHash,
-            ]}
+            style={[styles.badgeText, isReveal ? styles.badgeTextReveal : styles.badgeTextHash]}
           >
-            {isReveal ? 'REVEAL' : `HASH${descriptor.algorithm ? ' • ' + descriptor.algorithm : ''}`}
+            {isReveal
+              ? 'REVEAL'
+              : `HASH${descriptor.algorithm ? ' • ' + descriptor.algorithm : ''}`}
           </Text>
         </View>
       </View>
-      <Text
-        style={[styles.preview, !isReveal && styles.previewHashed]}
-        numberOfLines={4}
-      >
+      <Text style={[styles.preview, !isReveal && styles.previewHashed]} numberOfLines={4}>
         {preview}
       </Text>
     </View>

--- a/app/mobile/components/tlsn/RevealApprovalSheet.tsx
+++ b/app/mobile/components/tlsn/RevealApprovalSheet.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import type { RevealRangeDescriptor } from '../../modules/tlsn-native/src';
+import { BottomSheetCard } from './BottomSheetCard';
+
+export type { RevealRangeDescriptor };
+
+interface RevealApprovalSheetProps {
+  visible: boolean;
+  descriptors: RevealRangeDescriptor[];
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+const PREVIEW_MAX = 256;
+
+/**
+ * Bottom-sheet shown after `compute_reveal` runs natively but before the
+ * verifier receives reveal data. The user sees a per-range preview of what's
+ * about to be revealed (real bytes) and approves or rejects.
+ *
+ * Backdrop tap or "Reject" both reject the gate.
+ */
+export function RevealApprovalSheet({
+  visible,
+  descriptors,
+  onApprove,
+  onReject,
+}: RevealApprovalSheetProps) {
+  const sent = descriptors.filter((d) => d.direction === 'SENT');
+  const recv = descriptors.filter((d) => d.direction === 'RECV');
+
+  return (
+    <BottomSheetCard visible={visible} onClose={onReject} dismissible>
+      <Text style={styles.title}>Approve reveal to verifier</Text>
+      <Text style={styles.subtitle}>
+        Review what's about to be sent. Anything not listed stays private.
+      </Text>
+
+      <ScrollView style={styles.scroll} contentContainerStyle={styles.scrollContent}>
+        {sent.length > 0 ? <DescriptorSection label="Sent" items={sent} /> : null}
+        {recv.length > 0 ? <DescriptorSection label="Received" items={recv} /> : null}
+        {descriptors.length === 0 ? (
+          <Text style={styles.empty}>No data will be revealed.</Text>
+        ) : null}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonReject]}
+          onPress={onReject}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextReject]}>Reject</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonApprove]}
+          onPress={onApprove}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextApprove]}>Approve</Text>
+        </TouchableOpacity>
+      </View>
+    </BottomSheetCard>
+  );
+}
+
+function DescriptorSection({
+  label,
+  items,
+}: {
+  label: string;
+  items: RevealRangeDescriptor[];
+}) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionLabel}>{label}</Text>
+      {items.map((item, idx) => (
+        <DescriptorRow key={`${label}-${idx}`} descriptor={item} />
+      ))}
+    </View>
+  );
+}
+
+function DescriptorRow({ descriptor }: { descriptor: RevealRangeDescriptor }) {
+  const isReveal = descriptor.action === 'REVEAL';
+  const preview =
+    descriptor.preview.length > PREVIEW_MAX
+      ? descriptor.preview.slice(0, PREVIEW_MAX) + '…'
+      : descriptor.preview;
+
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowHeader}>
+        <Text style={styles.rowLabel}>{descriptor.label}</Text>
+        <View
+          style={[
+            styles.badge,
+            isReveal ? styles.badgeReveal : styles.badgeHash,
+          ]}
+        >
+          <Text
+            style={[
+              styles.badgeText,
+              isReveal ? styles.badgeTextReveal : styles.badgeTextHash,
+            ]}
+          >
+            {isReveal ? 'REVEAL' : `HASH${descriptor.algorithm ? ' • ' + descriptor.algorithm : ''}`}
+          </Text>
+        </View>
+      </View>
+      <Text
+        style={[styles.preview, !isReveal && styles.previewHashed]}
+        numberOfLines={4}
+      >
+        {preview}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: { fontSize: 20, fontWeight: '700', color: '#111827' },
+  subtitle: {
+    fontSize: 13,
+    color: '#6b7280',
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  scroll: { maxHeight: 380 },
+  scrollContent: { paddingVertical: 8 },
+  section: { marginTop: 12 },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#6b7280',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  row: {
+    backgroundColor: '#f9fafb',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  rowLabel: { fontSize: 13, fontWeight: '600', color: '#374151', flex: 1 },
+  badge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    marginLeft: 8,
+  },
+  badgeReveal: { backgroundColor: '#d1fae5' },
+  badgeHash: { backgroundColor: '#fef3c7' },
+  badgeText: { fontSize: 10, fontWeight: '700', letterSpacing: 0.5 },
+  badgeTextReveal: { color: '#065f46' },
+  badgeTextHash: { color: '#92400e' },
+  preview: {
+    fontFamily: 'SpaceMono',
+    fontSize: 11,
+    color: '#1f2937',
+    lineHeight: 16,
+  },
+  previewHashed: { color: '#9ca3af', fontStyle: 'italic' },
+  empty: {
+    fontSize: 14,
+    color: '#6b7280',
+    fontStyle: 'italic',
+    paddingVertical: 16,
+    textAlign: 'center',
+  },
+  footer: {
+    flexDirection: 'row',
+    paddingTop: 16,
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  buttonText: { fontSize: 15, fontWeight: '600' },
+  buttonReject: { backgroundColor: '#fee2e2' },
+  buttonTextReject: { color: '#991b1b' },
+  buttonApprove: { backgroundColor: '#d1fae5' },
+  buttonTextApprove: { color: '#065f46' },
+});

--- a/app/mobile/components/tlsn/TimeoutWarningSheet.tsx
+++ b/app/mobile/components/tlsn/TimeoutWarningSheet.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { BottomSheetCard } from './BottomSheetCard';
+
+interface TimeoutWarningSheetProps {
+  visible: boolean;
+  /** Initial time remaining (ms) when the warning fires. The sheet ticks down on its own. */
+  initialRemainingMs: number;
+  onExtend: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Bottom-sheet warning shown ~60s before plugin deadline. Two buttons:
+ * "Extend 5 minutes" or "Exit now". Non-dismissable — user must choose.
+ */
+export function TimeoutWarningSheet({
+  visible,
+  initialRemainingMs,
+  onExtend,
+  onDismiss,
+}: TimeoutWarningSheetProps) {
+  const [remainingMs, setRemainingMs] = useState(initialRemainingMs);
+
+  useEffect(() => {
+    if (!visible) return;
+    setRemainingMs(initialRemainingMs);
+    const start = Date.now();
+    const id = setInterval(() => {
+      const elapsed = Date.now() - start;
+      setRemainingMs(Math.max(0, initialRemainingMs - elapsed));
+    }, 500);
+    return () => clearInterval(id);
+  }, [visible, initialRemainingMs]);
+
+  const seconds = Math.ceil(remainingMs / 1000);
+  const mm = Math.floor(seconds / 60);
+  const ss = seconds % 60;
+  const display = mm > 0 ? `${mm}:${ss.toString().padStart(2, '0')}` : `${ss}s`;
+
+  return (
+    <BottomSheetCard visible={visible} dismissible={false}>
+      <View style={styles.body}>
+        <Text style={styles.icon}>⏱️</Text>
+        <Text style={styles.title}>Plugin timeout warning</Text>
+        <Text style={styles.subtitle}>
+          This plugin will be terminated in
+          <Text style={styles.countdown}> {display}</Text>
+          {'.'}
+        </Text>
+        <Text style={styles.hint}>
+          Extend the timeout to keep working, or exit now.
+        </Text>
+      </View>
+
+      <View style={styles.footer}>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonDismiss]}
+          onPress={onDismiss}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextDismiss]}>Exit now</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.buttonExtend]}
+          onPress={onExtend}
+        >
+          <Text style={[styles.buttonText, styles.buttonTextExtend]}>
+            Extend 5 minutes
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </BottomSheetCard>
+  );
+}
+
+const styles = StyleSheet.create({
+  body: { alignItems: 'center', paddingTop: 8, paddingBottom: 8 },
+  icon: { fontSize: 48, marginBottom: 12 },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 15,
+    color: '#374151',
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+  countdown: { fontWeight: '700', color: '#b91c1c' },
+  hint: {
+    fontSize: 13,
+    color: '#6b7280',
+    marginTop: 8,
+    textAlign: 'center',
+  },
+  footer: {
+    flexDirection: 'column',
+    paddingTop: 16,
+    gap: 8,
+  },
+  button: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  buttonText: { fontSize: 15, fontWeight: '600' },
+  buttonDismiss: {
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+  },
+  buttonTextDismiss: { color: '#374151' },
+  buttonExtend: { backgroundColor: '#2563eb' },
+  buttonTextExtend: { color: '#ffffff' },
+});

--- a/app/mobile/components/tlsn/TimeoutWarningSheet.tsx
+++ b/app/mobile/components/tlsn/TimeoutWarningSheet.tsx
@@ -24,6 +24,7 @@ export function TimeoutWarningSheet({
 
   useEffect(() => {
     if (!visible) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setRemainingMs(initialRemainingMs);
     const start = Date.now();
     const id = setInterval(() => {
@@ -48,25 +49,15 @@ export function TimeoutWarningSheet({
           <Text style={styles.countdown}> {display}</Text>
           {'.'}
         </Text>
-        <Text style={styles.hint}>
-          Extend the timeout to keep working, or exit now.
-        </Text>
+        <Text style={styles.hint}>Extend the timeout to keep working, or exit now.</Text>
       </View>
 
       <View style={styles.footer}>
-        <TouchableOpacity
-          style={[styles.button, styles.buttonDismiss]}
-          onPress={onDismiss}
-        >
+        <TouchableOpacity style={[styles.button, styles.buttonDismiss]} onPress={onDismiss}>
           <Text style={[styles.buttonText, styles.buttonTextDismiss]}>Exit now</Text>
         </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.button, styles.buttonExtend]}
-          onPress={onExtend}
-        >
-          <Text style={[styles.buttonText, styles.buttonTextExtend]}>
-            Extend 5 minutes
-          </Text>
+        <TouchableOpacity style={[styles.button, styles.buttonExtend]} onPress={onExtend}>
+          <Text style={[styles.buttonText, styles.buttonTextExtend]}>Extend 5 minutes</Text>
         </TouchableOpacity>
       </View>
     </BottomSheetCard>

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -201,12 +201,6 @@ export class MobilePluginHost {
     windowId: number,
     header: InterceptedRequestHeader,
   ): void {
-    console.log(
-      '[MobilePluginHost] emitHeaderIntercepted windowId=',
-      windowId,
-      'url=',
-      header.url,
-    );
     eventEmitter.emit({ type: 'HEADER_INTERCEPTED', header, windowId });
   }
 

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -1,137 +1,57 @@
 /**
  * MobilePluginHost
  *
- * Analogous to the extension's Host class (packages/plugin-sdk/src/index.ts),
- * but designed for React Native. Uses native QuickJS (via quickjs-native Expo module)
- * instead of WASM-based @sebastianwessel/quickjs.
+ * Thin React Native adapter over `HostCore` from `@tlsn/plugin-sdk/host-core`.
  *
- * Responsibilities:
- * 1. Create QuickJS sandbox context via native module
- * 2. Inject plugin capability functions (prove, openWindow, div, button, hooks)
- * 3. Evaluate plugin code in the sandbox
- * 4. Handle callbacks when sandbox calls host functions
- * 5. Manage execution context (state store, hooks, event handling)
- * 6. Translate handler formats between plugin-sdk and mobile native
+ * The plugin engine itself (hooks, reactive main loop, state store, lifecycle,
+ * reveal approval, …) lives in HostCore. This file only handles the things
+ * specific to the mobile environment:
+ *
+ *   1. Picking the JS evaluator — `NativeFunctionEvaluator` (Hermes-safe;
+ *      no QuickJS WASM since Hermes lacks the WASM features the WASM build
+ *      depends on).
+ *   2. Wiring the host callbacks (onProve / onRenderPluginUi / openWindow /
+ *      closeWindow) supplied by the React layer.
+ *   3. Translating canonical plugin-sdk handlers to the PascalCase shape the
+ *      tlsn-native module expects, before invoking native prove().
+ *   4. Forwarding native progress events into the running plugin via the
+ *      `onProgress` callback HostCore exposes through `onProve`.
  */
 
-// Simple unique ID generator — avoids the `uuid` package which requires
-// crypto.getRandomValues() (unavailable in Hermes).
-let _idCounter = 0;
-function uuidv4(): string {
-  _idCounter++;
-  const ts = Date.now().toString(36);
-  const rand = Math.random().toString(36).substring(2, 10);
-  return `${ts}-${rand}-${_idCounter}`;
-}
+import { HostCore, NativeFunctionEvaluator } from '@tlsn/plugin-sdk/host-core';
+import type {
+  Handler,
+  DomJson,
+  WindowMessage,
+  InterceptedRequestHeader,
+  InterceptedRequest,
+  ProveProgressData,
+  RevealRangeDescriptor,
+} from '@tlsn/plugin-sdk';
 
-// ============================================================================
-// Types (mirrors plugin-sdk types, avoids importing plugin-sdk + its WASM deps)
-// ============================================================================
+import { translateHandler, type NativeHandler } from './handlerTranslation';
 
-export type DomOptions = {
-  className?: string;
-  id?: string;
-  style?: Record<string, string>;
-  onclick?: string;
-};
+// Re-export translation helpers and the native handler type so existing
+// callers (PluginScreen) can continue importing them from here.
+export { translateHandler, translateHandlers, type NativeHandler } from './handlerTranslation';
 
-export type DomJson =
-  | {
-      type: 'div' | 'button';
-      options: DomOptions;
-      children: DomJson[];
-    }
-  | string;
+// Re-export types used by other mobile modules so consumers don't need to
+// reach into @tlsn/plugin-sdk directly.
+export type {
+  DomJson,
+  DomOptions,
+  Handler,
+  Handler as PluginHandler,
+  InterceptedRequest,
+  InterceptedRequestHeader,
+  PluginConfig,
+  WindowMessage,
+} from '@tlsn/plugin-sdk';
 
-export interface InterceptedRequest {
-  id: string;
-  method: string;
-  url: string;
-  timestamp: number;
-  tabId: number;
-  requestBody?: unknown;
-}
-
-export interface InterceptedRequestHeader {
-  id: string;
-  method: string;
-  url: string;
-  timestamp: number;
-  type: string;
-  requestHeaders: { name: string; value?: string }[];
-  tabId: number;
-}
-
-/**
- * Plugin-sdk handler format (SCREAMING_SNAKE_CASE).
- *
- * The `action` field accepts either the `'REVEAL'` string shorthand or the
- * canonical object form. Plugin-sdk's `prove()` wrapper canonicalizes before
- * handing handlers to the host; the mobile host also tolerates the shorthand
- * defensively since it runs plugin code outside of plugin-sdk.
- */
-export interface PluginHandler {
-  type: 'SENT' | 'RECV';
-  part:
-    | 'START_LINE'
-    | 'PROTOCOL'
-    | 'METHOD'
-    | 'REQUEST_TARGET'
-    | 'STATUS_CODE'
-    | 'HEADERS'
-    | 'BODY'
-    | 'ALL';
-  action:
-    | 'REVEAL'
-    | { kind: 'REVEAL' }
-    | { kind: 'HASH'; algorithm: 'BLAKE3' | 'SHA256' | 'KECCAK256' };
-  params?: Record<string, unknown>;
-}
-
-/** Mobile native handler format (PascalCase) */
-export interface NativeHandler {
-  handlerType: 'Sent' | 'Recv';
-  part:
-    | 'StartLine'
-    | 'Protocol'
-    | 'Method'
-    | 'RequestTarget'
-    | 'StatusCode'
-    | 'Headers'
-    | 'Body'
-    | 'All';
-  action: { type: 'Reveal' } | { type: 'Hash'; algorithm: 'Blake3' | 'Sha256' | 'Keccak256' };
-  params?: {
-    key?: string;
-    hideKey?: boolean;
-    hideValue?: boolean;
-    contentType?: string;
-    path?: string;
-    regex?: string;
-    flags?: string;
-  };
-}
-
-export interface PluginConfig {
-  name: string;
-  description: string;
-  version?: string;
-  author?: string;
-  requests?: {
-    method: string;
-    host: string;
-    pathname: string;
-  }[];
-  urls?: string[];
-  oauthHosts?: string[];
-}
-
-export type WindowMessage =
-  | { type: 'HEADER_INTERCEPTED'; header: InterceptedRequestHeader; windowId: number }
-  | { type: 'REQUEST_INTERCEPTED'; request: InterceptedRequest; windowId: number }
-  | { type: 'PLUGIN_UI_CLICK'; onclick: string; windowId: number }
-  | { type: 'WINDOW_CLOSED'; windowId: number }
-  | { type: 'RE_RENDER_PLUGIN_UI'; windowId: number };
+// ---------------------------------------------------------------------------
+// EventEmitter shape — mobile owns its emitter implementation, so we just
+// describe the interface HostCore consumes.
+// ---------------------------------------------------------------------------
 
 type EventListener = (message: WindowMessage) => void;
 
@@ -141,559 +61,136 @@ export interface EventEmitter {
   emit: (message: WindowMessage) => void;
 }
 
-interface ExecutionContext {
-  id: string;
-  plugin: string;
-  requests: InterceptedRequest[];
-  headers: InterceptedRequestHeader[];
-  windowId: number;
-  context: Record<string, { effects: unknown[][]; selectors: unknown[][] }>;
-  currentContext: string;
-  stateStore: Record<string, unknown>;
-  main: (force?: boolean) => DomJson | null;
-  callbacks: Record<string, () => Promise<void>>;
+// ---------------------------------------------------------------------------
+// MobilePluginHost options — accepts handlers in the *native* format. The
+// host translates the plugin-sdk format to the native format internally.
+// ---------------------------------------------------------------------------
+
+interface NativeProverOptions {
+  verifierUrl: string;
+  proxyUrl: string;
+  maxRecvData?: number;
+  maxSentData?: number;
+  handlers: NativeHandler[];
 }
-
-// ============================================================================
-// Handler format translation
-// ============================================================================
-
-const HANDLER_TYPE_MAP: Record<string, 'Sent' | 'Recv'> = {
-  SENT: 'Sent',
-  RECV: 'Recv',
-};
-
-const HANDLER_PART_MAP: Record<string, NativeHandler['part']> = {
-  START_LINE: 'StartLine',
-  PROTOCOL: 'Protocol',
-  METHOD: 'Method',
-  REQUEST_TARGET: 'RequestTarget',
-  STATUS_CODE: 'StatusCode',
-  HEADERS: 'Headers',
-  BODY: 'Body',
-  ALL: 'All',
-};
-
-const ALGORITHM_MAP: Record<string, 'Blake3' | 'Sha256' | 'Keccak256'> = {
-  BLAKE3: 'Blake3',
-  SHA256: 'Sha256',
-  KECCAK256: 'Keccak256',
-};
-
-function translateAction(handler: PluginHandler): NativeHandler['action'] {
-  const action =
-    typeof handler.action === 'string' ? ({ kind: handler.action } as const) : handler.action;
-  if (action.kind === 'HASH') {
-    return {
-      type: 'Hash',
-      algorithm: ALGORITHM_MAP[action.algorithm],
-    };
-  }
-  return { type: 'Reveal' };
-}
-
-export function translateHandler(handler: PluginHandler): NativeHandler {
-  const result: NativeHandler = {
-    handlerType: HANDLER_TYPE_MAP[handler.type] || 'Sent',
-    part: HANDLER_PART_MAP[handler.part] || 'StartLine',
-    action: translateAction(handler),
-  };
-
-  if (handler.params) {
-    result.params = {};
-    if (handler.params.key) result.params.key = handler.params.key as string;
-    if (handler.params.hideKey) result.params.hideKey = handler.params.hideKey as boolean;
-    if (handler.params.hideValue) result.params.hideValue = handler.params.hideValue as boolean;
-    if (handler.params.path) result.params.path = handler.params.path as string;
-    if (handler.params.regex) result.params.regex = handler.params.regex as string;
-    if (handler.params.flags) result.params.flags = handler.params.flags as string;
-    // Plugin uses params.type: 'json', native uses params.contentType: 'json'
-    if (handler.params.type) result.params.contentType = handler.params.type as string;
-  }
-
-  return result;
-}
-
-export function translateHandlers(handlers: PluginHandler[]): NativeHandler[] {
-  return handlers.map(translateHandler);
-}
-
-// ============================================================================
-// Execution context registry (same pattern as plugin-sdk)
-// ============================================================================
-
-const contextRegistry = new Map<string, ExecutionContext>();
-
-function updateContext(uuid: string, updates: Partial<ExecutionContext>): void {
-  const ctx = contextRegistry.get(uuid);
-  if (!ctx) throw new Error('Execution context not found: ' + uuid);
-  contextRegistry.set(uuid, { ...ctx, ...updates });
-}
-
-// ============================================================================
-// Hook factories (equivalent to plugin-sdk's makeUseEffect, makeUseHeaders, etc.)
-// ============================================================================
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (a === null || b === null) return false;
-  if (typeof a !== typeof b) return false;
-  if (typeof a !== 'object') return false;
-
-  const aObj = a as Record<string, unknown>;
-  const bObj = b as Record<string, unknown>;
-  const aKeys = Object.keys(aObj);
-  const bKeys = Object.keys(bObj);
-  if (aKeys.length !== bKeys.length) return false;
-
-  for (const key of aKeys) {
-    if (!deepEqual(aObj[key], bObj[key])) return false;
-  }
-  return true;
-}
-
-function createDomJson(
-  type: 'div' | 'button',
-  param1: DomOptions | DomJson[] = {},
-  param2: DomJson[] = [],
-): DomJson {
-  let options: DomOptions = {};
-  let children: DomJson[] = [];
-  if (Array.isArray(param1)) {
-    children = param1;
-  } else if (typeof param1 === 'object') {
-    options = param1;
-    children = param2;
-  }
-  return { type, options, children };
-}
-
-function makeUseEffect(
-  uuid: string,
-  hookContext: Record<string, { effects: unknown[][]; selectors: unknown[][] }>,
-) {
-  return (effect: () => void, deps: unknown[]) => {
-    const ctx = contextRegistry.get(uuid);
-    if (!ctx) throw new Error('Execution context not found');
-    const fnName = ctx.currentContext;
-    hookContext[fnName] = hookContext[fnName] || { effects: [], selectors: [] };
-    const effects = hookContext[fnName].effects;
-    const lastDeps = ctx.context[fnName]?.effects[effects.length];
-    effects.push(deps);
-    if (deepEqual(lastDeps, deps)) return;
-    effect();
-  };
-}
-
-function makeUseRequests(
-  uuid: string,
-  hookContext: Record<string, { effects: unknown[][]; selectors: unknown[][] }>,
-) {
-  return (filterFn: (requests: InterceptedRequest[]) => InterceptedRequest[]) => {
-    const ctx = contextRegistry.get(uuid);
-    if (!ctx) throw new Error('Execution context not found');
-    const fnName = ctx.currentContext;
-    hookContext[fnName] = hookContext[fnName] || { effects: [], selectors: [] };
-    const requests = JSON.parse(JSON.stringify(ctx.requests || []));
-    const result = filterFn(requests);
-    hookContext[fnName].selectors.push(result);
-    return result;
-  };
-}
-
-function makeUseHeaders(
-  uuid: string,
-  hookContext: Record<string, { effects: unknown[][]; selectors: unknown[][] }>,
-) {
-  return (filterFn: (headers: InterceptedRequestHeader[]) => InterceptedRequestHeader[]) => {
-    const ctx = contextRegistry.get(uuid);
-    if (!ctx) throw new Error('Execution context not found');
-    const fnName = ctx.currentContext;
-    hookContext[fnName] = hookContext[fnName] || { effects: [], selectors: [] };
-    const headers = JSON.parse(JSON.stringify(ctx.headers || []));
-    const result = filterFn(headers);
-    if (!Array.isArray(result)) {
-      throw new Error('useHeaders: filter function must return an array');
-    }
-    hookContext[fnName].selectors.push(result);
-    return result;
-  };
-}
-
-function makeUseState(uuid: string, stateStore: Record<string, unknown>) {
-  return (key: string, defaultValue: unknown) => {
-    if (stateStore[key] === undefined && defaultValue !== undefined) {
-      stateStore[key] = defaultValue;
-    }
-    return stateStore[key];
-  };
-}
-
-function makeSetState(
-  uuid: string,
-  stateStore: Record<string, unknown>,
-  eventEmitter: EventEmitter,
-) {
-  return (key: string, value: unknown) => {
-    const ctx = contextRegistry.get(uuid);
-    if (!ctx) throw new Error('Execution context not found');
-    const oldStore = { ...stateStore };
-    stateStore[key] = value;
-    if (deepEqual(oldStore, stateStore)) return;
-    // Defer re-render to avoid recursive main() calls when setState is
-    // called from within main(). Without this, the recursive main(true)
-    // renders the correct UI, but then the original main() overwrites it
-    // with stale domJson (where the local variable still had the old value).
-    queueMicrotask(() => {
-      eventEmitter.emit({
-        type: 'RE_RENDER_PLUGIN_UI',
-        windowId: ctx.windowId || 0,
-      });
-    });
-  };
-}
-
-// ============================================================================
-// MobilePluginHost
-// ============================================================================
 
 interface MobilePluginHostOptions {
   /**
-   * Called when the plugin calls prove(requestOptions, proverOptions).
-   * The host should translate handlers and call tlsn-native.
+   * Called when the plugin invokes prove(). Receives handlers in the *native*
+   * (PascalCase) format ready to forward to the tlsn-native module.
    */
   onProve: (
     requestOptions: { url: string; method: string; headers: Record<string, string>; body?: string },
-    proverOptions: {
-      verifierUrl: string;
-      proxyUrl: string;
-      maxRecvData?: number;
-      maxSentData?: number;
-      handlers: PluginHandler[];
-    },
+    proverOptions: NativeProverOptions,
   ) => Promise<unknown>;
 
-  /** Called when the plugin renders UI (DomJson) */
+  /** Called when the plugin renders UI. */
   onRenderPluginUi: (windowId: number, domJson: DomJson) => void;
 
-  /** Called when the plugin calls openWindow(url, options) */
+  /** Called when the plugin opens a managed window. */
   onOpenWindow: (
     url: string,
     options?: { width?: number; height?: number; showOverlay?: boolean },
   ) => Promise<{ windowId: number; uuid: string; tabId: number }>;
 
-  /** Called when the plugin calls done() or closes a window */
+  /** Called when the plugin completes or the host needs to close the window. */
   onCloseWindow: (windowId: number) => void;
 }
 
-/**
- * MobilePluginHost executes plugin code and provides host capabilities.
- *
- * Currently uses direct function evaluation (no sandbox).
- * Phase 1 (QuickJS native module) will add true sandbox isolation.
- *
- * The key insight: plugin code exports functions (main, onClick, etc.) and
- * uses globals (div, button, prove, useState, etc.) that the host provides.
- * This class provides those globals and manages the execution lifecycle.
- */
+// ---------------------------------------------------------------------------
+// MobilePluginHost
+// ---------------------------------------------------------------------------
+
 export class MobilePluginHost {
-  private onProve: MobilePluginHostOptions['onProve'];
-  private onRenderPluginUi: MobilePluginHostOptions['onRenderPluginUi'];
-  private onOpenWindow: MobilePluginHostOptions['onOpenWindow'];
-  private onCloseWindow: MobilePluginHostOptions['onCloseWindow'];
-
-  // References to the active execution's state, used by setProveProgress()
-  private _activeStateStore: Record<string, unknown> | null = null;
-  private _activeEventEmitter: EventEmitter | null = null;
-  private _activeUuid: string | null = null;
-
-  constructor(options: MobilePluginHostOptions) {
-    this.onProve = options.onProve;
-    this.onRenderPluginUi = options.onRenderPluginUi;
-    this.onOpenWindow = options.onOpenWindow;
-    this.onCloseWindow = options.onCloseWindow;
-  }
+  private core: HostCore;
 
   /**
-   * Update the _proveProgress state from an external source (e.g. native progress events).
-   * This triggers a UI re-render so the plugin's progress bar updates.
+   * Captured by the onProve wrapper so external native progress events
+   * (delivered via setProveProgress) can be routed back into the running
+   * plugin's UI state.
    */
-  setProveProgress(data: { step: string; progress: number; message: string } | null): void {
-    if (!this._activeStateStore || !this._activeEventEmitter || !this._activeUuid) return;
-    this._activeStateStore['_proveProgress'] = data;
-    const ctx = contextRegistry.get(this._activeUuid);
-    this._activeEventEmitter.emit({
-      type: 'RE_RENDER_PLUGIN_UI',
-      windowId: ctx?.windowId || 0,
+  private _activeOnProgress: ((step: string, progress: number, message: string) => void) | null =
+    null;
+
+  constructor(options: MobilePluginHostOptions) {
+    const wrappedOnProve = async (
+      requestOptions: {
+        url: string;
+        method: string;
+        headers: Record<string, string>;
+        body?: string;
+      },
+      proverOptions: {
+        verifierUrl: string;
+        proxyUrl: string;
+        maxRecvData?: number;
+        maxSentData?: number;
+        handlers: Handler[];
+      },
+      onProgress?: (data: ProveProgressData) => void,
+    ): Promise<unknown> => {
+      this._activeOnProgress = onProgress
+        ? (step: string, progress: number, message: string) =>
+            onProgress({ step, progress, message })
+        : null;
+      try {
+        const nativeHandlers = (proverOptions.handlers ?? []).map(translateHandler);
+        return await options.onProve(requestOptions, {
+          verifierUrl: proverOptions.verifierUrl,
+          proxyUrl: proverOptions.proxyUrl,
+          maxRecvData: proverOptions.maxRecvData,
+          maxSentData: proverOptions.maxSentData,
+          handlers: nativeHandlers,
+        });
+      } finally {
+        this._activeOnProgress = null;
+      }
+    };
+
+    this.core = new HostCore({
+      evaluator: new NativeFunctionEvaluator(),
+      reRenderEvent: 'RE_RENDER_PLUGIN_UI',
+      enableTimeout: false,
+      onProve: wrappedOnProve,
+      onRenderPluginUi: options.onRenderPluginUi,
+      onOpenWindow: async (url, opts) => {
+        const response = await options.onOpenWindow(url, opts);
+        return {
+          type: 'WINDOW_OPENED',
+          payload: response,
+        };
+      },
+      onCloseWindow: options.onCloseWindow,
     });
   }
 
-  private _clearActiveRefs(): void {
-    this._activeStateStore = null;
-    this._activeEventEmitter = null;
-    this._activeUuid = null;
+  /**
+   * Push a progress update from the native prover into the active plugin.
+   *
+   * The mobile layer subscribes to native progress events on the tlsn-native
+   * module and forwards them here. While a prove() call is in flight, this
+   * routes through the `onProgress` callback HostCore wired into the prove
+   * pipeline (which updates `_proveProgress` in the plugin's state store and
+   * triggers a UI re-render). Outside of an active prove() call, this is a
+   * no-op.
+   */
+  setProveProgress(data: { step: string; progress: number; message: string } | null): void {
+    if (this._activeOnProgress && data) {
+      this._activeOnProgress(data.step, data.progress, data.message);
+    }
   }
 
   /**
    * Execute a plugin in the host environment.
    *
-   * This evaluates the plugin code, injects capabilities, calls main(),
-   * and returns a promise that resolves when the plugin calls done().
+   * Resolves with the value the plugin passes to `done()`, or rejects when
+   * the plugin throws or terminates abnormally.
    */
   async executePlugin(
     code: string,
     { eventEmitter }: { eventEmitter: EventEmitter },
   ): Promise<unknown> {
-    const uuid = uuidv4();
-    const hookContext: Record<string, { effects: unknown[][]; selectors: unknown[][] }> = {};
-    const stateStore: Record<string, unknown> = {};
-
-    // Store references so setProveProgress() can update state externally
-    this._activeStateStore = stateStore;
-    this._activeEventEmitter = eventEmitter;
-    this._activeUuid = uuid;
-
-    let doneResolve: (result?: unknown) => void;
-    let doneReject: (error: Error) => void;
-    let isCompleted = false;
-
-    const donePromise = new Promise((resolve, reject) => {
-      doneResolve = resolve;
-      doneReject = reject;
-    });
-
-    const onCloseWindow = this.onCloseWindow;
-    const onRenderPluginUi = this.onRenderPluginUi;
-    const onOpenWindow = this.onOpenWindow;
-    const onProve = this.onProve;
-
-    // Build the capability globals that plugin code expects
-    const capabilities = {
-      div: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
-        createDomJson('div', param1, param2),
-      button: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
-        createDomJson('button', param1, param2),
-      openWindow: async (
-        url: string,
-        options?: { width?: number; height?: number; showOverlay?: boolean },
-      ) => {
-        const response = await onOpenWindow(url, options);
-        updateContext(uuid, { windowId: response.windowId });
-
-        // Set up message listener for this window
-        const onMessage = async (message: WindowMessage) => {
-          if (message.type === 'WINDOW_CLOSED') {
-            eventEmitter.removeListener(onMessage);
-            return;
-          }
-
-          const ctx = contextRegistry.get(uuid);
-          if (!ctx) {
-            eventEmitter.removeListener(onMessage);
-            return;
-          }
-
-          if ('windowId' in message && message.windowId !== ctx.windowId) return;
-
-          try {
-            if (message.type === 'REQUEST_INTERCEPTED') {
-              updateContext(uuid, {
-                requests: [...(ctx.requests || []), message.request],
-              });
-              ctx.main();
-            }
-            if (message.type === 'HEADER_INTERCEPTED') {
-              updateContext(uuid, {
-                headers: [...(ctx.headers || []), message.header],
-              });
-              ctx.main();
-            }
-            if (message.type === 'PLUGIN_UI_CLICK') {
-              const cb = ctx.callbacks[message.onclick];
-              if (cb) {
-                updateContext(uuid, { currentContext: message.onclick });
-                await cb();
-                if (contextRegistry.has(uuid)) {
-                  updateContext(uuid, { currentContext: '' });
-                }
-              }
-            }
-            if (message.type === 'RE_RENDER_PLUGIN_UI') {
-              ctx.main(true);
-            }
-          } catch (error) {
-            console.error(`[MobilePluginHost] Error handling message ${message.type}:`, error);
-            eventEmitter.removeListener(onMessage);
-          }
-        };
-
-        eventEmitter.addListener(onMessage);
-        return response;
-      },
-      useEffect: makeUseEffect(uuid, hookContext),
-      useRequests: makeUseRequests(uuid, hookContext),
-      useHeaders: makeUseHeaders(uuid, hookContext),
-      useState: makeUseState(uuid, stateStore),
-      setState: makeSetState(uuid, stateStore, eventEmitter),
-      prove: async (
-        requestOptions: Parameters<MobilePluginHostOptions['onProve']>[0],
-        proverOptions: Parameters<MobilePluginHostOptions['onProve']>[1],
-      ) => {
-        // Native progress events update _proveProgress via setProveProgress().
-        // The wrapper only handles COMPLETE and error cleanup.
-        try {
-          const result = await onProve(requestOptions, proverOptions);
-          stateStore['_proveProgress'] = { step: 'COMPLETE', progress: 1, message: 'Complete' };
-          eventEmitter.emit({
-            type: 'RE_RENDER_PLUGIN_UI',
-            windowId: contextRegistry.get(uuid)?.windowId || 0,
-          });
-          return result;
-        } catch (err) {
-          stateStore['_proveProgress'] = null;
-          eventEmitter.emit({
-            type: 'RE_RENDER_PLUGIN_UI',
-            windowId: contextRegistry.get(uuid)?.windowId || 0,
-          });
-          throw err;
-        }
-      },
-      done: (result?: unknown) => {
-        if (isCompleted) return;
-        isCompleted = true;
-        const ctx = contextRegistry.get(uuid);
-        if (ctx?.windowId) onCloseWindow(ctx.windowId);
-        contextRegistry.delete(uuid);
-        this._clearActiveRefs();
-        doneResolve(result);
-      },
-      doneWithOverlay: (result?: unknown) => {
-        if (isCompleted) return;
-        isCompleted = true;
-        const ctx = contextRegistry.get(uuid);
-        if (ctx?.windowId) onCloseWindow(ctx.windowId);
-        contextRegistry.delete(uuid);
-        this._clearActiveRefs();
-        doneResolve(result);
-      },
-    };
-
-    // Evaluate the plugin code.
-    //
-    // NOTE: This currently uses Function() constructor (no sandbox isolation).
-    // Phase 1 (QuickJS native Expo module) will replace this with true sandboxed
-    // evaluation via the native QuickJS C engine.
-    let exportedCode: Record<string, unknown>;
-    try {
-      exportedCode = evaluatePluginCode(code, capabilities);
-    } catch (evalError) {
-      const error = evalError instanceof Error ? evalError : new Error(String(evalError));
-      this._clearActiveRefs();
-      doneReject!(new Error(`Plugin evaluation failed: ${error.message}`));
-      return donePromise;
-    }
-
-    const { main: mainFn, ...otherExports } = exportedCode;
-
-    if (typeof mainFn !== 'function') {
-      this._clearActiveRefs();
-      doneReject!(new Error('Main function not found in plugin'));
-      return donePromise;
-    }
-
-    // Collect callback functions (onClick, expandUI, minimizeUI, etc.)
-    const callbacks: Record<string, () => Promise<void>> = {};
-    for (const key in otherExports) {
-      if (typeof otherExports[key] === 'function') {
-        callbacks[key] = otherExports[key] as () => Promise<void>;
-      }
-    }
-
-    let lastJson: DomJson | null = null;
-
-    const main = (force = false) => {
-      try {
-        updateContext(uuid, { currentContext: 'main' });
-
-        let result = (mainFn as () => DomJson)();
-        const lastSelectors = contextRegistry.get(uuid)?.context['main']?.selectors;
-        const selectors = hookContext['main']?.selectors;
-        const lastStateStore = contextRegistry.get(uuid)?.stateStore;
-
-        if (
-          !force &&
-          deepEqual(lastSelectors, selectors) &&
-          deepEqual(lastStateStore, stateStore)
-        ) {
-          result = null as unknown as DomJson;
-        }
-
-        updateContext(uuid, {
-          currentContext: '',
-          context: {
-            ...contextRegistry.get(uuid)?.context,
-            main: {
-              effects: JSON.parse(JSON.stringify(hookContext['main']?.effects || [])),
-              selectors: JSON.parse(JSON.stringify(hookContext['main']?.selectors || [])),
-            },
-          },
-          stateStore: JSON.parse(JSON.stringify(stateStore)),
-        });
-
-        if (hookContext['main']) {
-          hookContext['main'].effects.length = 0;
-          hookContext['main'].selectors.length = 0;
-        }
-
-        if (result) {
-          lastJson = result;
-          // Wait for windowId to be set before rendering
-          const ctx = contextRegistry.get(uuid);
-          if (ctx?.windowId) {
-            onRenderPluginUi(ctx.windowId, lastJson);
-          } else {
-            // Queue render for when window opens
-            waitForWindow(() => contextRegistry.get(uuid)?.windowId).then((windowId) => {
-              if (windowId && lastJson) {
-                onRenderPluginUi(windowId, lastJson);
-              }
-            });
-          }
-        }
-
-        return result;
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        if (!isCompleted) {
-          isCompleted = true;
-          const ctx = contextRegistry.get(uuid);
-          if (ctx?.windowId) onCloseWindow(ctx.windowId);
-          contextRegistry.delete(uuid);
-          this._clearActiveRefs();
-          doneReject!(new Error(`Plugin main() error: ${err.message}`));
-        }
-        return null;
-      }
-    };
-
-    // Register execution context
-    contextRegistry.set(uuid, {
-      id: uuid,
-      plugin: code,
-      requests: [],
-      headers: [],
-      windowId: 0,
-      context: {},
-      currentContext: '',
-      stateStore: {},
-      main,
-      callbacks,
-    });
-
-    // Run initial main()
-    main();
-
-    return donePromise;
+    return this.core.executePlugin(code, { eventEmitter });
   }
 
   /**
@@ -704,71 +201,36 @@ export class MobilePluginHost {
     windowId: number,
     header: InterceptedRequestHeader,
   ): void {
-    eventEmitter.emit({
-      type: 'HEADER_INTERCEPTED',
-      header,
-      windowId,
-    });
+    eventEmitter.emit({ type: 'HEADER_INTERCEPTED', header, windowId });
   }
 
   /**
-   * Dispatch a plugin UI button click.
+   * Feed an intercepted request into a running plugin's execution context.
+   */
+  emitRequestIntercepted(
+    eventEmitter: EventEmitter,
+    windowId: number,
+    request: InterceptedRequest,
+  ): void {
+    eventEmitter.emit({ type: 'REQUEST_INTERCEPTED', request, windowId });
+  }
+
+  /**
+   * Dispatch a plugin UI button click into the running plugin.
    */
   emitPluginAction(eventEmitter: EventEmitter, windowId: number, onclick: string): void {
-    eventEmitter.emit({
-      type: 'PLUGIN_UI_CLICK',
-      onclick,
-      windowId,
-    });
+    eventEmitter.emit({ type: 'PLUGIN_UI_CLICK', onclick, windowId });
   }
-}
 
-// ============================================================================
-// Plugin code evaluation
-// ============================================================================
-
-/**
- * Evaluate plugin code with injected capabilities.
- *
- * TEMPORARY: Uses Function() constructor (no sandbox).
- * Will be replaced with native QuickJS evaluation in Phase 1.
- */
-function evaluatePluginCode(
-  code: string,
-  capabilities: Record<string, unknown>,
-): Record<string, unknown> {
-  // Build the preamble that makes capabilities available as globals
-  const capabilityNames = Object.keys(capabilities);
-  const preamble = capabilityNames
-    .map((name) => `const ${name} = __capabilities__.${name};`)
-    .join('\n');
-
-  // The plugin code ends with `export default { config, main, onClick, ... }`
-  // We need to capture that. Transform the export to a return.
-  const transformedCode = code
-    .replace(/export\s+default\s+/, 'return ')
-    // Also handle: export { main, onClick, ... }
-    .replace(/export\s*\{[^}]+\}\s*;?/g, '');
-
-  const wrappedCode = `
-    ${preamble}
-    ${transformedCode}
-  `;
-
-  const fn = new Function('__capabilities__', wrappedCode);
-  return fn(capabilities);
-}
-
-// ============================================================================
-// Utilities
-// ============================================================================
-
-async function waitForWindow(getter: () => number | undefined, retry = 0): Promise<number | null> {
-  const value = getter();
-  if (value) return value;
-  if (retry < 100) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return waitForWindow(getter, retry + 1);
+  /**
+   * Register a pending reveal-approval gate. Resolves once the user clicks
+   * Approve in the overlay; rejects on Reject.
+   */
+  registerRevealApproval(
+    resolve: () => void,
+    reject: (err: Error) => void,
+    descriptors: RevealRangeDescriptor[],
+  ): void {
+    this.core.registerRevealApproval(resolve, reject, descriptors);
   }
-  return null;
 }

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -26,8 +26,13 @@ import type {
   InterceptedRequestHeader,
   InterceptedRequest,
   ProveProgressData,
-  RevealRangeDescriptor,
+  RevealRangeDescriptor as PluginSdkRevealRangeDescriptor,
 } from '@tlsn/plugin-sdk';
+// Mobile reveal-approval descriptors come from the native two-phase prove
+// (with real transcript byte previews), so we use the native type — distinct
+// from plugin-sdk's RevealRangeDescriptor which uses SCREAMING_SNAKE_CASE
+// algorithm names.
+import type { RevealRangeDescriptor } from '../modules/tlsn-native/src';
 
 import { translateHandler, type NativeHandler } from './handlerTranslation';
 
@@ -47,6 +52,8 @@ export type {
   PluginConfig,
   WindowMessage,
 } from '@tlsn/plugin-sdk';
+
+export type { RevealRangeDescriptor } from '../modules/tlsn-native/src';
 
 // ---------------------------------------------------------------------------
 // EventEmitter shape — mobile owns its emitter implementation, so we just
@@ -74,15 +81,37 @@ interface NativeProverOptions {
   handlers: NativeHandler[];
 }
 
+/**
+ * Pre-execution approval modes — mirrors the extension's `ApprovalMode` and
+ * the plugin-approval bottom sheet. Set via `setApprovalMode()` after the
+ * user picks one. Must be set before the plugin's first `prove()` call.
+ */
+export type ApprovalMode = 'manual' | 'all-session' | 'rejected';
+
+interface RevealApprovalRequest {
+  descriptors: RevealRangeDescriptor[];
+  approve: () => void;
+  reject: (err: Error) => void;
+}
+
 interface MobilePluginHostOptions {
   /**
-   * Called when the plugin invokes prove(). Receives handlers in the *native*
+   * Phase A of the prove split. Called when the plugin invokes prove().
+   * Should run the native prover up through `compute_reveal` and return
+   * the descriptors + opaque session id. Receives handlers in the *native*
    * (PascalCase) format ready to forward to the tlsn-native module.
    */
-  onProve: (
+  onProveUntilReveal: (
     requestOptions: { url: string; method: string; headers: Record<string, string>; body?: string },
     proverOptions: NativeProverOptions,
-  ) => Promise<unknown>;
+  ) => Promise<{ sessionId: string; descriptors: RevealRangeDescriptor[] }>;
+
+  /**
+   * Phase B of the prove split. Approve or reject the session prepared by
+   * `onProveUntilReveal`. On approve, returns the proof result. On reject,
+   * rejects with "User rejected reveal".
+   */
+  onProveFinalize: (sessionId: string, approved: boolean) => Promise<unknown>;
 
   /** Called when the plugin renders UI. */
   onRenderPluginUi: (windowId: number, domJson: DomJson) => void;
@@ -95,6 +124,22 @@ interface MobilePluginHostOptions {
 
   /** Called when the plugin completes or the host needs to close the window. */
   onCloseWindow: (windowId: number) => void;
+
+  /**
+   * Called when HostCore's timeout interval fires its 60-second warning.
+   * The platform should show its own UI; resolve via `extend` (push the
+   * deadline back 5 minutes) or `dismiss` (treat as user-acknowledged but
+   * let the deadline run out).
+   */
+  onTimeoutWarning?: (callbacks: { extend: () => void; dismiss: () => void }) => void;
+
+  /**
+   * Called from the prove pipeline (between `onProveUntilReveal` and
+   * `onProveFinalize`) when the user must approve the reveal. The platform
+   * shows its own UI; resolve `approve()` to continue, or `reject(err)` to
+   * abort. If unset, all reveals are auto-approved.
+   */
+  onRevealApproval?: (request: RevealApprovalRequest) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,7 +157,22 @@ export class MobilePluginHost {
   private _activeOnProgress: ((step: string, progress: number, message: string) => void) | null =
     null;
 
+  /** Set by `setApprovalMode()` after the plugin-approval sheet resolves. */
+  private _approvalMode: ApprovalMode = 'manual';
+
+  /**
+   * Tracks whether the user has already approved at least one reveal in this
+   * plugin run. Combined with `_approvalMode === 'all-session'`, suppresses
+   * the reveal sheet for subsequent prove() calls.
+   */
+  private _sessionRevealApproved = false;
+
+  /** External callback to display the reveal-approval sheet. */
+  private _onRevealApproval?: MobilePluginHostOptions['onRevealApproval'];
+
   constructor(options: MobilePluginHostOptions) {
+    this._onRevealApproval = options.onRevealApproval;
+
     const wrappedOnProve = async (
       requestOptions: {
         url: string;
@@ -133,15 +193,45 @@ export class MobilePluginHost {
         ? (step: string, progress: number, message: string) =>
             onProgress({ step, progress, message })
         : null;
+
       try {
         const nativeHandlers = (proverOptions.handlers ?? []).map(translateHandler);
-        return await options.onProve(requestOptions, {
+        const nativeProverOptions: NativeProverOptions = {
           verifierUrl: proverOptions.verifierUrl,
           proxyUrl: proverOptions.proxyUrl,
           maxRecvData: proverOptions.maxRecvData,
           maxSentData: proverOptions.maxSentData,
           handlers: nativeHandlers,
-        });
+        };
+
+        // Phase A: run the protocol up through compute_reveal natively.
+        const prep = await options.onProveUntilReveal(requestOptions, nativeProverOptions);
+
+        // Decide whether the user must approve this reveal.
+        const skipApprovalGate =
+          this._approvalMode === 'all-session' && this._sessionRevealApproved;
+
+        let approved = true;
+        if (!skipApprovalGate && this._onRevealApproval) {
+          try {
+            await new Promise<void>((resolve, reject) => {
+              this._onRevealApproval!({
+                descriptors: prep.descriptors,
+                approve: resolve,
+                reject,
+              });
+            });
+            this._sessionRevealApproved = true;
+          } catch (e) {
+            approved = false;
+            // Surface the rejection up-stack after we drop the native session.
+            void options.onProveFinalize(prep.sessionId, false).catch(() => {});
+            throw e instanceof Error ? e : new Error(String(e));
+          }
+        }
+
+        // Phase B: complete the proof.
+        return await options.onProveFinalize(prep.sessionId, approved);
       } finally {
         this._activeOnProgress = null;
       }
@@ -150,7 +240,8 @@ export class MobilePluginHost {
     this.core = new HostCore({
       evaluator: new NativeFunctionEvaluator(),
       reRenderEvent: 'RE_RENDER_PLUGIN_UI',
-      enableTimeout: false,
+      enableTimeout: true,
+      onTimeoutWarning: options.onTimeoutWarning,
       onProve: wrappedOnProve,
       onRenderPluginUi: options.onRenderPluginUi,
       onOpenWindow: async (url, opts) => {
@@ -162,6 +253,17 @@ export class MobilePluginHost {
       },
       onCloseWindow: options.onCloseWindow,
     });
+  }
+
+  /**
+   * Set the approval mode chosen on the pre-execution approval sheet.
+   * Must be called before the plugin's first prove() call. Setting
+   * `'rejected'` is informational on this side (the caller is expected to
+   * not start the plugin at all in that case).
+   */
+  setApprovalMode(mode: ApprovalMode): void {
+    this._approvalMode = mode;
+    this._sessionRevealApproved = false;
   }
 
   /**
@@ -223,13 +325,15 @@ export class MobilePluginHost {
   }
 
   /**
-   * Register a pending reveal-approval gate. Resolves once the user clicks
-   * Approve in the overlay; rejects on Reject.
+   * Legacy: register a pending reveal-approval gate via HostCore's DomJson
+   * overlay (used by extension parity). Mobile's native flow uses the
+   * `onRevealApproval` constructor option instead, which renders a real
+   * native bottom sheet with byte-level previews.
    */
   registerRevealApproval(
     resolve: () => void,
     reject: (err: Error) => void,
-    descriptors: RevealRangeDescriptor[],
+    descriptors: PluginSdkRevealRangeDescriptor[],
   ): void {
     this.core.registerRevealApproval(resolve, reject, descriptors);
   }

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -160,13 +160,6 @@ export class MobilePluginHost {
   /** Set by `setApprovalMode()` after the plugin-approval sheet resolves. */
   private _approvalMode: ApprovalMode = 'manual';
 
-  /**
-   * Tracks whether the user has already approved at least one reveal in this
-   * plugin run. Combined with `_approvalMode === 'all-session'`, suppresses
-   * the reveal sheet for subsequent prove() calls.
-   */
-  private _sessionRevealApproved = false;
-
   /** External callback to display the reveal-approval sheet. */
   private _onRevealApproval?: MobilePluginHostOptions['onRevealApproval'];
 
@@ -208,8 +201,7 @@ export class MobilePluginHost {
         const prep = await options.onProveUntilReveal(requestOptions, nativeProverOptions);
 
         // Decide whether the user must approve this reveal.
-        const skipApprovalGate =
-          this._approvalMode === 'all-session' && this._sessionRevealApproved;
+        const skipApprovalGate = this._approvalMode === 'all-session';
 
         let approved = true;
         if (!skipApprovalGate && this._onRevealApproval) {
@@ -221,7 +213,6 @@ export class MobilePluginHost {
                 reject,
               });
             });
-            this._sessionRevealApproved = true;
           } catch (e) {
             approved = false;
             // Surface the rejection up-stack after we drop the native session.
@@ -263,7 +254,6 @@ export class MobilePluginHost {
    */
   setApprovalMode(mode: ApprovalMode): void {
     this._approvalMode = mode;
-    this._sessionRevealApproved = false;
   }
 
   /**

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -201,6 +201,12 @@ export class MobilePluginHost {
     windowId: number,
     header: InterceptedRequestHeader,
   ): void {
+    console.log(
+      '[MobilePluginHost] emitHeaderIntercepted windowId=',
+      windowId,
+      'url=',
+      header.url,
+    );
     eventEmitter.emit({ type: 'HEADER_INTERCEPTED', header, windowId });
   }
 

--- a/app/mobile/lib/handlerTranslation.ts
+++ b/app/mobile/lib/handlerTranslation.ts
@@ -1,0 +1,105 @@
+/**
+ * Handler format translation
+ *
+ * Plugin-sdk uses canonical SCREAMING_SNAKE_CASE handler descriptors
+ * (`type: 'SENT' | 'RECV'`, `part: 'START_LINE' | …`, `action: 'REVEAL' | { kind: 'HASH', algorithm }`).
+ *
+ * The mobile native module (Rust/Kotlin/Swift) uses PascalCase enum variants
+ * (`handlerType: 'Sent' | 'Recv'`, `part: 'StartLine' | …`, `action: { type: 'Reveal' } | { type: 'Hash', algorithm }`).
+ *
+ * This module bridges those two representations.
+ */
+
+import type { Handler } from '@tlsn/plugin-sdk';
+
+/**
+ * Mobile native handler format (PascalCase).
+ *
+ * Mirrors the broader shape accepted by the native side, including the
+ * subset of params used by current plugins. The `tlsn-native` package
+ * exports a narrower `Handler` type; this superset is what we hand to
+ * the native module after translation.
+ */
+export interface NativeHandler {
+  handlerType: 'Sent' | 'Recv';
+  part:
+    | 'StartLine'
+    | 'Protocol'
+    | 'Method'
+    | 'RequestTarget'
+    | 'StatusCode'
+    | 'Headers'
+    | 'Body'
+    | 'All';
+  action: { type: 'Reveal' } | { type: 'Hash'; algorithm: 'Blake3' | 'Sha256' | 'Keccak256' };
+  params?: {
+    key?: string;
+    hideKey?: boolean;
+    hideValue?: boolean;
+    contentType?: string;
+    path?: string;
+    regex?: string;
+    flags?: string;
+  };
+}
+
+const HANDLER_TYPE_MAP: Record<string, 'Sent' | 'Recv'> = {
+  SENT: 'Sent',
+  RECV: 'Recv',
+};
+
+const HANDLER_PART_MAP: Record<string, NativeHandler['part']> = {
+  START_LINE: 'StartLine',
+  PROTOCOL: 'Protocol',
+  METHOD: 'Method',
+  REQUEST_TARGET: 'RequestTarget',
+  STATUS_CODE: 'StatusCode',
+  HEADERS: 'Headers',
+  BODY: 'Body',
+  ALL: 'All',
+};
+
+const ALGORITHM_MAP: Record<string, 'Blake3' | 'Sha256' | 'Keccak256'> = {
+  BLAKE3: 'Blake3',
+  SHA256: 'Sha256',
+  KECCAK256: 'Keccak256',
+};
+
+function translateAction(handler: Handler): NativeHandler['action'] {
+  const action =
+    typeof handler.action === 'string' ? ({ kind: handler.action } as const) : handler.action;
+  if (action.kind === 'HASH') {
+    return {
+      type: 'Hash',
+      algorithm: ALGORITHM_MAP[action.algorithm],
+    };
+  }
+  return { type: 'Reveal' };
+}
+
+export function translateHandler(handler: Handler): NativeHandler {
+  const result: NativeHandler = {
+    handlerType: HANDLER_TYPE_MAP[handler.type] || 'Sent',
+    part: HANDLER_PART_MAP[handler.part] || 'StartLine',
+    action: translateAction(handler),
+  };
+
+  const params = (handler as { params?: Record<string, unknown> }).params;
+  if (params) {
+    result.params = {};
+    if (params.key) result.params.key = params.key as string;
+    if (params.hideKey) result.params.hideKey = params.hideKey as boolean;
+    if (params.hideValue) result.params.hideValue = params.hideValue as boolean;
+    if (params.path) result.params.path = params.path as string;
+    if (params.regex) result.params.regex = params.regex as string;
+    if (params.flags) result.params.flags = params.flags as string;
+    // Plugin uses params.type: 'json' | 'regex'; native uses params.contentType.
+    if (params.type) result.params.contentType = params.type as string;
+  }
+
+  return result;
+}
+
+export function translateHandlers(handlers: Handler[]): NativeHandler[] {
+  return handlers.map(translateHandler);
+}

--- a/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
+++ b/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
@@ -76,11 +76,18 @@ private fun parseProverOptions(optionsObj: JSONObject): ProverOptions {
         }
     }
 
+    val mode: Mode? = when (optionsObj.optString("mode", "")) {
+        "Mpc" -> Mode.MPC
+        "Proxy" -> Mode.PROXY
+        else -> null
+    }
+
     return ProverOptions(
         verifierUrl = verifierUrl,
         maxSentData = maxSentData,
         maxRecvData = maxRecvData,
-        handlers = handlers
+        handlers = handlers,
+        mode = mode
     )
 }
 

--- a/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
+++ b/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
@@ -14,8 +14,12 @@ import uniffi.tlsn_mobile.HandlerAction
 import uniffi.tlsn_mobile.HandlerParams
 import uniffi.tlsn_mobile.HashAlgorithm
 import uniffi.tlsn_mobile.ProgressCallback
+import uniffi.tlsn_mobile.ProofResult
+import uniffi.tlsn_mobile.RevealPreparation
 import uniffi.tlsn_mobile.initialize as rustInitialize
 import uniffi.tlsn_mobile.prove as rustProve
+import uniffi.tlsn_mobile.proveUntilReveal as rustProveUntilReveal
+import uniffi.tlsn_mobile.proveFinalize as rustProveFinalize
 import org.json.JSONObject
 import org.json.JSONArray
 
@@ -37,6 +41,160 @@ private fun jsonToNative(value: Any?): Any? = when (value) {
     }
     JSONObject.NULL -> null
     else -> value
+}
+
+private fun parseHttpRequest(requestObj: JSONObject): HttpRequest {
+    val url = requestObj.optString("url", "")
+    val method = requestObj.optString("method", "")
+
+    val headers = mutableListOf<HttpHeader>()
+    val headersJsonObj = requestObj.optJSONObject("headers")
+    if (headersJsonObj != null) {
+        for (name in headersJsonObj.keys()) {
+            headers.add(HttpHeader(name, headersJsonObj.getString(name)))
+        }
+    }
+
+    val body: String? = if (requestObj.has("body") && !requestObj.isNull("body")) {
+        requestObj.getString("body")
+    } else null
+
+    return HttpRequest(url = url, method = method, headers = headers, body = body)
+}
+
+private fun parseProverOptions(optionsObj: JSONObject): ProverOptions {
+    val verifierUrl = optionsObj.optString("verifierUrl", "")
+    val maxSentData = optionsObj.optInt("maxSentData", 4096).toUInt()
+    val maxRecvData = optionsObj.optInt("maxRecvData", 16384).toUInt()
+
+    val handlers = mutableListOf<Handler>()
+    val handlersArray = optionsObj.optJSONArray("handlers")
+    if (handlersArray != null) {
+        for (index in 0 until handlersArray.length()) {
+            val handlerObj = handlersArray.getJSONObject(index)
+            parseHandler(handlerObj)?.let { handlers.add(it) }
+        }
+    }
+
+    return ProverOptions(
+        verifierUrl = verifierUrl,
+        maxSentData = maxSentData,
+        maxRecvData = maxRecvData,
+        handlers = handlers
+    )
+}
+
+private fun parseHandler(handlerObj: JSONObject): Handler? {
+    val handlerTypeStr = handlerObj.optString("handlerType", "")
+    val partStr = handlerObj.optString("part", "")
+    val actionObj = handlerObj.optJSONObject("action") ?: return null
+    val actionType = actionObj.optString("type", "")
+
+    if (handlerTypeStr.isEmpty() || partStr.isEmpty() || actionType.isEmpty()) return null
+
+    val handlerType = when (handlerTypeStr) {
+        "Sent" -> HandlerType.SENT
+        "Recv" -> HandlerType.RECV
+        else -> return null
+    }
+
+    val part = when (partStr) {
+        "StartLine" -> HandlerPart.START_LINE
+        "Protocol" -> HandlerPart.PROTOCOL
+        "Method" -> HandlerPart.METHOD
+        "RequestTarget" -> HandlerPart.REQUEST_TARGET
+        "StatusCode" -> HandlerPart.STATUS_CODE
+        "Headers" -> HandlerPart.HEADERS
+        "Body" -> HandlerPart.BODY
+        "All" -> HandlerPart.ALL
+        else -> return null
+    }
+
+    val action: HandlerAction = when (actionType) {
+        "Reveal" -> HandlerAction.Reveal
+        "Hash" -> {
+            val algoStr = actionObj.optString("algorithm", "")
+            val algorithm = when (algoStr) {
+                "Blake3" -> HashAlgorithm.BLAKE3
+                "Sha256" -> HashAlgorithm.SHA256
+                "Keccak256" -> HashAlgorithm.KECCAK256
+                else -> return null
+            }
+            HandlerAction.Hash(algorithm)
+        }
+        else -> return null
+    }
+
+    val paramsObj = handlerObj.optJSONObject("params")
+    val params = if (paramsObj != null) {
+        HandlerParams(
+            key = if (paramsObj.has("key")) paramsObj.optString("key") else null,
+            hideKey = if (paramsObj.has("hideKey")) paramsObj.optBoolean("hideKey") else null,
+            hideValue = if (paramsObj.has("hideValue")) paramsObj.optBoolean("hideValue") else null,
+            contentType = if (paramsObj.has("contentType")) paramsObj.optString("contentType") else null,
+            path = if (paramsObj.has("path")) paramsObj.optString("path") else null,
+            regex = if (paramsObj.has("regex")) paramsObj.optString("regex") else null,
+            flags = if (paramsObj.has("flags")) paramsObj.optString("flags") else null
+        )
+    } else null
+
+    return Handler(handlerType, part, action, params)
+}
+
+private fun proofResultToMap(result: ProofResult, handlersPassed: Int): Map<String, Any> {
+    val responseHeaders = result.response.headers.map { header ->
+        mapOf("name" to header.name, "value" to header.value)
+    }
+
+    val bodyJson: Any = try {
+        jsonToNative(JSONObject(result.response.body))!!
+    } catch (_: Exception) {
+        try { jsonToNative(JSONArray(result.response.body))!! } catch (_: Exception) { result.response.body }
+    }
+
+    return mapOf(
+        "status" to result.response.status.toInt(),
+        "headers" to responseHeaders,
+        "body" to bodyJson,
+        "transcript" to mapOf(
+            "sentLength" to result.transcript.sent.size,
+            "recvLength" to result.transcript.recv.size
+        ),
+        "debug" to mapOf(
+            "handlersPassedToRust" to handlersPassed,
+            "handlersReceivedByRust" to result.handlersReceived.toInt()
+        )
+    )
+}
+
+private fun revealPreparationToMap(prep: RevealPreparation): Map<String, Any> {
+    val responseHeaders = prep.response.headers.map { h ->
+        mapOf("name" to h.name, "value" to h.value)
+    }
+    val bodyJson: Any = try {
+        jsonToNative(JSONObject(prep.response.body))!!
+    } catch (_: Exception) {
+        try { jsonToNative(JSONArray(prep.response.body))!! } catch (_: Exception) { prep.response.body }
+    }
+    val descriptors = prep.descriptors.map { d ->
+        val entry = mutableMapOf<String, Any>(
+            "direction" to d.direction,
+            "label" to d.label,
+            "action" to d.action,
+            "preview" to d.preview
+        )
+        d.algorithm?.let { entry["algorithm"] = it }
+        entry
+    }
+    return mapOf(
+        "sessionId" to prep.sessionId,
+        "response" to mapOf(
+            "status" to prep.response.status.toInt(),
+            "headers" to responseHeaders,
+            "body" to bodyJson
+        ),
+        "descriptors" to descriptors
+    )
 }
 
 class TlsnNativeModule : Module() {
@@ -228,6 +386,61 @@ class TlsnNativeModule : Module() {
 
                     promise.resolve(resultMap)
 
+                } catch (e: uniffi.tlsn_mobile.TlsnException) {
+                    promise.reject("TlsnError", "$e", null)
+                } catch (e: Exception) {
+                    promise.reject("UnknownError", e.localizedMessage, null)
+                }
+            }.start()
+        }
+
+        // Phase A: prove until reveal — JSON-string args (Android bridge ergonomics).
+        AsyncFunction("proveUntilReveal") { requestJson: String, optionsJson: String, promise: Promise ->
+            Thread {
+                try {
+                    val request = parseHttpRequest(JSONObject(requestJson))
+                    val options = parseProverOptions(JSONObject(optionsJson))
+                    if (request.url.isEmpty()) {
+                        return@Thread promise.reject("InvalidRequest", "Missing url", null)
+                    }
+                    if (options.verifierUrl.isEmpty()) {
+                        return@Thread promise.reject("InvalidOptions", "Missing verifierUrl", null)
+                    }
+
+                    val progressCallback = object : ProgressCallback {
+                        override fun onProgress(step: String, progress: Double, message: String) {
+                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
+                                "step" to step, "progress" to progress, "message" to message
+                            ))
+                        }
+                    }
+
+                    val prep = rustProveUntilReveal(request, options, progressCallback)
+                    android.util.Log.i("TlsnNative",
+                        "proveUntilReveal complete: session=${prep.sessionId} descriptors=${prep.descriptors.size}")
+                    promise.resolve(revealPreparationToMap(prep))
+                } catch (e: uniffi.tlsn_mobile.TlsnException) {
+                    promise.reject("TlsnError", "$e", null)
+                } catch (e: Exception) {
+                    promise.reject("UnknownError", e.localizedMessage, null)
+                }
+            }.start()
+        }
+
+        // Phase B: finalize the prove (or drop it).
+        AsyncFunction("proveFinalize") { sessionId: String, approved: Boolean, promise: Promise ->
+            Thread {
+                try {
+                    val progressCallback = object : ProgressCallback {
+                        override fun onProgress(step: String, progress: Double, message: String) {
+                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
+                                "step" to step, "progress" to progress, "message" to message
+                            ))
+                        }
+                    }
+
+                    val result = rustProveFinalize(sessionId, approved, progressCallback)
+                    promise.resolve(proofResultToMap(result, -1))
                 } catch (e: uniffi.tlsn_mobile.TlsnException) {
                     promise.reject("TlsnError", "$e", null)
                 } catch (e: Exception) {

--- a/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
+++ b/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
@@ -76,10 +76,15 @@ private fun parseProverOptions(optionsObj: JSONObject): ProverOptions {
         }
     }
 
-    val mode: Mode? = when (optionsObj.optString("mode", "")) {
+    val modeStr = optionsObj.optString("mode", "")
+    val mode: Mode? = when (modeStr) {
         "Mpc" -> Mode.MPC
         "Proxy" -> Mode.PROXY
-        else -> null
+        "" -> null
+        else -> {
+            android.util.Log.w("TlsnNative", "unknown mode '$modeStr', defaulting to Mpc")
+            null
+        }
     }
 
     return ProverOptions(
@@ -205,6 +210,16 @@ private fun revealPreparationToMap(prep: RevealPreparation): Map<String, Any> {
 }
 
 class TlsnNativeModule : Module() {
+    private fun makeProgressCallback(): ProgressCallback = object : ProgressCallback {
+        override fun onProgress(step: String, progress: Double, message: String) {
+            sendEvent("onProveProgress", mapOf(
+                "step" to step,
+                "progress" to progress,
+                "message" to message
+            ))
+        }
+    }
+
     override fun definition() = ModuleDefinition {
         Name("TlsnNative")
 
@@ -220,178 +235,24 @@ class TlsnNativeModule : Module() {
         AsyncFunction("prove") { requestJson: String, optionsJson: String, promise: Promise ->
             Thread {
                 try {
-                    val requestObj = JSONObject(requestJson)
-                    val optionsObj = JSONObject(optionsJson)
-
-                    // Parse HTTP request
-                    val url = requestObj.optString("url", "")
-                        .ifEmpty { return@Thread promise.reject("InvalidRequest", "Missing url", null) }
-                    val method = requestObj.optString("method", "")
-                        .ifEmpty { return@Thread promise.reject("InvalidRequest", "Missing method", null) }
-
-                    val headers = mutableListOf<HttpHeader>()
-                    val headersJsonObj = requestObj.optJSONObject("headers")
-                    if (headersJsonObj != null) {
-                        for (name in headersJsonObj.keys()) {
-                            headers.add(HttpHeader(name, headersJsonObj.getString(name)))
-                        }
+                    val request = parseHttpRequest(JSONObject(requestJson))
+                    val options = parseProverOptions(JSONObject(optionsJson))
+                    if (request.url.isEmpty()) {
+                        return@Thread promise.reject("InvalidRequest", "Missing url", null)
+                    }
+                    if (request.method.isEmpty()) {
+                        return@Thread promise.reject("InvalidRequest", "Missing method", null)
+                    }
+                    if (options.verifierUrl.isEmpty()) {
+                        return@Thread promise.reject("InvalidOptions", "Missing verifierUrl", null)
                     }
 
-                    val body: String? = if (requestObj.has("body") && !requestObj.isNull("body")) {
-                        requestObj.getString("body")
-                    } else null
-
-                    val request = HttpRequest(
-                        url = url,
-                        method = method,
-                        headers = headers,
-                        body = body
-                    )
-
-                    // Parse prover options
-                    val verifierUrl = optionsObj.optString("verifierUrl", "")
-                        .ifEmpty { return@Thread promise.reject("InvalidOptions", "Missing verifierUrl", null) }
-
-                    val maxSentData = optionsObj.optInt("maxSentData", 4096).toUInt()
-                    val maxRecvData = optionsObj.optInt("maxRecvData", 16384).toUInt()
-
-                    // Parse handlers for selective disclosure
-                    val handlers = mutableListOf<Handler>()
-                    val handlersArray = optionsObj.optJSONArray("handlers")
-
-                    if (handlersArray != null) {
-                        for (index in 0 until handlersArray.length()) {
-                            val handlerObj = handlersArray.getJSONObject(index)
-                            val handlerTypeStr = handlerObj.optString("handlerType", "")
-                            val partStr = handlerObj.optString("part", "")
-                            val actionObj = handlerObj.optJSONObject("action") ?: continue
-                            val actionType = actionObj.optString("type", "")
-
-                            if (handlerTypeStr.isEmpty() || partStr.isEmpty() || actionType.isEmpty()) continue
-
-                            val handlerType = when (handlerTypeStr) {
-                                "Sent" -> HandlerType.SENT
-                                "Recv" -> HandlerType.RECV
-                                else -> continue
-                            }
-
-                            val part = when (partStr) {
-                                "StartLine" -> HandlerPart.START_LINE
-                                "Protocol" -> HandlerPart.PROTOCOL
-                                "Method" -> HandlerPart.METHOD
-                                "RequestTarget" -> HandlerPart.REQUEST_TARGET
-                                "StatusCode" -> HandlerPart.STATUS_CODE
-                                "Headers" -> HandlerPart.HEADERS
-                                "Body" -> HandlerPart.BODY
-                                "All" -> HandlerPart.ALL
-                                else -> continue
-                            }
-
-                            val action: HandlerAction = when (actionType) {
-                                "Reveal" -> HandlerAction.Reveal
-                                "Hash" -> {
-                                    val algoStr = actionObj.optString("algorithm", "")
-                                    val algorithm = when (algoStr) {
-                                        "Blake3" -> HashAlgorithm.BLAKE3
-                                        "Sha256" -> HashAlgorithm.SHA256
-                                        "Keccak256" -> HashAlgorithm.KECCAK256
-                                        else -> continue
-                                    }
-                                    HandlerAction.Hash(algorithm)
-                                }
-                                else -> continue
-                            }
-
-                            val paramsObj = handlerObj.optJSONObject("params")
-                            val params = if (paramsObj != null) {
-                                HandlerParams(
-                                    key = if (paramsObj.has("key")) paramsObj.optString("key") else null,
-                                    hideKey = if (paramsObj.has("hideKey")) paramsObj.optBoolean("hideKey") else null,
-                                    hideValue = if (paramsObj.has("hideValue")) paramsObj.optBoolean("hideValue") else null,
-                                    contentType = if (paramsObj.has("contentType")) paramsObj.optString("contentType") else null,
-                                    path = if (paramsObj.has("path")) paramsObj.optString("path") else null,
-                                    regex = if (paramsObj.has("regex")) paramsObj.optString("regex") else null,
-                                    flags = if (paramsObj.has("flags")) paramsObj.optString("flags") else null
-                                )
-                            } else {
-                                null
-                            }
-
-                            handlers.add(Handler(handlerType, part, action, params))
-                            android.util.Log.i("TlsnNative", "Handler $index: type=$handlerTypeStr, part=$partStr, action=$actionType")
-                        }
-                    }
-
-                    android.util.Log.i("TlsnNative", "Final handlers count: ${handlers.size}")
-
-                    // Parse optional protocol mode (default Mpc).
-                    val mode: Mode? = when (optionsObj.optString("mode", "")) {
-                        "Mpc" -> Mode.MPC
-                        "Proxy" -> Mode.PROXY
-                        "" -> null
-                        else -> {
-                            android.util.Log.w("TlsnNative", "unknown mode '${optionsObj.optString("mode")}', defaulting to Mpc")
-                            null
-                        }
-                    }
-
-                    val options = ProverOptions(
-                        verifierUrl = verifierUrl,
-                        maxSentData = maxSentData,
-                        maxRecvData = maxRecvData,
-                        handlers = handlers,
-                        mode = mode
-                    )
-
-                    // Create progress callback that emits Expo events
-                    val progressCallback = object : ProgressCallback {
-                        override fun onProgress(step: String, progress: Double, message: String) {
-                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
-                                "step" to step,
-                                "progress" to progress,
-                                "message" to message
-                            ))
-                        }
-                    }
-
-                    // Call the prove function with progress callback
-                    val result = rustProve(request, options, progressCallback)
-
-                    // Convert response headers
-                    val responseHeaders = result.response.headers.map { header ->
-                        mapOf("name" to header.name, "value" to header.value)
-                    }
-
-                    // Parse response body as JSON, converting to native Map/List for Expo bridge
-                    val bodyJson: Any = try {
-                        jsonToNative(JSONObject(result.response.body))!!
-                    } catch (_: Exception) {
-                        try {
-                            jsonToNative(JSONArray(result.response.body))!!
-                        } catch (_: Exception) {
-                            result.response.body
-                        }
-                    }
+                    val result = rustProve(request, options, makeProgressCallback())
 
                     android.util.Log.i("TlsnNative",
                         "Proof complete! Sent: ${result.transcript.sent.size} bytes, Recv: ${result.transcript.recv.size} bytes")
 
-                    // Build result dictionary
-                    val resultMap = mapOf(
-                        "status" to result.response.status.toInt(),
-                        "headers" to responseHeaders,
-                        "body" to bodyJson,
-                        "transcript" to mapOf(
-                            "sentLength" to result.transcript.sent.size,
-                            "recvLength" to result.transcript.recv.size
-                        ),
-                        "debug" to mapOf(
-                            "handlersPassedToRust" to handlers.size,
-                            "handlersReceivedByRust" to result.handlersReceived.toInt()
-                        )
-                    )
-
-                    promise.resolve(resultMap)
+                    promise.resolve(proofResultToMap(result, options.handlers.size))
 
                 } catch (e: uniffi.tlsn_mobile.TlsnException) {
                     promise.reject("TlsnError", "$e", null)
@@ -414,15 +275,7 @@ class TlsnNativeModule : Module() {
                         return@Thread promise.reject("InvalidOptions", "Missing verifierUrl", null)
                     }
 
-                    val progressCallback = object : ProgressCallback {
-                        override fun onProgress(step: String, progress: Double, message: String) {
-                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
-                                "step" to step, "progress" to progress, "message" to message
-                            ))
-                        }
-                    }
-
-                    val prep = rustProveUntilReveal(request, options, progressCallback)
+                    val prep = rustProveUntilReveal(request, options, makeProgressCallback())
                     android.util.Log.i("TlsnNative",
                         "proveUntilReveal complete: session=${prep.sessionId} descriptors=${prep.descriptors.size}")
                     promise.resolve(revealPreparationToMap(prep))
@@ -438,15 +291,7 @@ class TlsnNativeModule : Module() {
         AsyncFunction("proveFinalize") { sessionId: String, approved: Boolean, promise: Promise ->
             Thread {
                 try {
-                    val progressCallback = object : ProgressCallback {
-                        override fun onProgress(step: String, progress: Double, message: String) {
-                            this@TlsnNativeModule.sendEvent("onProveProgress", mapOf(
-                                "step" to step, "progress" to progress, "message" to message
-                            ))
-                        }
-                    }
-
-                    val result = rustProveFinalize(sessionId, approved, progressCallback)
+                    val result = rustProveFinalize(sessionId, approved, makeProgressCallback())
                     promise.resolve(proofResultToMap(result, -1))
                 } catch (e: uniffi.tlsn_mobile.TlsnException) {
                     promise.reject("TlsnError", "$e", null)

--- a/app/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
+++ b/app/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
@@ -23,14 +23,204 @@ class SwiftProgressCallback: ProgressCallback {
     }
 }
 
+// MARK: - Parsing helpers
+
+private enum ParseError: Error {
+    case missing(String)
+    case invalid(String, String)
+}
+
+private func parseHttpRequest(_ dict: [String: Any]) throws -> HttpRequest {
+    guard let url = dict["url"] as? String else { throw ParseError.missing("url") }
+    guard let method = dict["method"] as? String else { throw ParseError.missing("method") }
+
+    var headers: [HttpHeader] = []
+    if let headersDict = dict["headers"] as? [String: String] {
+        for (name, value) in headersDict {
+            headers.append(HttpHeader(name: name, value: value))
+        }
+    }
+
+    return HttpRequest(
+        url: url,
+        method: method,
+        headers: headers,
+        body: dict["body"] as? String
+    )
+}
+
+private func parseProverOptions(_ dict: [String: Any]) throws -> ProverOptions {
+    guard let verifierUrl = dict["verifierUrl"] as? String else {
+        throw ParseError.missing("verifierUrl")
+    }
+
+    let maxSentData = (dict["maxSentData"] as? NSNumber)?.uint32Value ?? 4096
+    let maxRecvData = (dict["maxRecvData"] as? NSNumber)?.uint32Value ?? 16384
+
+    var handlers: [Handler] = []
+    if let handlersArray = dict["handlers"] as? [[String: Any]] {
+        for (index, handlerDict) in handlersArray.enumerated() {
+            if let h = parseHandler(handlerDict, index: index) {
+                handlers.append(h)
+            }
+        }
+    }
+
+    var mode: Mode? = nil
+    if let modeStr = dict["mode"] as? String {
+        switch modeStr {
+        case "Mpc": mode = .mpc
+        case "Proxy": mode = .proxy
+        default:
+            print("[TlsnNative] unknown mode '\(modeStr)', defaulting to Mpc")
+        }
+    }
+
+    return ProverOptions(
+        verifierUrl: verifierUrl,
+        maxSentData: maxSentData,
+        maxRecvData: maxRecvData,
+        handlers: handlers,
+        mode: mode
+    )
+}
+
+private func parseHandler(_ dict: [String: Any], index: Int) -> Handler? {
+    guard let handlerTypeStr = dict["handlerType"] as? String,
+          let partStr = dict["part"] as? String,
+          let actionDict = dict["action"] as? [String: Any],
+          let actionType = actionDict["type"] as? String else {
+        print("[TlsnNative] Handler \(index): missing required field")
+        return nil
+    }
+
+    let handlerType: HandlerType
+    switch handlerTypeStr {
+    case "Sent": handlerType = .sent
+    case "Recv": handlerType = .recv
+    default: return nil
+    }
+
+    let part: HandlerPart
+    switch partStr {
+    case "StartLine": part = .startLine
+    case "Protocol": part = .protocol
+    case "Method": part = .method
+    case "RequestTarget": part = .requestTarget
+    case "StatusCode": part = .statusCode
+    case "Headers": part = .headers
+    case "Body": part = .body
+    case "All": part = .all
+    default: return nil
+    }
+
+    let action: HandlerAction
+    switch actionType {
+    case "Reveal":
+        action = .reveal
+    case "Hash":
+        guard let algoStr = actionDict["algorithm"] as? String else { return nil }
+        let algorithm: HashAlgorithm
+        switch algoStr {
+        case "Blake3": algorithm = .blake3
+        case "Sha256": algorithm = .sha256
+        case "Keccak256": algorithm = .keccak256
+        default: return nil
+        }
+        action = .hash(algorithm: algorithm)
+    default:
+        return nil
+    }
+
+    var params: HandlerParams? = nil
+    if let paramsDict = dict["params"] as? [String: Any] {
+        params = HandlerParams(
+            key: paramsDict["key"] as? String,
+            hideKey: paramsDict["hideKey"] as? Bool,
+            hideValue: paramsDict["hideValue"] as? Bool,
+            contentType: paramsDict["contentType"] as? String,
+            path: paramsDict["path"] as? String,
+            regex: paramsDict["regex"] as? String,
+            flags: paramsDict["flags"] as? String
+        )
+    }
+
+    return Handler(handlerType: handlerType, part: part, action: action, params: params)
+}
+
+// MARK: - Result serialization
+
+private func proofResultToDict(_ result: ProofResult, handlersPassed: Int) -> [String: Any] {
+    var responseHeaders: [[String: String]] = []
+    for header in result.response.headers {
+        responseHeaders.append(["name": header.name, "value": header.value])
+    }
+
+    var bodyJson: Any = result.response.body
+    if let jsonData = result.response.body.data(using: .utf8),
+       let json = try? JSONSerialization.jsonObject(with: jsonData) {
+        bodyJson = json
+    }
+
+    return [
+        "status": Int(result.response.status),
+        "headers": responseHeaders,
+        "body": bodyJson,
+        "transcript": [
+            "sentLength": result.transcript.sent.count,
+            "recvLength": result.transcript.recv.count
+        ],
+        "debug": [
+            "handlersPassedToRust": handlersPassed,
+            "handlersReceivedByRust": result.handlersReceived
+        ]
+    ]
+}
+
+private func revealPreparationToDict(_ prep: RevealPreparation) -> [String: Any] {
+    var responseHeaders: [[String: String]] = []
+    for header in prep.response.headers {
+        responseHeaders.append(["name": header.name, "value": header.value])
+    }
+
+    var bodyJson: Any = prep.response.body
+    if let jsonData = prep.response.body.data(using: .utf8),
+       let json = try? JSONSerialization.jsonObject(with: jsonData) {
+        bodyJson = json
+    }
+
+    let descriptors: [[String: Any]] = prep.descriptors.map { d in
+        var entry: [String: Any] = [
+            "direction": d.direction,
+            "label": d.label,
+            "action": d.action,
+            "preview": d.preview
+        ]
+        if let alg = d.algorithm {
+            entry["algorithm"] = alg
+        }
+        return entry
+    }
+
+    return [
+        "sessionId": prep.sessionId,
+        "response": [
+            "status": Int(prep.response.status),
+            "headers": responseHeaders,
+            "body": bodyJson
+        ],
+        "descriptors": descriptors
+    ]
+}
+
+// MARK: - Module
+
 public class TlsnNativeModule: Module {
     public func definition() -> ModuleDefinition {
         Name("TlsnNative")
 
-        // Declare events that can be sent to JS
         Events("onProveProgress")
 
-        // Initialize the TLSN library
         Function("initialize") {
             do {
                 try initialize()
@@ -39,217 +229,22 @@ public class TlsnNativeModule: Module {
             }
         }
 
-        // High-level prove function that matches the React Native interface
+        // Legacy one-shot prove. Kept for backward compat.
         AsyncFunction("prove") { (requestDict: [String: Any], optionsDict: [String: Any], promise: Promise) in
-            DispatchQueue.global(qos: .userInitiated).async {
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 do {
-                    // Parse HTTP request
-                    guard let url = requestDict["url"] as? String,
-                          let method = requestDict["method"] as? String else {
-                        promise.reject("InvalidRequest", "Missing url or method")
-                        return
-                    }
+                    let request = try parseHttpRequest(requestDict)
+                    let options = try parseProverOptions(optionsDict)
+                    let handlersCount = options.handlers.count
 
-                    var headers: [HttpHeader] = []
-                    if let headersDict = requestDict["headers"] as? [String: String] {
-                        for (name, value) in headersDict {
-                            headers.append(HttpHeader(name: name, value: value))
-                        }
-                    }
-
-                    let body = requestDict["body"] as? String
-
-                    let request = HttpRequest(
-                        url: url,
-                        method: method,
-                        headers: headers,
-                        body: body
-                    )
-
-                    // Parse prover options
-                    guard let verifierUrl = optionsDict["verifierUrl"] as? String else {
-                        promise.reject("InvalidOptions", "Missing verifierUrl")
-                        return
-                    }
-
-                    let maxSentData = (optionsDict["maxSentData"] as? NSNumber)?.uint32Value ?? 4096
-                    let maxRecvData = (optionsDict["maxRecvData"] as? NSNumber)?.uint32Value ?? 16384
-
-                    // Parse handlers for selective disclosure
-                    var handlers: [Handler] = []
-                    print("[TlsnNative] optionsDict keys: \(optionsDict.keys)")
-                    print("[TlsnNative] handlers raw value: \(String(describing: optionsDict["handlers"]))")
-
-                    if let handlersArray = optionsDict["handlers"] as? [[String: Any]] {
-                        print("[TlsnNative] Found \(handlersArray.count) handlers to parse")
-                        for (index, handlerDict) in handlersArray.enumerated() {
-                            print("[TlsnNative] Handler \(index) dict: \(handlerDict)")
-
-                            guard let handlerTypeStr = handlerDict["handlerType"] as? String else {
-                                print("[TlsnNative] Handler \(index): missing handlerType")
-                                continue
-                            }
-                            guard let partStr = handlerDict["part"] as? String else {
-                                print("[TlsnNative] Handler \(index): missing part")
-                                continue
-                            }
-                            guard let actionDict = handlerDict["action"] as? [String: Any],
-                                  let actionType = actionDict["type"] as? String else {
-                                print("[TlsnNative] Handler \(index): missing or malformed action")
-                                continue
-                            }
-
-                            print("[TlsnNative] Handler \(index): type=\(handlerTypeStr), part=\(partStr), action=\(actionType)")
-
-                            // Parse handler type
-                            let handlerType: HandlerType
-                            switch handlerTypeStr {
-                            case "Sent": handlerType = .sent
-                            case "Recv": handlerType = .recv
-                            default:
-                                print("[TlsnNative] Handler \(index): unknown handlerType '\(handlerTypeStr)'")
-                                continue
-                            }
-
-                            // Parse handler part
-                            let part: HandlerPart
-                            switch partStr {
-                            case "StartLine": part = .startLine
-                            case "Protocol": part = .protocol
-                            case "Method": part = .method
-                            case "RequestTarget": part = .requestTarget
-                            case "StatusCode": part = .statusCode
-                            case "Headers": part = .headers
-                            case "Body": part = .body
-                            case "All": part = .all
-                            default:
-                                print("[TlsnNative] Handler \(index): unknown part '\(partStr)'")
-                                continue
-                            }
-
-                            // Parse handler action
-                            let action: HandlerAction
-                            switch actionType {
-                            case "Reveal":
-                                action = .reveal
-                            case "Hash":
-                                guard let algoStr = actionDict["algorithm"] as? String else {
-                                    print("[TlsnNative] Handler \(index): Hash action missing algorithm")
-                                    continue
-                                }
-                                let algorithm: HashAlgorithm
-                                switch algoStr {
-                                case "Blake3": algorithm = .blake3
-                                case "Sha256": algorithm = .sha256
-                                case "Keccak256": algorithm = .keccak256
-                                default:
-                                    print("[TlsnNative] Handler \(index): unknown hash algorithm '\(algoStr)'")
-                                    continue
-                                }
-                                action = .hash(algorithm: algorithm)
-                            default:
-                                print("[TlsnNative] Handler \(index): unknown action type '\(actionType)'")
-                                continue
-                            }
-
-                            // Parse optional params
-                            var params: HandlerParams? = nil
-                            if let paramsDict = handlerDict["params"] as? [String: Any] {
-                                let key = paramsDict["key"] as? String
-                                let hideKey = paramsDict["hideKey"] as? Bool
-                                let hideValue = paramsDict["hideValue"] as? Bool
-                                let contentType = paramsDict["contentType"] as? String
-                                let path = paramsDict["path"] as? String
-                                let regex = paramsDict["regex"] as? String
-                                let flags = paramsDict["flags"] as? String
-                                params = HandlerParams(
-                                    key: key,
-                                    hideKey: hideKey,
-                                    hideValue: hideValue,
-                                    contentType: contentType,
-                                    path: path,
-                                    regex: regex,
-                                    flags: flags
-                                )
-                                print("[TlsnNative] Handler \(index) params: key=\(String(describing: key)), contentType=\(String(describing: contentType)), path=\(String(describing: path))")
-                            }
-
-                            handlers.append(Handler(handlerType: handlerType, part: part, action: action, params: params))
-                            print("[TlsnNative] Handler \(index) successfully parsed")
-                        }
-                    } else {
-                        print("[TlsnNative] Could not parse handlers array - checking raw type")
-                        if let rawHandlers = optionsDict["handlers"] {
-                            print("[TlsnNative] handlers type: \(type(of: rawHandlers))")
-                        } else {
-                            print("[TlsnNative] handlers key not found in optionsDict")
-                        }
-                    }
-
-                    NSLog("[TlsnNative] Final handlers count: %d", handlers.count)
-                    os_log("[TlsnNative] Handlers to Rust: %d", log: logger, type: .info, handlers.count)
-
-                    // Parse optional protocol mode (default Mpc).
-                    var mode: Mode? = nil
-                    if let modeStr = optionsDict["mode"] as? String {
-                        switch modeStr {
-                        case "Mpc": mode = .mpc
-                        case "Proxy": mode = .proxy
-                        default:
-                            print("[TlsnNative] unknown mode '\(modeStr)', defaulting to Mpc")
-                        }
-                    }
-
-                    let options = ProverOptions(
-                        verifierUrl: verifierUrl,
-                        maxSentData: maxSentData,
-                        maxRecvData: maxRecvData,
-                        handlers: handlers,
-                        mode: mode
-                    )
-
-                    // Create progress callback that emits Expo events
-                    let progressCallback = SwiftProgressCallback { [weak self] name, body in
+                    let progressCallback = SwiftProgressCallback { name, body in
                         self?.sendEvent(name, body)
                     }
 
-                    // Call the prove function with progress callback
                     let result = try prove(request: request, options: options, progress: progressCallback)
-
-                    // Convert response headers to dictionary
-                    var responseHeaders: [[String: String]] = []
-                    for header in result.response.headers {
-                        responseHeaders.append(["name": header.name, "value": header.value])
-                    }
-
-                    // Parse response body as JSON if possible
-                    var bodyJson: Any = result.response.body
-                    if let jsonData = result.response.body.data(using: .utf8),
-                       let json = try? JSONSerialization.jsonObject(with: jsonData) {
-                        bodyJson = json
-                    }
-
-                    // Log transcript info
                     NSLog("[TlsnNative] Proof complete! Sent: %d bytes, Recv: %d bytes",
                           result.transcript.sent.count, result.transcript.recv.count)
-
-                    // Build result dictionary
-                    let resultDict: [String: Any] = [
-                        "status": Int(result.response.status),
-                        "headers": responseHeaders,
-                        "body": bodyJson,
-                        "transcript": [
-                            "sentLength": result.transcript.sent.count,
-                            "recvLength": result.transcript.recv.count
-                        ],
-                        "debug": [
-                            "handlersPassedToRust": handlers.count,
-                            "handlersReceivedByRust": result.handlersReceived
-                        ]
-                    ]
-
-                    promise.resolve(resultDict)
-
+                    promise.resolve(proofResultToDict(result, handlersPassed: handlersCount))
                 } catch let error as TlsnError {
                     promise.reject("TlsnError", "\(error)")
                 } catch {
@@ -258,7 +253,58 @@ public class TlsnNativeModule: Module {
             }
         }
 
-        // Check if native module is available
+        // Phase A: prove up to (but not including) reveal. Returns descriptors with
+        // real byte previews of every range about to be revealed/hashed. Pair with
+        // proveFinalize(sessionId, approved).
+        AsyncFunction("proveUntilReveal") { (requestDict: [String: Any], optionsDict: [String: Any], promise: Promise) in
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                do {
+                    let request = try parseHttpRequest(requestDict)
+                    let options = try parseProverOptions(optionsDict)
+
+                    let progressCallback = SwiftProgressCallback { name, body in
+                        self?.sendEvent(name, body)
+                    }
+
+                    let prep = try proveUntilReveal(
+                        request: request,
+                        options: options,
+                        progress: progressCallback
+                    )
+                    NSLog("[TlsnNative] proveUntilReveal complete: session=%@ descriptors=%d",
+                          prep.sessionId, prep.descriptors.count)
+                    promise.resolve(revealPreparationToDict(prep))
+                } catch let error as TlsnError {
+                    promise.reject("TlsnError", "\(error)")
+                } catch {
+                    promise.reject("UnknownError", error.localizedDescription)
+                }
+            }
+        }
+
+        // Phase B: finalize the prove (or drop it). Returns the proof result on
+        // approval, or rejects with "User rejected reveal" on rejection.
+        AsyncFunction("proveFinalize") { (sessionId: String, approved: Bool, promise: Promise) in
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                do {
+                    let progressCallback = SwiftProgressCallback { name, body in
+                        self?.sendEvent(name, body)
+                    }
+
+                    let result = try proveFinalize(
+                        sessionId: sessionId,
+                        approved: approved,
+                        progress: progressCallback
+                    )
+                    promise.resolve(proofResultToDict(result, handlersPassed: -1))
+                } catch let error as TlsnError {
+                    promise.reject("TlsnError", "\(error)")
+                } catch {
+                    promise.reject("UnknownError", error.localizedDescription)
+                }
+            }
+        }
+
         Function("isAvailable") { () -> Bool in
             return true
         }

--- a/app/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
+++ b/app/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
@@ -7,6 +7,20 @@ interface TlsnNativeModuleInterface {
     request: Record<string, unknown>,
     options: Record<string, unknown>,
   ): Promise<Record<string, unknown>>;
+  /**
+   * Phase A of the two-phase prove: runs the protocol up through
+   * compute_reveal natively, then pauses with a list of byte-preview
+   * descriptors. Pair with `proveFinalize`.
+   */
+  proveUntilReveal(
+    request: Record<string, unknown> | string,
+    options: Record<string, unknown> | string,
+  ): Promise<Record<string, unknown>>;
+  /**
+   * Phase B: complete the prepared session (`approved=true`) or drop it
+   * (`approved=false`).
+   */
+  proveFinalize(sessionId: string, approved: boolean): Promise<Record<string, unknown>>;
   isAvailable(): boolean;
   addListener(eventName: string): void;
   removeListeners(count: number): void;

--- a/app/mobile/modules/tlsn-native/src/index.ts
+++ b/app/mobile/modules/tlsn-native/src/index.ts
@@ -60,6 +60,34 @@ export interface ProveProgress {
   message: string;
 }
 
+/**
+ * Per-range preview returned by `proveUntilReveal`. Each entry describes one
+ * byte range that the prover is about to reveal (or hash-commit) to the
+ * verifier, with the actual transcript bytes as `preview` for user review.
+ */
+export interface RevealRangeDescriptor {
+  direction: 'SENT' | 'RECV';
+  label: string;
+  action: 'REVEAL' | 'HASH';
+  algorithm?: 'Blake3' | 'Sha256' | 'Keccak256';
+  preview: string;
+}
+
+/**
+ * Output of `proveUntilReveal`. Pass `sessionId` back to `proveFinalize`
+ * along with an `approved` bool. State has a 5-minute TTL on the native
+ * side, so the caller must finalize (approve or reject) within that window.
+ */
+export interface RevealPreparation {
+  sessionId: string;
+  response: {
+    status: number;
+    headers: HttpHeader[];
+    body: unknown;
+  };
+  descriptors: RevealRangeDescriptor[];
+}
+
 const emitter = new EventEmitter(TlsnNativeModule);
 
 /**
@@ -100,6 +128,47 @@ export async function prove(request: ProveRequest, options: ProverOptions): Prom
     ) as unknown as Promise<ProveResult>;
   }
   return TlsnNativeModule.prove(request, options) as unknown as Promise<ProveResult>;
+}
+
+/**
+ * Phase A of the two-phase prove: runs MPC + HTTP request + compute_reveal,
+ * then pauses with a list of range descriptors (each with a real byte preview
+ * of the transcript slice it covers). Pair with `proveFinalize`.
+ */
+export async function proveUntilReveal(
+  request: ProveRequest,
+  options: ProverOptions,
+): Promise<RevealPreparation> {
+  const isAndroid = Platform.OS === 'android';
+
+  if (isAndroid && options.verifierUrl) {
+    options = {
+      ...options,
+      verifierUrl: options.verifierUrl
+        .replace('://localhost', '://10.0.2.2')
+        .replace('://127.0.0.1', '://10.0.2.2'),
+    };
+  }
+
+  if (isAndroid) {
+    return TlsnNativeModule.proveUntilReveal(
+      JSON.stringify(request),
+      JSON.stringify(options),
+    ) as unknown as Promise<RevealPreparation>;
+  }
+  return TlsnNativeModule.proveUntilReveal(request, options) as unknown as Promise<RevealPreparation>;
+}
+
+/**
+ * Phase B of the two-phase prove. If `approved` is true, completes the proof
+ * and returns the result. If false, the native side drops the session and
+ * rejects with `TlsnError::ProofFailed("User rejected reveal")`.
+ */
+export async function proveFinalize(
+  sessionId: string,
+  approved: boolean,
+): Promise<ProveResult> {
+  return TlsnNativeModule.proveFinalize(sessionId, approved) as unknown as Promise<ProveResult>;
 }
 
 /**

--- a/app/mobile/modules/tlsn-native/src/index.ts
+++ b/app/mobile/modules/tlsn-native/src/index.ts
@@ -156,7 +156,10 @@ export async function proveUntilReveal(
       JSON.stringify(options),
     ) as unknown as Promise<RevealPreparation>;
   }
-  return TlsnNativeModule.proveUntilReveal(request, options) as unknown as Promise<RevealPreparation>;
+  return TlsnNativeModule.proveUntilReveal(
+    request,
+    options,
+  ) as unknown as Promise<RevealPreparation>;
 }
 
 /**
@@ -164,10 +167,7 @@ export async function proveUntilReveal(
  * and returns the result. If false, the native side drops the session and
  * rejects with `TlsnError::ProofFailed("User rejected reveal")`.
  */
-export async function proveFinalize(
-  sessionId: string,
-  approved: boolean,
-): Promise<ProveResult> {
+export async function proveFinalize(sessionId: string, approved: boolean): Promise<ProveResult> {
   return TlsnNativeModule.proveFinalize(sessionId, approved) as unknown as Promise<ProveResult>;
 }
 

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -37,6 +37,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-get-random-values": "^2.0.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig(
     ignores: [
       '**/build/',
       '**/dist/',
+      '**/zip/',
       'packages/extension/lib/',
       'packages/extension/webpack.config.js',
       'packages/demo/public/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-get-random-values": "^2.0.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -12742,6 +12743,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
@@ -18942,6 +18949,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-get-random-values": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+      "integrity": "sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-base64-decode": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.81"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2834,7 +2834,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2852,7 +2851,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2870,7 +2868,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2888,7 +2885,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2904,7 +2900,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2922,7 +2917,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2940,7 +2934,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2958,7 +2951,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2976,7 +2968,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2994,7 +2985,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3012,7 +3002,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3030,7 +3019,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3048,7 +3036,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3066,7 +3053,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3084,7 +3070,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3102,7 +3087,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3120,7 +3104,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3138,7 +3121,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3156,7 +3138,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3174,7 +3155,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3192,7 +3172,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3210,7 +3189,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3228,7 +3206,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3246,7 +3223,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3264,7 +3240,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3282,7 +3257,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5673,7 +5647,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -5716,7 +5689,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5736,7 +5708,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5758,7 +5729,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5780,7 +5750,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5802,7 +5771,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5824,7 +5792,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5846,7 +5813,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5868,7 +5834,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5890,7 +5855,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5912,7 +5876,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5934,7 +5897,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5956,7 +5918,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5978,7 +5939,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -5992,7 +5952,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16746,8 +16705,7 @@
       "version": "7.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -21337,7 +21295,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -23371,7 +23328,6 @@
         "classnames": "^2.3.2",
         "comlink": "^4.4.2",
         "events": "^3.3.0",
-        "fast-deep-equal": "^3.1.3",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "react": "^19.0.0",
@@ -23511,6 +23467,7 @@
         "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
         "@sebastianwessel/quickjs": "^3.0.0",
         "@tlsn/common": "*",
+        "fast-deep-equal": "^3.1.3",
         "uuid": "^13.0.0"
       },
       "devDependencies": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -28,7 +28,6 @@
     "classnames": "^2.3.2",
     "comlink": "^4.4.2",
     "events": "^3.3.0",
-    "fast-deep-equal": "^3.1.3",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "react": "^19.0.0",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -10,6 +10,10 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./host-core": {
+      "import": "./dist/host-core.js",
+      "types": "./dist/host-core.d.ts"
+    },
     "./styles": {
       "import": "./dist/styles.js",
       "types": "./dist/styles.d.ts"

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -86,6 +86,7 @@
     "@jitl/quickjs-ng-wasmfile-release-sync": "^0.31.0",
     "@sebastianwessel/quickjs": "^3.0.0",
     "@tlsn/common": "*",
+    "fast-deep-equal": "^3.1.3",
     "uuid": "^13.0.0"
   }
 }

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -1540,38 +1540,49 @@ export class HostCore {
 // NativeFunctionEvaluator
 // ---------------------------------------------------------------------------
 
-function preprocessForNativeEval(code: string): string {
-  // Collect named exports: export function main() / export const config = ...
+/**
+ * Parse the plugin's `export` declarations and return the source with `export`
+ * keywords stripped, plus a comma-separated `entries` string mapping each
+ * exported name to an arrow-function wrapper (arrow functions have no
+ * `.prototype`, which avoids a QuickJS handleToNative cycle for function
+ * exports). Returns null if the code has no recognized export syntax.
+ *
+ * Both the QuickJS-based and `new Function()`-based evaluators use the same
+ * parse output; they differ only in the trailer they append (ES module
+ * `export default { ... }` vs. function-body `return { ... }`).
+ */
+export function extractPluginExports(code: string): { stripped: string; entries: string } | null {
+  const wrap = (names: string[]) =>
+    names
+      .map((n) => `${n}: typeof ${n} === 'function' ? (...args) => ${n}(...args) : ${n}`)
+      .join(',\n  ');
+
   const exportNames: string[] = [];
   const exportRegex = /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
   let match;
   while ((match = exportRegex.exec(code)) !== null) {
     exportNames.push(match[1]);
   }
-
   if (exportNames.length > 0) {
-    const stripped = code.replace(/^(\s*)export\s+/gm, '$1');
-    const entries = exportNames
-      .map((n) => `${n}: typeof ${n} === 'function' ? (...args) => ${n}(...args) : ${n}`)
-      .join(',\n  ');
-    return `${stripped}\nreturn { ${entries} };`;
+    return {
+      stripped: code.replace(/^(\s*)export\s+/gm, '$1'),
+      entries: wrap(exportNames),
+    };
   }
 
-  // Handle export default { ... }
   const defaultMatch = code.match(/export\s+default\s+\{([^}]+)\}\s*;?\s*$/);
   if (defaultMatch) {
     const names = defaultMatch[1]
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean);
-    const stripped = code.replace(/export\s+default\s+\{[^}]+\}\s*;?\s*$/, '');
-    const entries = names
-      .map((n) => `${n}: typeof ${n} === 'function' ? (...args) => ${n}(...args) : ${n}`)
-      .join(',\n  ');
-    return `${stripped}\nreturn { ${entries} };`;
+    return {
+      stripped: code.replace(/export\s+default\s+\{[^}]+\}\s*;?\s*$/, ''),
+      entries: wrap(names),
+    };
   }
 
-  return code;
+  return null;
 }
 
 export class NativeFunctionEvaluator implements PluginEvaluator {
@@ -1579,7 +1590,8 @@ export class NativeFunctionEvaluator implements PluginEvaluator {
     code: string,
     capabilities: Record<string, AnyFunction>,
   ): Promise<PluginEvaluatorResult> {
-    const processedCode = preprocessForNativeEval(code);
+    const parsed = extractPluginExports(code);
+    const processedCode = parsed ? `${parsed.stripped}\nreturn { ${parsed.entries} };` : code;
     const keys = Object.keys(capabilities);
     const vals = Object.values(capabilities);
     const fn = new Function(...keys, processedCode);

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -1,0 +1,1498 @@
+/**
+ * @tlsn/plugin-sdk — platform-agnostic plugin runtime
+ *
+ * This module contains everything that does not depend on a specific
+ * JavaScript evaluator (QuickJS WASM, new Function(), native QuickJS, …).
+ * Platform-specific code lives in index.ts (QuickJS) or in the consuming
+ * platform's host class (e.g. MobilePluginHost).
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { logger, LogLevel, DEFAULT_LOG_LEVEL } from '@tlsn/common';
+import {
+  DomJson,
+  DomOptions,
+  ExecutionContext,
+  InterceptedRequest,
+  InterceptedRequestHeader,
+  OpenWindowResponse,
+  WindowMessage,
+  Handler,
+  PluginConfig,
+  ProveProgressData,
+  RevealRangeDescriptor,
+  canonicalizeHandlers,
+} from './types';
+import deepEqual from 'fast-deep-equal';
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type HookContext = {
+  [functionName: string]: {
+    effects: unknown[][];
+    selectors: unknown[][];
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyFunction = (...args: any[]) => any;
+
+// ---------------------------------------------------------------------------
+// PluginEvaluator — the single platform-specific seam
+// ---------------------------------------------------------------------------
+
+export interface PluginEvaluatorResult {
+  /** Exported functions from the plugin code (main, onClick handlers, config, …) */
+  exports: Record<string, unknown>;
+  /** Called by HostCore when the plugin finishes (success or error). */
+  dispose: () => void;
+}
+
+/**
+ * Abstraction over the JavaScript sandbox used to execute plugin code.
+ *
+ * - Extension: QuickJS WASM (via @sebastianwessel/quickjs)
+ * - Mobile:    new Function() (Hermes-safe, no WASM)
+ * - Tests:     new Function() mock evaluator
+ */
+export interface PluginEvaluator {
+  evaluate(code: string, capabilities: Record<string, AnyFunction>): Promise<PluginEvaluatorResult>;
+}
+
+// ---------------------------------------------------------------------------
+// HostCoreOptions
+// ---------------------------------------------------------------------------
+
+export interface HostCoreOptions {
+  evaluator: PluginEvaluator;
+  onProve: (
+    requestOptions: {
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    },
+    proverOptions: {
+      verifierUrl: string;
+      proxyUrl: string;
+      maxRecvData?: number;
+      maxSentData?: number;
+      handlers: Handler[];
+    },
+    onProgress?: (data: ProveProgressData) => void,
+  ) => Promise<unknown>;
+  onRenderPluginUi: (windowId: number, result: DomJson) => void;
+  onCloseWindow: (windowId: number) => void;
+  onOpenWindow: (
+    url: string,
+    options?: {
+      width?: number;
+      height?: number;
+      showOverlay?: boolean;
+    },
+  ) => Promise<OpenWindowResponse>;
+  logLevel?: LogLevel;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level registry (avoids circular references in capability closures)
+// ---------------------------------------------------------------------------
+
+export const executionContextRegistry = new Map<string, ExecutionContext>();
+
+// ---------------------------------------------------------------------------
+// Timeout constants
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+export const MIN_TIMEOUT_MS = 2 * 60 * 1000;
+export const MAX_TIMEOUT_MS = 60 * 60 * 1000;
+export const TIMEOUT_WARNING_LEAD_MS = 60 * 1000;
+export const TIMEOUT_EXTEND_MS = 5 * 60 * 1000;
+
+export function clampTimeout(value?: number): number {
+  if (value == null) return DEFAULT_TIMEOUT_MS;
+  return Math.max(MIN_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, value));
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper functions
+// ---------------------------------------------------------------------------
+
+export function updateExecutionContext(
+  uuid: string,
+  params: {
+    windowId?: number;
+    plugin?: string;
+    requests?: InterceptedRequest[];
+    headers?: InterceptedRequestHeader[];
+    context?: HookContext;
+    currentContext?: string;
+    stateStore?: Record<string, unknown>;
+    revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
+    revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
+    revealWasRejected?: boolean;
+  },
+): void {
+  const context = executionContextRegistry.get(uuid);
+  if (!context) {
+    throw new Error('Execution context not found');
+  }
+  executionContextRegistry.set(uuid, { ...context, ...params });
+}
+
+export function createDomJson(
+  type: 'div' | 'button' | 'input',
+  param1: DomOptions | DomJson[] = {},
+  param2: DomJson[] = [],
+): DomJson {
+  let options: DomOptions = {};
+  let children: DomJson[] = [];
+
+  if (Array.isArray(param1)) {
+    children = param1;
+  } else if (typeof param1 === 'object') {
+    options = param1;
+    children = param2;
+  }
+
+  return { type, options, children };
+}
+
+export function getJsonBody(request: InterceptedRequest): unknown {
+  const bytes = request.requestBody?.raw?.[0]?.bytes;
+  if (!bytes) return null;
+
+  const text = String.fromCharCode(
+    ...(bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes),
+  );
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook factories
+// ---------------------------------------------------------------------------
+
+export function makeUseEffect(uuid: string, context: HookContext) {
+  return (effect: () => void, deps: unknown[]) => {
+    const executionContext = executionContextRegistry.get(uuid);
+    if (!executionContext) {
+      throw new Error('Execution context not found');
+    }
+    const functionName = executionContext.currentContext;
+    context[functionName] = context[functionName] || { effects: [], selectors: [] };
+    const effects = context[functionName].effects;
+    const lastDeps = executionContext.context[functionName]?.effects[effects.length];
+    effects.push(deps);
+    if (deepEqual(lastDeps, deps)) {
+      return;
+    }
+    effect();
+  };
+}
+
+export function makeUseRequests(uuid: string, context: HookContext) {
+  return (filterFn: (requests: InterceptedRequest[]) => InterceptedRequest[]) => {
+    const executionContext = executionContextRegistry.get(uuid);
+    if (!executionContext) {
+      throw new Error('Execution context not found');
+    }
+    const functionName = executionContext.currentContext;
+    context[functionName] = context[functionName] || { effects: [], selectors: [] };
+    const selectors = context[functionName].selectors;
+    const requests = JSON.parse(JSON.stringify(executionContext.requests || []));
+    const result = filterFn(requests);
+    selectors.push(result);
+    return result;
+  };
+}
+
+export function makeUseHeaders(uuid: string, context: HookContext) {
+  return (filterFn: (headers: InterceptedRequestHeader[]) => InterceptedRequestHeader[]) => {
+    const executionContext = executionContextRegistry.get(uuid);
+    if (!executionContext) {
+      throw new Error('Execution context not found');
+    }
+    const functionName = executionContext.currentContext;
+    context[functionName] = context[functionName] || { effects: [], selectors: [] };
+    const selectors = context[functionName].selectors;
+    const headers = JSON.parse(JSON.stringify(executionContext.headers || []));
+    const result = filterFn(headers);
+
+    if (result === undefined) {
+      throw new Error(`useHeaders: filter function returned undefined. expect an array`);
+    }
+    if (!Array.isArray(result)) {
+      throw new Error(`useHeaders: filter function must return an array, got ${typeof result}. `);
+    }
+
+    selectors.push(result);
+    return result;
+  };
+}
+
+export function makeUseState(
+  uuid: string,
+  stateStore: Record<string, unknown>,
+  _eventEmitter: {
+    emit: (message: WindowMessage) => void;
+  },
+) {
+  return (key: string, defaultValue: unknown) => {
+    const executionContext = executionContextRegistry.get(uuid);
+    if (!executionContext) {
+      throw new Error('Execution context not found');
+    }
+    if (!(key in stateStore) && defaultValue !== undefined) {
+      stateStore[key] = defaultValue;
+    }
+    return stateStore[key];
+  };
+}
+
+export function makeSetState(
+  uuid: string,
+  stateStore: Record<string, unknown>,
+  eventEmitter: {
+    emit: (message: WindowMessage) => void;
+  },
+) {
+  return (key: string, value: unknown) => {
+    const executionContext = executionContextRegistry.get(uuid);
+    if (!executionContext) {
+      throw new Error('Execution context not found');
+    }
+    stateStore[key] = value;
+    if (deepEqual(stateStore, executionContext.stateStore)) {
+      return;
+    }
+
+    eventEmitter.emit({
+      type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+      windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+    });
+  };
+}
+
+export function makeUsePluginTimeout(stateStore: Record<string, unknown>) {
+  return (): { remaining: number; total: number } | null => {
+    return (stateStore['_pluginTimeout'] as { remaining: number; total: number }) ?? null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PluginLifecycle
+// ---------------------------------------------------------------------------
+
+export interface PluginLifecycle {
+  isCompleted: boolean;
+  pendingCallbacks: number;
+  onDrain: (() => void) | null;
+}
+
+// ---------------------------------------------------------------------------
+// makeOpenWindow
+// ---------------------------------------------------------------------------
+
+export function makeOpenWindow(
+  uuid: string,
+  eventEmitter: {
+    addListener: (listener: (message: WindowMessage) => void) => void;
+    removeListener: (listener: (message: WindowMessage) => void) => void;
+  },
+  onOpenWindow: (
+    url: string,
+    options?: {
+      width?: number;
+      height?: number;
+      showOverlay?: boolean;
+    },
+  ) => Promise<OpenWindowResponse>,
+  _onCloseWindow: (windowId: number) => void,
+  lifecycle: PluginLifecycle,
+  onError?: (error: Error) => void,
+) {
+  let cachedResult: { windowId: number; uuid: string; tabId: number } | null = null;
+
+  return async (
+    url: string,
+    options?: {
+      width?: number;
+      height?: number;
+      showOverlay?: boolean;
+    },
+  ): Promise<{ windowId: number; uuid: string; tabId: number }> => {
+    if (!url || typeof url !== 'string') {
+      throw new Error('URL must be a non-empty string');
+    }
+
+    if (cachedResult) {
+      return cachedResult;
+    }
+
+    let resolvedWindowId: number | null = null;
+    const pendingMessages: WindowMessage[] = [];
+
+    const onMessage = async (message: WindowMessage) => {
+      if (resolvedWindowId === null) {
+        pendingMessages.push(message);
+        return;
+      }
+
+      if (message.type === 'WINDOW_CLOSED') {
+        const executionContext = executionContextRegistry.get(uuid);
+        const ourWindowId = executionContext?.windowId ?? resolvedWindowId;
+
+        if (ourWindowId != null && message.windowId !== ourWindowId) {
+          return;
+        }
+
+        eventEmitter.removeListener(onMessage);
+
+        if (!lifecycle.isCompleted && onError) {
+          onError(new Error('Window closed by user'));
+        }
+        return;
+      }
+
+      if (lifecycle.isCompleted) {
+        logger.debug(`[makeOpenWindow] Ignoring message ${message.type}: plugin has completed`);
+        eventEmitter.removeListener(onMessage);
+        return;
+      }
+
+      const executionContext = executionContextRegistry.get(uuid);
+      if (!executionContext) {
+        logger.debug(
+          `[makeOpenWindow] Ignoring message ${message.type}: execution context no longer exists`,
+        );
+        eventEmitter.removeListener(onMessage);
+        return;
+      }
+
+      if (message.windowId !== executionContext.windowId) {
+        return;
+      }
+
+      try {
+        if (message.type === 'REQUEST_INTERCEPTED') {
+          const request = message.request;
+          updateExecutionContext(uuid, {
+            requests: [...(executionContext.requests || []), request],
+          });
+          executionContext.main();
+        }
+
+        if (message.type === 'REQUESTS_BATCH') {
+          const requests = message.requests;
+          updateExecutionContext(uuid, {
+            requests: [...(executionContext.requests || []), ...requests],
+          });
+          executionContext.main();
+        }
+
+        if (message.type === 'HEADER_INTERCEPTED') {
+          const header = message.header;
+          updateExecutionContext(uuid, {
+            headers: [...(executionContext.headers || []), header],
+          });
+          executionContext.main();
+        }
+
+        if (message.type === 'HEADERS_BATCH') {
+          const headers = message.headers;
+          updateExecutionContext(uuid, {
+            headers: [...(executionContext.headers || []), ...headers],
+          });
+          executionContext.main();
+        }
+
+        if (message.type === 'PLUGIN_UI_CLICK') {
+          logger.debug('PLUGIN_UI_CLICK', message);
+          if (message.onclick === '_revealApprove') {
+            const liveCtx = executionContextRegistry.get(uuid);
+            const approval = liveCtx?.revealApproval;
+            if (approval) {
+              updateExecutionContext(uuid, {
+                revealApproval: null,
+                revealApprovalDescriptors: null,
+              });
+              approval.resolve();
+            }
+            return;
+          }
+          if (message.onclick === '_revealReject') {
+            const liveCtx = executionContextRegistry.get(uuid);
+            const approval = liveCtx?.revealApproval;
+            if (approval) {
+              updateExecutionContext(uuid, {
+                revealApproval: null,
+                revealApprovalDescriptors: null,
+                revealWasRejected: true,
+              });
+              approval.reject(new Error('User rejected reveal'));
+            }
+            return;
+          }
+          const cb = executionContext.callbacks[message.onclick];
+
+          logger.debug('Callback:', cb);
+          if (cb) {
+            lifecycle.pendingCallbacks++;
+            try {
+              updateExecutionContext(uuid, {
+                currentContext: message.onclick,
+              });
+              const result = await cb();
+              if (executionContextRegistry.has(uuid)) {
+                updateExecutionContext(uuid, {
+                  currentContext: '',
+                });
+              }
+              logger.debug('Callback result:', result);
+            } finally {
+              lifecycle.pendingCallbacks--;
+              if (lifecycle.pendingCallbacks === 0 && lifecycle.onDrain) {
+                lifecycle.onDrain();
+                lifecycle.onDrain = null;
+              }
+            }
+          }
+        }
+
+        if (message.type === 'RE_RENDER_PLUGIN_UI') {
+          logger.debug('[makeOpenWindow] RE_RENDER_PLUGIN_UI', message.windowId);
+          executionContext.main(true);
+        }
+      } catch (error) {
+        logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);
+        eventEmitter.removeListener(onMessage);
+        const err = error instanceof Error ? error : new Error(String(error));
+        if (onError) {
+          onError(err);
+        }
+      }
+    };
+
+    eventEmitter.addListener(onMessage);
+
+    try {
+      const response = await onOpenWindow(url, options);
+
+      if (response?.type === 'WINDOW_ERROR') {
+        throw new Error(
+          response.payload?.details || response.payload?.error || 'Failed to open window',
+        );
+      }
+
+      if (response?.type === 'WINDOW_OPENED' && response.payload) {
+        const windowId = response.payload.windowId;
+
+        if (!executionContextRegistry.has(uuid)) {
+          eventEmitter.removeListener(onMessage);
+          cachedResult = {
+            windowId: response.payload.windowId,
+            uuid: response.payload.uuid,
+            tabId: response.payload.tabId,
+          };
+          return cachedResult;
+        }
+
+        updateExecutionContext(uuid, { windowId });
+
+        const executionContext = executionContextRegistry.get(uuid);
+        if (executionContext) {
+          let headers = executionContext.headers || [];
+          let requests = executionContext.requests || [];
+          let bufferedCount = 0;
+          let windowWasClosed = false;
+
+          for (const msg of pendingMessages) {
+            if (msg.windowId !== windowId) continue;
+
+            if (msg.type === 'WINDOW_CLOSED') {
+              windowWasClosed = true;
+            } else if (msg.type === 'HEADER_INTERCEPTED' && msg.header) {
+              headers = [...headers, msg.header];
+              bufferedCount++;
+            } else if (msg.type === 'HEADERS_BATCH' && msg.headers) {
+              headers = [...headers, ...msg.headers];
+              bufferedCount += msg.headers.length;
+            } else if (msg.type === 'REQUEST_INTERCEPTED' && msg.request) {
+              requests = [...requests, msg.request];
+              bufferedCount++;
+            } else if (msg.type === 'REQUESTS_BATCH' && msg.requests) {
+              requests = [...requests, ...msg.requests];
+              bufferedCount += msg.requests.length;
+            }
+          }
+
+          if (bufferedCount > 0) {
+            logger.debug(
+              `[makeOpenWindow] Replaying ${bufferedCount} buffered message(s) into execution context`,
+            );
+            updateExecutionContext(uuid, { headers, requests });
+            executionContext.main(true);
+          }
+
+          if (windowWasClosed) {
+            eventEmitter.removeListener(onMessage);
+            if (!lifecycle.isCompleted && onError) {
+              onError(new Error('Window closed by user'));
+            }
+            pendingMessages.length = 0;
+            cachedResult = {
+              windowId: response.payload.windowId,
+              uuid: response.payload.uuid,
+              tabId: response.payload.tabId,
+            };
+            return cachedResult;
+          }
+        }
+        pendingMessages.length = 0;
+        resolvedWindowId = windowId;
+
+        cachedResult = {
+          windowId: response.payload.windowId,
+          uuid: response.payload.uuid,
+          tabId: response.payload.tabId,
+        };
+        return cachedResult;
+      }
+
+      throw new Error('Invalid response from background script');
+    } catch (error) {
+      eventEmitter.removeListener(onMessage);
+      logger.error('[makeOpenWindow] Failed to open window:', error);
+      throw error;
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Overlay helpers
+// ---------------------------------------------------------------------------
+
+export function createCompletionOverlay(
+  title = 'Proof complete!',
+  message = 'This window will close shortly.',
+): DomJson {
+  return {
+    type: 'div',
+    options: {
+      style: {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: '9999999',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      },
+    },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            backgroundColor: '#ffffff',
+            borderRadius: '16px',
+            padding: '40px 48px',
+            textAlign: 'center',
+            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
+            maxWidth: '360px',
+            width: '90%',
+          },
+        },
+        children: [
+          {
+            type: 'div',
+            options: {
+              style: {
+                width: '72px',
+                height: '72px',
+                margin: '0 auto 20px auto',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '48px',
+              },
+            },
+            children: ['✅'],
+          },
+          {
+            type: 'div',
+            options: {
+              style: {
+                fontSize: '22px',
+                fontWeight: '700',
+                color: '#111827',
+                marginBottom: '8px',
+                letterSpacing: '-0.02em',
+              },
+            },
+            children: [title],
+          },
+          {
+            type: 'div',
+            options: {
+              style: {
+                fontSize: '14px',
+                color: '#6b7280',
+                lineHeight: '1.5',
+              },
+            },
+            children: [message],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function createTimeoutWarningOverlay(): DomJson {
+  return {
+    type: 'div',
+    options: {
+      style: {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: '9999999',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      },
+    },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            backgroundColor: '#ffffff',
+            borderRadius: '16px',
+            padding: '40px 48px',
+            textAlign: 'center',
+            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
+            maxWidth: '360px',
+            width: '90%',
+          },
+        },
+        children: [
+          {
+            type: 'div',
+            options: {
+              style: {
+                width: '72px',
+                height: '72px',
+                margin: '0 auto 20px auto',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '48px',
+              },
+            },
+            children: ['⏱️'],
+          },
+          {
+            type: 'div',
+            options: {
+              style: {
+                fontSize: '22px',
+                fontWeight: '700',
+                color: '#111827',
+                marginBottom: '8px',
+                letterSpacing: '-0.02em',
+              },
+            },
+            children: ['Plugin Timeout Warning'],
+          },
+          {
+            type: 'div',
+            options: {
+              style: {
+                fontSize: '14px',
+                color: '#6b7280',
+                lineHeight: '1.5',
+                marginBottom: '24px',
+              },
+            },
+            children: ['The plugin will time out in less than 1 minute.'],
+          },
+          {
+            type: 'button',
+            options: {
+              onclick: '_extendTimeout',
+              style: {
+                padding: '12px 24px',
+                border: 'none',
+                borderRadius: '8px',
+                backgroundColor: '#2563eb',
+                color: '#ffffff',
+                fontSize: '14px',
+                fontWeight: '600',
+                cursor: 'pointer',
+                marginRight: '12px',
+              },
+            },
+            children: ['Extend by 5 min'],
+          },
+          {
+            type: 'button',
+            options: {
+              onclick: '_dismissTimeoutWarning',
+              style: {
+                padding: '12px 24px',
+                border: '1px solid #d1d5db',
+                borderRadius: '8px',
+                backgroundColor: '#ffffff',
+                color: '#374151',
+                fontSize: '14px',
+                cursor: 'pointer',
+              },
+            },
+            children: ['Let it expire'],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function createRevealApprovalOverlay(descriptors: RevealRangeDescriptor[]): DomJson {
+  const sentDescriptors = descriptors.filter((d) => d.direction === 'SENT');
+  const recvDescriptors = descriptors.filter((d) => d.direction === 'RECV');
+
+  const renderDescriptorRow = (descriptor: RevealRangeDescriptor): DomJson => {
+    const isReveal = descriptor.action === 'REVEAL';
+    return {
+      type: 'div',
+      options: {
+        style: {
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '8px',
+          marginBottom: '8px',
+        },
+      },
+      children: [
+        {
+          type: 'div',
+          options: {
+            style: { fontSize: '12px', color: '#374151', minWidth: '120px' },
+          },
+          children: [descriptor.label],
+        },
+        {
+          type: 'div',
+          options: {
+            style: {
+              fontSize: '11px',
+              fontWeight: '600',
+              padding: '2px 6px',
+              borderRadius: '4px',
+              backgroundColor: isReveal ? '#d1fae5' : '#fef3c7',
+              color: isReveal ? '#065f46' : '#92400e',
+            },
+          },
+          children: [descriptor.action],
+        },
+        {
+          type: 'div',
+          options: {
+            style: {
+              fontFamily: 'monospace',
+              fontSize: '11px',
+              color: isReveal ? '#6b7280' : '#9ca3af',
+              fontStyle: isReveal ? 'normal' : 'italic',
+              wordBreak: 'break-all',
+            },
+          },
+          children: [descriptor.preview],
+        },
+      ],
+    };
+  };
+
+  const renderSection = (
+    title: 'Sent' | 'Received',
+    sectionDescriptors: RevealRangeDescriptor[],
+  ): DomJson => ({
+    type: 'div',
+    options: { style: { marginBottom: '16px' } },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            fontSize: '12px',
+            fontWeight: '600',
+            color: '#6b7280',
+            textTransform: 'uppercase',
+            marginBottom: '8px',
+          },
+        },
+        children: [title],
+      },
+      ...sectionDescriptors.map(renderDescriptorRow),
+    ],
+  });
+
+  const cardChildren: DomJson[] = [
+    {
+      type: 'div',
+      options: {
+        style: {
+          fontSize: '20px',
+          fontWeight: '700',
+          color: '#111827',
+          marginBottom: '16px',
+        },
+      },
+      children: ['Approve Reveal to Verifier'],
+    },
+  ];
+
+  if (sentDescriptors.length > 0) cardChildren.push(renderSection('Sent', sentDescriptors));
+  if (recvDescriptors.length > 0) cardChildren.push(renderSection('Received', recvDescriptors));
+
+  cardChildren.push({
+    type: 'div',
+    options: {
+      style: {
+        display: 'flex',
+        justifyContent: 'flex-end',
+        gap: '12px',
+        marginTop: '24px',
+      },
+    },
+    children: [
+      {
+        type: 'button',
+        options: {
+          onclick: '_revealReject',
+          style: {
+            backgroundColor: '#fee2e2',
+            color: '#991b1b',
+            border: 'none',
+            padding: '8px 20px',
+            borderRadius: '8px',
+            fontWeight: '600',
+            cursor: 'pointer',
+          },
+        },
+        children: ['Reject'],
+      },
+      {
+        type: 'button',
+        options: {
+          onclick: '_revealApprove',
+          style: {
+            backgroundColor: '#d1fae5',
+            color: '#065f46',
+            border: 'none',
+            padding: '8px 20px',
+            borderRadius: '8px',
+            fontWeight: '600',
+            cursor: 'pointer',
+          },
+        },
+        children: ['Approve'],
+      },
+    ],
+  });
+
+  return {
+    type: 'div',
+    options: {
+      style: {
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: '9999998',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+      },
+    },
+    children: [
+      {
+        type: 'div',
+        options: {
+          style: {
+            backgroundColor: '#ffffff',
+            borderRadius: '16px',
+            padding: '32px',
+            maxWidth: '520px',
+            width: '90%',
+            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
+          },
+        },
+        children: cardChildren,
+      },
+    ],
+  };
+}
+
+export function decorateJson(base: DomJson, overlays: DomJson[]): DomJson {
+  if (overlays.length === 0) return base;
+  return {
+    type: 'div',
+    options: { style: {} },
+    children: [base, ...overlays],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// waitForWindow utility
+// ---------------------------------------------------------------------------
+
+export async function waitForWindow(
+  callback: () => Promise<number | undefined>,
+  retry = 0,
+): Promise<number | null> {
+  const resp = await callback();
+
+  if (resp) return resp;
+
+  if (retry < 100) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    return waitForWindow(callback, retry + 1);
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// HostCore
+// ---------------------------------------------------------------------------
+
+export class HostCore {
+  protected capabilities: Map<string, AnyFunction> = new Map();
+  private evaluator: PluginEvaluator;
+  private onProve: HostCoreOptions['onProve'];
+  private onRenderPluginUi: (windowId: number, result: DomJson) => void;
+  private onCloseWindow: (windowId: number) => void;
+  private onOpenWindow: HostCoreOptions['onOpenWindow'];
+  private _activeUuid: string | null = null;
+
+  constructor(options: HostCoreOptions) {
+    this.evaluator = options.evaluator;
+    this.onProve = options.onProve;
+    this.onRenderPluginUi = options.onRenderPluginUi;
+    this.onCloseWindow = options.onCloseWindow;
+    this.onOpenWindow = options.onOpenWindow;
+
+    logger.init(options.logLevel ?? DEFAULT_LOG_LEVEL);
+  }
+
+  addCapability(name: string, handler: AnyFunction): void {
+    this.capabilities.set(name, handler);
+  }
+
+  async executePlugin(
+    code: string,
+    {
+      eventEmitter,
+    }: {
+      eventEmitter: {
+        addListener: (listener: (message: WindowMessage) => void) => void;
+        removeListener: (listener: (message: WindowMessage) => void) => void;
+        emit: (message: WindowMessage) => void;
+      };
+    },
+  ): Promise<unknown> {
+    const uuid = uuidv4();
+    this._activeUuid = uuid;
+
+    const context: HookContext = {};
+    const stateStore: Record<string, unknown> = {};
+
+    let doneResolve: (value?: unknown) => void;
+    let doneReject: (error: Error) => void;
+
+    const lifecycle: PluginLifecycle = {
+      isCompleted: false,
+      pendingCallbacks: 0,
+      onDrain: null,
+    };
+
+    const donePromise = new Promise((resolve, reject) => {
+      doneResolve = resolve;
+      doneReject = reject;
+    });
+
+    const DRAIN_TIMEOUT_MS = 30_000;
+
+    const waitForPendingCallbacks = (): Promise<void> => {
+      if (lifecycle.pendingCallbacks === 0) return Promise.resolve();
+
+      if (lifecycle.onDrain !== null) {
+        logger.warn(
+          '[executePlugin] onDrain already set — multiple waiters detected, this is a bug',
+        );
+      }
+
+      return new Promise<void>((resolve) => {
+        lifecycle.onDrain = resolve;
+
+        setTimeout(() => {
+          if (lifecycle.onDrain === resolve) {
+            logger.warn(
+              `[executePlugin] Timed out waiting for ${lifecycle.pendingCallbacks} callback(s) to drain after ${DRAIN_TIMEOUT_MS}ms — forcing disposal`,
+            );
+            lifecycle.onDrain = null;
+            resolve();
+          }
+        }, DRAIN_TIMEOUT_MS);
+      });
+    };
+
+    // Mutable reference: updated once evaluate() resolves.
+    // terminateWithError / done / doneWithOverlay all call this.
+    let dispose: () => void = () => {};
+
+    const terminateWithError = (error: Error) => {
+      if (lifecycle.isCompleted) return;
+      lifecycle.isCompleted = true;
+      logger.error('[executePlugin] Plugin terminated with error:', error);
+
+      const ctx = executionContextRegistry.get(uuid);
+      const pendingApproval = ctx?.revealApproval;
+      if (pendingApproval) {
+        try {
+          pendingApproval.reject(error);
+        } catch (rejectError) {
+          logger.error('[executePlugin] Error rejecting pending reveal approval:', rejectError);
+        }
+      }
+      if (ctx?.windowId) {
+        try {
+          this.onCloseWindow(ctx.windowId);
+        } catch (closeError) {
+          logger.error('[executePlugin] Error closing window:', closeError);
+        }
+      }
+
+      const finalize = () => {
+        executionContextRegistry.delete(uuid);
+        doneReject(error);
+        try {
+          dispose();
+        } catch (disposeError) {
+          logger.error('[executePlugin] Error disposing evaluator:', disposeError);
+        }
+      };
+
+      if (lifecycle.pendingCallbacks > 0) {
+        logger.debug(
+          `[executePlugin] Deferring disposal: ${lifecycle.pendingCallbacks} callback(s) in-flight`,
+        );
+        waitForPendingCallbacks().then(finalize);
+      } else {
+        finalize();
+      }
+    };
+
+    const onCloseWindow = this.onCloseWindow;
+    const onRenderPluginUi = this.onRenderPluginUi;
+    const onOpenWindow = this.onOpenWindow;
+    const onProve = this.onProve;
+
+    // Build the capabilities map that is passed to the evaluator.
+    // Custom capabilities (addCapability) are merged in last.
+    const capabilities: Record<string, AnyFunction> = {
+      div: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
+        createDomJson('div', param1, param2),
+      button: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
+        createDomJson('button', param1, param2),
+      input: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
+        createDomJson('input', param1, param2),
+      openWindow: makeOpenWindow(
+        uuid,
+        eventEmitter,
+        onOpenWindow,
+        onCloseWindow,
+        lifecycle,
+        (err: Error) => terminateWithError(err),
+      ),
+      useEffect: makeUseEffect(uuid, context),
+      useRequests: makeUseRequests(uuid, context),
+      useHeaders: makeUseHeaders(uuid, context),
+      useState: makeUseState(uuid, stateStore, eventEmitter),
+      setState: makeSetState(uuid, stateStore, eventEmitter),
+      usePluginTimeout: makeUsePluginTimeout(stateStore),
+      prove: async (
+        requestOptions: Parameters<typeof onProve>[0],
+        proverOptions: Parameters<typeof onProve>[1],
+      ) => {
+        const setProgress = (data: ProveProgressData) => {
+          stateStore['_proveProgress'] = data;
+          eventEmitter.emit({
+            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+          });
+        };
+        setProgress({ step: 'CONNECTING', progress: 0, message: 'Connecting...' });
+        try {
+          const canonicalProverOptions = {
+            ...proverOptions,
+            handlers: canonicalizeHandlers(proverOptions.handlers),
+          };
+          const result = await onProve(requestOptions, canonicalProverOptions, setProgress);
+          setProgress({ step: 'COMPLETE', progress: 1, message: 'Complete' });
+          return result;
+        } catch (err) {
+          stateStore['_proveProgress'] = null;
+          eventEmitter.emit({
+            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+          });
+          throw err;
+        }
+      },
+      done: (args?: unknown) => {
+        if (lifecycle.isCompleted) return;
+        lifecycle.isCompleted = true;
+
+        const ctx = executionContextRegistry.get(uuid);
+        if (ctx?.windowId) {
+          onCloseWindow(ctx.windowId);
+        }
+
+        const wasRejected = ctx?.revealWasRejected === true;
+        const finalize = () => {
+          executionContextRegistry.delete(uuid);
+          if (wasRejected) {
+            doneReject(new Error('User rejected reveal'));
+          } else {
+            doneResolve(args);
+          }
+          try {
+            dispose();
+          } catch (disposeError) {
+            logger.error('[executePlugin] Error disposing evaluator:', disposeError);
+          }
+        };
+
+        if (lifecycle.pendingCallbacks > 0) {
+          logger.debug(
+            `[executePlugin] done() called with ${lifecycle.pendingCallbacks} callback(s) in-flight, deferring cleanup`,
+          );
+          waitForPendingCallbacks().then(finalize);
+        } else {
+          finalize();
+        }
+      },
+      getJsonBody: (request: InterceptedRequest) => getJsonBody(request),
+      doneWithOverlay: (
+        args?: unknown,
+        options?: { title?: string; message?: string; delayMs?: number },
+      ) => {
+        if (lifecycle.isCompleted) return;
+        lifecycle.isCompleted = true;
+
+        const ctx = executionContextRegistry.get(uuid);
+        const windowId = ctx?.windowId;
+        const wasRejected = ctx?.revealWasRejected === true;
+        const settle = () => {
+          if (wasRejected) {
+            doneReject(new Error('User rejected reveal'));
+          } else {
+            doneResolve(args);
+          }
+        };
+
+        if (!windowId) {
+          const finalize = () => {
+            executionContextRegistry.delete(uuid);
+            settle();
+            try {
+              dispose();
+            } catch (disposeError) {
+              logger.error('[executePlugin] Error disposing evaluator:', disposeError);
+            }
+          };
+
+          if (lifecycle.pendingCallbacks > 0) {
+            waitForPendingCallbacks().then(finalize);
+          } else {
+            finalize();
+          }
+          return;
+        }
+
+        const delayMs = options?.delayMs ?? 2000;
+        onRenderPluginUi(windowId, createCompletionOverlay(options?.title, options?.message));
+
+        const closeAndFinalize = () => {
+          onCloseWindow(windowId);
+          executionContextRegistry.delete(uuid);
+          settle();
+          try {
+            dispose();
+          } catch (disposeError) {
+            logger.error('[executePlugin] Error disposing evaluator:', disposeError);
+          }
+        };
+
+        const startDelay = () => {
+          setTimeout(closeAndFinalize, delayMs);
+        };
+
+        if (lifecycle.pendingCallbacks > 0) {
+          waitForPendingCallbacks().then(startDelay);
+        } else {
+          startDelay();
+        }
+      },
+    };
+
+    // Merge in any custom capabilities registered via addCapability()
+    for (const [name, handler] of this.capabilities) {
+      capabilities[name] = handler;
+    }
+
+    // --- Call the platform-specific evaluator ---
+    let exportedCode: Record<string, unknown>;
+    try {
+      const result = await this.evaluator.evaluate(code, capabilities);
+      exportedCode = result.exports;
+      dispose = result.dispose; // Update mutable ref now that evaluator has returned
+    } catch (evalError) {
+      const error = evalError instanceof Error ? evalError : new Error(String(evalError));
+      terminateWithError(new Error(`Plugin evaluation failed: ${error.message}`));
+      return donePromise;
+    }
+
+    const { main: rawMainFn, ...args } = exportedCode;
+
+    if (typeof rawMainFn !== 'function') {
+      terminateWithError(new Error('Main function not found in plugin'));
+      return donePromise;
+    }
+
+    const mainFn = rawMainFn as (...args: unknown[]) => DomJson | null;
+
+    const callbacks: { [callbackName: string]: () => Promise<void> } = {};
+
+    for (const key in args) {
+      if (typeof args[key] === 'function') {
+        callbacks[key] = args[key] as () => Promise<void>;
+      }
+    }
+
+    let json: DomJson | null = null;
+
+    const main = (force = false) => {
+      if (lifecycle.isCompleted) return null;
+
+      try {
+        updateExecutionContext(uuid, { currentContext: 'main' });
+
+        let result = mainFn();
+        const lastSelectors = executionContextRegistry.get(uuid)?.context['main']?.selectors;
+        const selectors = context['main']?.selectors;
+        const lastStateStore = executionContextRegistry.get(uuid)?.stateStore;
+
+        if (
+          !force &&
+          deepEqual(lastSelectors, selectors) &&
+          deepEqual(lastStateStore, stateStore)
+        ) {
+          result = null;
+        }
+
+        updateExecutionContext(uuid, {
+          currentContext: '',
+          context: {
+            ...executionContextRegistry.get(uuid)?.context,
+            main: {
+              effects: JSON.parse(JSON.stringify(context['main']?.effects ?? [])),
+              selectors: JSON.parse(JSON.stringify(context['main']?.selectors ?? [])),
+            },
+          },
+          stateStore: JSON.parse(JSON.stringify(stateStore)),
+        });
+
+        if (context['main']) {
+          context['main'].effects.length = 0;
+          context['main'].selectors.length = 0;
+        }
+
+        if (result) {
+          logger.debug('Main function executed:', result);
+          logger.debug(
+            'executionContextRegistry.get(uuid)?.windowId',
+            executionContextRegistry.get(uuid)?.windowId,
+          );
+
+          const overlays: DomJson[] = [];
+          const ctx = executionContextRegistry.get(uuid);
+          if (ctx?.revealApprovalDescriptors) {
+            overlays.push(createRevealApprovalOverlay(ctx.revealApprovalDescriptors));
+          }
+          if (timeoutWarningShown) {
+            overlays.push(createTimeoutWarningOverlay());
+          }
+          json = decorateJson(result, overlays);
+
+          waitForWindow(async () => executionContextRegistry.get(uuid)?.windowId).then(
+            (windowId: number | null) => {
+              if (windowId == null) {
+                logger.error(
+                  '[executePlugin] Window never opened after timeout, skipping UI render',
+                );
+                return;
+              }
+              logger.debug('render result', json as DomJson);
+              onRenderPluginUi(windowId, json as DomJson);
+            },
+          );
+        }
+
+        return result;
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        terminateWithError(new Error(`Plugin main() error: ${err.message}`));
+        return null;
+      }
+    };
+
+    executionContextRegistry.set(uuid, {
+      id: uuid,
+      plugin: code,
+      pluginUrl: '',
+      context: {},
+      currentContext: '',
+      // Provide a compatible sandbox stub so the ExecutionContext type is satisfied.
+      // The real dispose is called via the `dispose` closure above.
+      sandbox: { eval: async () => undefined, dispose: () => dispose() },
+      main: main,
+      callbacks: callbacks,
+      stateStore: {},
+    });
+
+    // --- Timeout lifecycle ---
+    const pluginConfig = args.config as PluginConfig | undefined;
+    const timeoutMs = clampTimeout(pluginConfig?.timeout);
+    let deadline = Date.now() + timeoutMs;
+    let timeoutWarningShown = false;
+
+    const updateTimeoutState = () => {
+      const remaining = Math.max(0, deadline - Date.now());
+      stateStore['_pluginTimeout'] = { remaining, total: timeoutMs };
+    };
+
+    const extendTimeout = () => {
+      deadline = Date.now() + TIMEOUT_EXTEND_MS;
+      timeoutWarningShown = false;
+      updateTimeoutState();
+      eventEmitter.emit({
+        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+        windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+      });
+    };
+
+    const dismissTimeoutWarning = () => {
+      timeoutWarningShown = false;
+      eventEmitter.emit({
+        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+        windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+      });
+    };
+
+    callbacks['_extendTimeout'] = async () => {
+      extendTimeout();
+    };
+    callbacks['_dismissTimeoutWarning'] = async () => {
+      dismissTimeoutWarning();
+    };
+
+    updateTimeoutState();
+
+    const timeoutIntervalId = setInterval(() => {
+      if (lifecycle.isCompleted) {
+        clearInterval(timeoutIntervalId);
+        return;
+      }
+
+      const remaining = deadline - Date.now();
+      updateTimeoutState();
+
+      if (remaining <= TIMEOUT_WARNING_LEAD_MS && remaining > 0 && !timeoutWarningShown) {
+        timeoutWarningShown = true;
+        eventEmitter.emit({
+          type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+          windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+        });
+      }
+
+      if (remaining <= 0) {
+        clearInterval(timeoutIntervalId);
+        terminateWithError(new Error('Plugin execution timeout'));
+      }
+    }, 1000);
+
+    const cleanup = () => {
+      clearInterval(timeoutIntervalId);
+      if (this._activeUuid === uuid) {
+        this._activeUuid = null;
+      }
+    };
+    donePromise.then(cleanup, cleanup);
+
+    main();
+
+    return donePromise;
+  }
+
+  createDomJson = (
+    type: 'div' | 'button' | 'input',
+    param1: DomOptions | DomJson[] = {},
+    param2: DomJson[] = [],
+  ): DomJson => {
+    return createDomJson(type, param1, param2);
+  };
+
+  registerRevealApproval(
+    resolve: () => void,
+    reject: (err: Error) => void,
+    descriptors: RevealRangeDescriptor[],
+  ): void {
+    if (!this._activeUuid) return;
+    const uuid = this._activeUuid;
+    updateExecutionContext(uuid, {
+      revealApproval: { resolve, reject },
+      revealApprovalDescriptors: descriptors,
+    });
+    const ctx = executionContextRegistry.get(uuid);
+    ctx?.main(true);
+  }
+
+  renderUi(windowId: number, json: DomJson): void {
+    this.onRenderPluginUi(windowId, json);
+  }
+}

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -94,6 +94,8 @@ export interface HostCoreOptions {
     },
   ) => Promise<OpenWindowResponse>;
   logLevel?: LogLevel;
+  reRenderEvent?: string;
+  enableTimeout?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +265,7 @@ export function makeSetState(
   eventEmitter: {
     emit: (message: WindowMessage) => void;
   },
+  reRenderEvent: string,
 ) {
   return (key: string, value: unknown) => {
     const executionContext = executionContextRegistry.get(uuid);
@@ -275,9 +278,9 @@ export function makeSetState(
     }
 
     eventEmitter.emit({
-      type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+      type: reRenderEvent,
       windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-    });
+    } as WindowMessage);
   };
 }
 
@@ -997,6 +1000,8 @@ export class HostCore {
   private onCloseWindow: (windowId: number) => void;
   private onOpenWindow: HostCoreOptions['onOpenWindow'];
   private _activeUuid: string | null = null;
+  private reRenderEvent: string;
+  private enableTimeout: boolean;
 
   constructor(options: HostCoreOptions) {
     this.evaluator = options.evaluator;
@@ -1004,6 +1009,8 @@ export class HostCore {
     this.onRenderPluginUi = options.onRenderPluginUi;
     this.onCloseWindow = options.onCloseWindow;
     this.onOpenWindow = options.onOpenWindow;
+    this.reRenderEvent = options.reRenderEvent ?? 'TO_BG_RE_RENDER_PLUGIN_UI';
+    this.enableTimeout = options.enableTimeout ?? true;
 
     logger.init(options.logLevel ?? DEFAULT_LOG_LEVEL);
   }
@@ -1026,6 +1033,8 @@ export class HostCore {
   ): Promise<unknown> {
     const uuid = uuidv4();
     this._activeUuid = uuid;
+
+    const reRenderEvent = this.reRenderEvent;
 
     const context: HookContext = {};
     const stateStore: Record<string, unknown> = {};
@@ -1142,7 +1151,7 @@ export class HostCore {
       useRequests: makeUseRequests(uuid, context),
       useHeaders: makeUseHeaders(uuid, context),
       useState: makeUseState(uuid, stateStore, eventEmitter),
-      setState: makeSetState(uuid, stateStore, eventEmitter),
+      setState: makeSetState(uuid, stateStore, eventEmitter, reRenderEvent),
       usePluginTimeout: makeUsePluginTimeout(stateStore),
       prove: async (
         requestOptions: Parameters<typeof onProve>[0],
@@ -1151,9 +1160,9 @@ export class HostCore {
         const setProgress = (data: ProveProgressData) => {
           stateStore['_proveProgress'] = data;
           eventEmitter.emit({
-            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+            type: reRenderEvent,
             windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-          });
+          } as WindowMessage);
         };
         setProgress({ step: 'CONNECTING', progress: 0, message: 'Connecting...' });
         try {
@@ -1167,9 +1176,9 @@ export class HostCore {
         } catch (err) {
           stateStore['_proveProgress'] = null;
           eventEmitter.emit({
-            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+            type: reRenderEvent,
             windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-          });
+          } as WindowMessage);
           throw err;
         }
       },
@@ -1411,17 +1420,17 @@ export class HostCore {
       timeoutWarningShown = false;
       updateTimeoutState();
       eventEmitter.emit({
-        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+        type: reRenderEvent,
         windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-      });
+      } as WindowMessage);
     };
 
     const dismissTimeoutWarning = () => {
       timeoutWarningShown = false;
       eventEmitter.emit({
-        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
+        type: reRenderEvent,
         windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-      });
+      } as WindowMessage);
     };
 
     callbacks['_extendTimeout'] = async () => {
@@ -1433,31 +1442,35 @@ export class HostCore {
 
     updateTimeoutState();
 
-    const timeoutIntervalId = setInterval(() => {
-      if (lifecycle.isCompleted) {
-        clearInterval(timeoutIntervalId);
-        return;
-      }
+    let timeoutIntervalId: ReturnType<typeof setInterval> | null = null;
 
-      const remaining = deadline - Date.now();
-      updateTimeoutState();
+    if (this.enableTimeout) {
+      timeoutIntervalId = setInterval(() => {
+        if (lifecycle.isCompleted) {
+          if (timeoutIntervalId !== null) clearInterval(timeoutIntervalId);
+          return;
+        }
 
-      if (remaining <= TIMEOUT_WARNING_LEAD_MS && remaining > 0 && !timeoutWarningShown) {
-        timeoutWarningShown = true;
-        eventEmitter.emit({
-          type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-          windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-        });
-      }
+        const remaining = deadline - Date.now();
+        updateTimeoutState();
 
-      if (remaining <= 0) {
-        clearInterval(timeoutIntervalId);
-        terminateWithError(new Error('Plugin execution timeout'));
-      }
-    }, 1000);
+        if (remaining <= TIMEOUT_WARNING_LEAD_MS && remaining > 0 && !timeoutWarningShown) {
+          timeoutWarningShown = true;
+          eventEmitter.emit({
+            type: reRenderEvent,
+            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+          } as WindowMessage);
+        }
+
+        if (remaining <= 0) {
+          if (timeoutIntervalId !== null) clearInterval(timeoutIntervalId);
+          terminateWithError(new Error('Plugin execution timeout'));
+        }
+      }, 1000);
+    }
 
     const cleanup = () => {
-      clearInterval(timeoutIntervalId);
+      if (timeoutIntervalId !== null) clearInterval(timeoutIntervalId);
       if (this._activeUuid === uuid) {
         this._activeUuid = null;
       }
@@ -1494,5 +1507,23 @@ export class HostCore {
 
   renderUi(windowId: number, json: DomJson): void {
     this.onRenderPluginUi(windowId, json);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// NativeFunctionEvaluator
+// ---------------------------------------------------------------------------
+
+export class NativeFunctionEvaluator implements PluginEvaluator {
+  async evaluate(
+    code: string,
+    capabilities: Record<string, AnyFunction>,
+  ): Promise<PluginEvaluatorResult> {
+    const keys = Object.keys(capabilities);
+    const vals = Object.values(capabilities);
+    const fn = new Function(...keys, code);
+    const exports: Record<string, unknown> = {};
+    fn.call(exports, ...vals);
+    return { exports, dispose: () => {} };
   }
 }

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -1514,16 +1514,50 @@ export class HostCore {
 // NativeFunctionEvaluator
 // ---------------------------------------------------------------------------
 
+function preprocessForNativeEval(code: string): string {
+  // Collect named exports: export function main() / export const config = ...
+  const exportNames: string[] = [];
+  const exportRegex = /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
+  let match;
+  while ((match = exportRegex.exec(code)) !== null) {
+    exportNames.push(match[1]);
+  }
+
+  if (exportNames.length > 0) {
+    const stripped = code.replace(/^(\s*)export\s+/gm, '$1');
+    const entries = exportNames
+      .map((n) => `${n}: typeof ${n} === 'function' ? (...args) => ${n}(...args) : ${n}`)
+      .join(',\n  ');
+    return `${stripped}\nreturn { ${entries} };`;
+  }
+
+  // Handle export default { ... }
+  const defaultMatch = code.match(/export\s+default\s+\{([^}]+)\}\s*;?\s*$/);
+  if (defaultMatch) {
+    const names = defaultMatch[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const stripped = code.replace(/export\s+default\s+\{[^}]+\}\s*;?\s*$/, '');
+    const entries = names
+      .map((n) => `${n}: typeof ${n} === 'function' ? (...args) => ${n}(...args) : ${n}`)
+      .join(',\n  ');
+    return `${stripped}\nreturn { ${entries} };`;
+  }
+
+  return code;
+}
+
 export class NativeFunctionEvaluator implements PluginEvaluator {
   async evaluate(
     code: string,
     capabilities: Record<string, AnyFunction>,
   ): Promise<PluginEvaluatorResult> {
+    const processedCode = preprocessForNativeEval(code);
     const keys = Object.keys(capabilities);
     const vals = Object.values(capabilities);
-    const fn = new Function(...keys, code);
-    const exports: Record<string, unknown> = {};
-    fn.call(exports, ...vals);
+    const fn = new Function(...keys, processedCode);
+    const exports = (fn(...vals) as Record<string, unknown>) ?? {};
     return { exports, dispose: () => {} };
   }
 }

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -96,6 +96,14 @@ export interface HostCoreOptions {
   logLevel?: LogLevel;
   reRenderEvent?: string;
   enableTimeout?: boolean;
+  /**
+   * If set, the host calls this when the plugin enters its
+   * `TIMEOUT_WARNING_LEAD_MS` window — instead of decorating the plugin's
+   * DomJson with the built-in timeout warning overlay. Lets platforms render
+   * a native warning UI (e.g. a bottom sheet on mobile). The callback is
+   * fired at most once per warning cycle; calling `extend` resets the cycle.
+   */
+  onTimeoutWarning?: (callbacks: { extend: () => void; dismiss: () => void }) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -1006,6 +1014,7 @@ export class HostCore {
   private _activeUuid: string | null = null;
   private reRenderEvent: string;
   private enableTimeout: boolean;
+  private onTimeoutWarning?: HostCoreOptions['onTimeoutWarning'];
 
   constructor(options: HostCoreOptions) {
     this.evaluator = options.evaluator;
@@ -1015,6 +1024,7 @@ export class HostCore {
     this.onOpenWindow = options.onOpenWindow;
     this.reRenderEvent = options.reRenderEvent ?? 'TO_BG_RE_RENDER_PLUGIN_UI';
     this.enableTimeout = options.enableTimeout ?? true;
+    this.onTimeoutWarning = options.onTimeoutWarning;
 
     logger.init(options.logLevel ?? DEFAULT_LOG_LEVEL);
   }
@@ -1367,7 +1377,9 @@ export class HostCore {
           if (ctx?.revealApprovalDescriptors) {
             overlays.push(createRevealApprovalOverlay(ctx.revealApprovalDescriptors));
           }
-          if (timeoutWarningShown) {
+          // Skip the DomJson overlay if a native warning handler is registered;
+          // the platform will render its own UI via onTimeoutWarning.
+          if (timeoutWarningShown && !this.onTimeoutWarning) {
             overlays.push(createTimeoutWarningOverlay());
           }
           json = decorateJson(result, overlays);
@@ -1459,11 +1471,21 @@ export class HostCore {
         updateTimeoutState();
 
         if (remaining <= TIMEOUT_WARNING_LEAD_MS && remaining > 0 && !timeoutWarningShown) {
-          timeoutWarningShown = true;
-          eventEmitter.emit({
-            type: reRenderEvent,
-            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-          } as WindowMessage);
+          if (this.onTimeoutWarning) {
+            // Native warning path: don't flip the DomJson decorator flag, but
+            // still mark that the warning fired so we don't re-fire each tick.
+            timeoutWarningShown = true;
+            this.onTimeoutWarning({
+              extend: extendTimeout,
+              dismiss: dismissTimeoutWarning,
+            });
+          } else {
+            timeoutWarningShown = true;
+            eventEmitter.emit({
+              type: reRenderEvent,
+              windowId: executionContextRegistry.get(uuid)?.windowId || 0,
+            } as WindowMessage);
+          }
         }
 
         if (remaining <= 0) {

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -406,6 +406,9 @@ export function makeOpenWindow(
 
         if (message.type === 'HEADER_INTERCEPTED') {
           const header = message.header;
+          logger.warn(
+            `[makeOpenWindow] HEADER_INTERCEPTED: ${header.url} (total=${(executionContext.headers?.length ?? 0) + 1})`,
+          );
           updateExecutionContext(uuid, {
             headers: [...(executionContext.headers || []), header],
           });

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -381,6 +381,9 @@ export function makeOpenWindow(
       }
 
       if (message.windowId !== executionContext.windowId) {
+        logger.warn(
+          `[makeOpenWindow] Dropping ${message.type}: windowId ${message.windowId} != ctx.windowId ${executionContext.windowId}`,
+        );
         return;
       }
 

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -381,9 +381,6 @@ export function makeOpenWindow(
       }
 
       if (message.windowId !== executionContext.windowId) {
-        logger.warn(
-          `[makeOpenWindow] Dropping ${message.type}: windowId ${message.windowId} != ctx.windowId ${executionContext.windowId}`,
-        );
         return;
       }
 
@@ -406,9 +403,6 @@ export function makeOpenWindow(
 
         if (message.type === 'HEADER_INTERCEPTED') {
           const header = message.header;
-          logger.warn(
-            `[makeOpenWindow] HEADER_INTERCEPTED: ${header.url} (total=${(executionContext.headers?.length ?? 0) + 1})`,
-          );
           updateExecutionContext(uuid, {
             headers: [...(executionContext.headers || []), header],
           });
@@ -478,7 +472,11 @@ export function makeOpenWindow(
 
         if (message.type === 'RE_RENDER_PLUGIN_UI') {
           logger.debug('[makeOpenWindow] RE_RENDER_PLUGIN_UI', message.windowId);
-          executionContext.main(true);
+          // Defer to a microtask so a setState() that fires synchronously from
+          // within main() runs the re-render AFTER the current main() returns.
+          // Otherwise the inner re-render's DOM gets overwritten by the outer
+          // run's stale DOM via the closure-captured `json` reference.
+          Promise.resolve().then(() => executionContext.main(true));
         }
       } catch (error) {
         logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -14,6 +14,7 @@ import {
   AnyFunction,
   HookContext,
   updateExecutionContext,
+  extractPluginExports,
 } from './host-core';
 import { InterceptedRequest, InterceptedRequestHeader, PluginConfig } from './types';
 
@@ -40,51 +41,14 @@ export {
  *    are silently discarded.
  *
  * This function strips named exports, then re-exports them via `export default { ... }`
- * with arrow function wrappers (arrow functions have no .prototype).
+ * with arrow function wrappers (arrow functions have no .prototype). The parse step
+ * is shared with NativeFunctionEvaluator via `extractPluginExports`; only the
+ * trailer differs (ES module export here, function-body return there).
  */
 export function preprocessPluginCode(code: string): string {
-  // Handle named exports: export function main() / export const config = ...
-  const exportNames: string[] = [];
-  const exportRegex = /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
-  let match;
-
-  while ((match = exportRegex.exec(code)) !== null) {
-    exportNames.push(match[1]);
-  }
-
-  if (exportNames.length > 0) {
-    const strippedCode = code.replace(/^(\s*)export\s+/gm, '$1');
-    const entries = exportNames
-      .map(
-        (name) =>
-          `${name}: typeof ${name} === 'function' ? (...args) => ${name}(...args) : ${name}`,
-      )
-      .join(',\n  ');
-
-    return `${strippedCode}\nexport default { ${entries} };`;
-  }
-
-  // Handle export default { ... } — wrap function references in arrow functions
-  // to avoid QuickJS handleToNative stack overflow on .prototype
-  const defaultExportMatch = code.match(/export\s+default\s+\{([^}]+)\}\s*;?\s*$/);
-
-  if (defaultExportMatch) {
-    const names = defaultExportMatch[1]
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
-    const strippedCode = code.replace(/export\s+default\s+\{[^}]+\}\s*;?\s*$/, '');
-    const entries = names
-      .map(
-        (name) =>
-          `${name}: typeof ${name} === 'function' ? (...args) => ${name}(...args) : ${name}`,
-      )
-      .join(',\n  ');
-
-    return `${strippedCode}\nexport default { ${entries} };`;
-  }
-
-  return code;
+  const parsed = extractPluginExports(code);
+  if (!parsed) return code;
+  return `${parsed.stripped}\nexport default { ${parsed.entries} };`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -368,7 +368,7 @@ export { getJsonBody } from './host-core';
 
 // Export HostCore and PluginEvaluator for platform implementors
 export type { PluginEvaluator, PluginEvaluatorResult, HostCoreOptions } from './host-core';
-export { HostCore } from './host-core';
+export { HostCore, NativeFunctionEvaluator } from './host-core';
 
 // Timeout constants (consumed by tests and extension code)
 export {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -6,569 +6,16 @@
 
 import { SandboxEvalCode, type SandboxOptions, loadQuickJs } from '@sebastianwessel/quickjs';
 import variant from '@jitl/quickjs-ng-wasmfile-release-sync';
-import { v4 as uuidv4 } from 'uuid';
-import { logger, LogLevel, DEFAULT_LOG_LEVEL } from '@tlsn/common';
 import {
-  DomJson,
-  DomOptions,
-  ExecutionContext,
-  InterceptedRequest,
-  InterceptedRequestHeader,
-  OpenWindowResponse,
-  WindowMessage,
-  Handler,
-  PluginConfig,
-  ProveProgressData,
-  RevealRangeDescriptor,
-  canonicalizeHandlers,
-} from './types';
-import deepEqual from 'fast-deep-equal';
-
-// Type alias for hook context used throughout the module
-type HookContext = {
-  [functionName: string]: {
-    effects: unknown[][];
-    selectors: unknown[][];
-  };
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyFunction = (...args: any[]) => any;
-
-// Module-level registry to avoid circular references in capability closures
-const executionContextRegistry = new Map<string, ExecutionContext>();
-
-// Timeout constants
-export const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
-export const MIN_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes
-export const MAX_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
-export const TIMEOUT_WARNING_LEAD_MS = 60 * 1000; // 1 minute warning
-export const TIMEOUT_EXTEND_MS = 5 * 60 * 1000; // 5 minutes per extend
-
-export function clampTimeout(value?: number): number {
-  if (value == null) return DEFAULT_TIMEOUT_MS;
-  return Math.max(MIN_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, value));
-}
-
-// Pure function for updating execution context without `this` binding
-function updateExecutionContext(
-  uuid: string,
-  params: {
-    windowId?: number;
-    plugin?: string;
-    requests?: InterceptedRequest[];
-    headers?: InterceptedRequestHeader[];
-    context?: HookContext;
-    currentContext?: string;
-    stateStore?: Record<string, unknown>;
-    revealApproval?: { resolve: () => void; reject: (err: Error) => void } | null;
-    revealApprovalDescriptors?: RevealRangeDescriptor[] | null;
-    revealWasRejected?: boolean;
-  },
-): void {
-  const context = executionContextRegistry.get(uuid);
-  if (!context) {
-    throw new Error('Execution context not found');
-  }
-  executionContextRegistry.set(uuid, { ...context, ...params });
-}
-
-// Pure function for creating DOM JSON without `this` binding
-function createDomJson(
-  type: 'div' | 'button' | 'input',
-  param1: DomOptions | DomJson[] = {},
-  param2: DomJson[] = [],
-): DomJson {
-  let options: DomOptions = {};
-  let children: DomJson[] = [];
-
-  if (Array.isArray(param1)) {
-    children = param1;
-  } else if (typeof param1 === 'object') {
-    options = param1;
-    children = param2;
-  }
-
-  return {
-    type,
-    options,
-    children,
-  };
-}
-
-// Pure function for creating useEffect hook without `this` binding
-function makeUseEffect(uuid: string, context: HookContext) {
-  return (effect: () => void, deps: unknown[]) => {
-    const executionContext = executionContextRegistry.get(uuid);
-    if (!executionContext) {
-      throw new Error('Execution context not found');
-    }
-    const functionName = executionContext.currentContext;
-    context[functionName] = context[functionName] || {
-      effects: [],
-      selectors: [],
-    };
-    const effects = context[functionName].effects;
-    const lastDeps = executionContext.context[functionName]?.effects[effects.length];
-    effects.push(deps);
-    if (deepEqual(lastDeps, deps)) {
-      return;
-    }
-    effect();
-  };
-}
-
-// Pure function for creating useRequests hook without `this` binding
-function makeUseRequests(uuid: string, context: HookContext) {
-  return (filterFn: (requests: InterceptedRequest[]) => InterceptedRequest[]) => {
-    const executionContext = executionContextRegistry.get(uuid);
-    if (!executionContext) {
-      throw new Error('Execution context not found');
-    }
-    const functionName = executionContext.currentContext;
-    context[functionName] = context[functionName] || {
-      effects: [],
-      selectors: [],
-    };
-    const selectors = context[functionName].selectors;
-    const requests = JSON.parse(JSON.stringify(executionContext.requests || []));
-    const result = filterFn(requests);
-    selectors.push(result);
-    return result;
-  };
-}
-
-// Pure function for creating useHeaders hook without `this` binding
-function makeUseHeaders(uuid: string, context: HookContext) {
-  return (filterFn: (headers: InterceptedRequestHeader[]) => InterceptedRequestHeader[]) => {
-    const executionContext = executionContextRegistry.get(uuid);
-    if (!executionContext) {
-      throw new Error('Execution context not found');
-    }
-    const functionName = executionContext.currentContext;
-    context[functionName] = context[functionName] || {
-      effects: [],
-      selectors: [],
-    };
-    const selectors = context[functionName].selectors;
-    // Serialize headers to break circular references
-    const headers = JSON.parse(JSON.stringify(executionContext.headers || []));
-    const result = filterFn(headers);
-
-    // Validate that filterFn returned an array
-    if (result === undefined) {
-      throw new Error(`useHeaders: filter function returned undefined. expect an array`);
-    }
-    if (!Array.isArray(result)) {
-      throw new Error(`useHeaders: filter function must return an array, got ${typeof result}. `);
-    }
-
-    selectors.push(result);
-    return result;
-  };
-}
-
-function makeUseState(
-  uuid: string,
-  stateStore: Record<string, unknown>,
-  _eventEmitter: {
-    emit: (message: WindowMessage) => void;
-  },
-) {
-  return (key: string, defaultValue: unknown) => {
-    const executionContext = executionContextRegistry.get(uuid);
-    if (!executionContext) {
-      throw new Error('Execution context not found');
-    }
-    if (!(key in stateStore) && defaultValue !== undefined) {
-      stateStore[key] = defaultValue;
-    }
-    // eventEmitter.emit({
-    //   type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-    //   windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-    // });
-    return stateStore[key];
-  };
-}
-
-function makeSetState(
-  uuid: string,
-  stateStore: Record<string, unknown>,
-  eventEmitter: {
-    emit: (message: WindowMessage) => void;
-  },
-) {
-  return (key: string, value: unknown) => {
-    const executionContext = executionContextRegistry.get(uuid);
-    if (!executionContext) {
-      throw new Error('Execution context not found');
-    }
-    stateStore[key] = value;
-    if (deepEqual(stateStore, executionContext.stateStore)) {
-      return;
-    }
-
-    eventEmitter.emit({
-      type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-      windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-    });
-  };
-}
-
-// Pure function for creating usePluginTimeout hook
-function makeUsePluginTimeout(stateStore: Record<string, unknown>) {
-  return (): { remaining: number; total: number } | null => {
-    return (stateStore['_pluginTimeout'] as { remaining: number; total: number }) ?? null;
-  };
-}
-
-/**
- * Tracks the lifecycle of a plugin execution to prevent race conditions
- * between async callbacks and sandbox disposal.
- */
-interface PluginLifecycle {
-  /** Whether the plugin has completed (done() or terminateWithError called) */
-  isCompleted: boolean;
-  /** Number of async callbacks currently in-flight */
-  pendingCallbacks: number;
-  /** Called when pendingCallbacks drops to 0, if set */
-  onDrain: (() => void) | null;
-}
-
-// Pure function for creating openWindow without `this` binding
-function makeOpenWindow(
-  uuid: string,
-  eventEmitter: {
-    addListener: (listener: (message: WindowMessage) => void) => void;
-    removeListener: (listener: (message: WindowMessage) => void) => void;
-  },
-  onOpenWindow: (
-    url: string,
-    options?: {
-      width?: number;
-      height?: number;
-      showOverlay?: boolean;
-    },
-  ) => Promise<OpenWindowResponse>,
-  _onCloseWindow: (windowId: number) => void,
-  lifecycle: PluginLifecycle,
-  onError?: (error: Error) => void,
-) {
-  let cachedResult: { windowId: number; uuid: string; tabId: number } | null = null;
-
-  return async (
-    url: string,
-    options?: {
-      width?: number;
-      height?: number;
-      showOverlay?: boolean;
-    },
-  ): Promise<{ windowId: number; uuid: string; tabId: number }> => {
-    if (!url || typeof url !== 'string') {
-      throw new Error('URL must be a non-empty string');
-    }
-
-    // Return cached result if window already opened (idempotent on re-renders)
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    // --- Race condition fix ---
-    // Register the event listener BEFORE calling onOpenWindow so that headers
-    // intercepted between window creation and response arrival are not lost.
-    // Messages that arrive before we know the windowId are buffered, then
-    // merged into the execution context in bulk (no replay/re-render needed —
-    // the next main() call will see the accumulated data).
-    let resolvedWindowId: number | null = null;
-    const pendingMessages: WindowMessage[] = [];
-
-    const onMessage = async (message: WindowMessage) => {
-      // Buffer messages while we don't have a windowId yet.
-      // They will be merged into execution context after onOpenWindow resolves.
-      if (resolvedWindowId === null) {
-        pendingMessages.push(message);
-        return;
-      }
-
-      // Handle window closed — check if it's our window
-      if (message.type === 'WINDOW_CLOSED') {
-        const executionContext = executionContextRegistry.get(uuid);
-        const ourWindowId = executionContext?.windowId ?? resolvedWindowId;
-
-        // Ignore close events for other windows
-        if (ourWindowId != null && message.windowId !== ourWindowId) {
-          return;
-        }
-
-        eventEmitter.removeListener(onMessage);
-
-        // Terminate the plugin if it hasn't already completed
-        if (!lifecycle.isCompleted && onError) {
-          onError(new Error('Window closed by user'));
-        }
-        return;
-      }
-
-      // Skip processing if the plugin has completed (done() or error)
-      // This prevents new work from starting while disposal is pending
-      if (lifecycle.isCompleted) {
-        logger.debug(`[makeOpenWindow] Ignoring message ${message.type}: plugin has completed`);
-        eventEmitter.removeListener(onMessage);
-        return;
-      }
-
-      // For all other messages, check if context still exists
-      // Context may have been cleaned up due to error or done() call
-      const executionContext = executionContextRegistry.get(uuid);
-      if (!executionContext) {
-        logger.debug(
-          `[makeOpenWindow] Ignoring message ${message.type}: execution context no longer exists`,
-        );
-        eventEmitter.removeListener(onMessage);
-        return;
-      }
-
-      // Only process messages for this plugin's window
-      if (message.windowId !== executionContext.windowId) {
-        return;
-      }
-
-      try {
-        if (message.type === 'REQUEST_INTERCEPTED') {
-          const request = message.request;
-          updateExecutionContext(uuid, {
-            requests: [...(executionContext.requests || []), request],
-          });
-          executionContext.main();
-        }
-
-        if (message.type === 'REQUESTS_BATCH') {
-          const requests = message.requests;
-          updateExecutionContext(uuid, {
-            requests: [...(executionContext.requests || []), ...requests],
-          });
-          executionContext.main();
-        }
-
-        if (message.type === 'HEADER_INTERCEPTED') {
-          const header = message.header;
-          updateExecutionContext(uuid, {
-            headers: [...(executionContext.headers || []), header],
-          });
-          executionContext.main();
-        }
-
-        if (message.type === 'HEADERS_BATCH') {
-          const headers = message.headers;
-          updateExecutionContext(uuid, {
-            headers: [...(executionContext.headers || []), ...headers],
-          });
-          executionContext.main();
-        }
-
-        if (message.type === 'PLUGIN_UI_CLICK') {
-          logger.debug('PLUGIN_UI_CLICK', message);
-          if (message.onclick === '_revealApprove') {
-            const liveCtx = executionContextRegistry.get(uuid);
-            const approval = liveCtx?.revealApproval;
-            if (approval) {
-              updateExecutionContext(uuid, {
-                revealApproval: null,
-                revealApprovalDescriptors: null,
-              });
-              approval.resolve();
-            }
-            return;
-          }
-          if (message.onclick === '_revealReject') {
-            const liveCtx = executionContextRegistry.get(uuid);
-            const approval = liveCtx?.revealApproval;
-            if (approval) {
-              updateExecutionContext(uuid, {
-                revealApproval: null,
-                revealApprovalDescriptors: null,
-                revealWasRejected: true,
-              });
-              approval.reject(new Error('User rejected reveal'));
-            }
-            return;
-          }
-          const cb = executionContext.callbacks[message.onclick];
-
-          logger.debug('Callback:', cb);
-          if (cb) {
-            // Track this async callback so sandbox disposal waits for it
-            lifecycle.pendingCallbacks++;
-            try {
-              updateExecutionContext(uuid, {
-                currentContext: message.onclick,
-              });
-              const result = await cb();
-              // Re-check context exists after async callback
-              if (executionContextRegistry.has(uuid)) {
-                updateExecutionContext(uuid, {
-                  currentContext: '',
-                });
-              }
-              logger.debug('Callback result:', result);
-            } finally {
-              lifecycle.pendingCallbacks--;
-              // If disposal is waiting for callbacks to drain, signal it
-              if (lifecycle.pendingCallbacks === 0 && lifecycle.onDrain) {
-                lifecycle.onDrain();
-                lifecycle.onDrain = null;
-              }
-            }
-          }
-        }
-
-        if (message.type === 'RE_RENDER_PLUGIN_UI') {
-          logger.debug('[makeOpenWindow] RE_RENDER_PLUGIN_UI', message.windowId);
-          executionContext.main(true);
-        }
-      } catch (error) {
-        logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);
-        eventEmitter.removeListener(onMessage);
-        const err = error instanceof Error ? error : new Error(String(error));
-        if (onError) {
-          onError(err);
-        }
-      }
-    };
-
-    // Register listener BEFORE opening the window to capture all messages
-    eventEmitter.addListener(onMessage);
-
-    try {
-      const response = await onOpenWindow(url, options);
-
-      // Check if response indicates an error
-      if (response?.type === 'WINDOW_ERROR') {
-        throw new Error(
-          response.payload?.details || response.payload?.error || 'Failed to open window',
-        );
-      }
-
-      // Return window info from successful response
-      if (response?.type === 'WINDOW_OPENED' && response.payload) {
-        const windowId = response.payload.windowId;
-
-        // Guard: context may have been cleaned up if done() was called
-        // from the initial main() before this async resolution.
-        if (!executionContextRegistry.has(uuid)) {
-          eventEmitter.removeListener(onMessage);
-          cachedResult = {
-            windowId: response.payload.windowId,
-            uuid: response.payload.uuid,
-            tabId: response.payload.tabId,
-          };
-          return cachedResult;
-        }
-
-        updateExecutionContext(uuid, {
-          windowId,
-        });
-
-        // Merge any buffered messages into the execution context in bulk.
-        // This avoids re-entrant main() calls during replay. The next
-        // main() invocation will naturally pick up all the accumulated data.
-        const executionContext = executionContextRegistry.get(uuid);
-        if (executionContext) {
-          let headers = executionContext.headers || [];
-          let requests = executionContext.requests || [];
-          let bufferedCount = 0;
-          let windowWasClosed = false;
-
-          for (const msg of pendingMessages) {
-            if (msg.windowId !== windowId) continue;
-
-            if (msg.type === 'WINDOW_CLOSED') {
-              windowWasClosed = true;
-            } else if (msg.type === 'HEADER_INTERCEPTED' && msg.header) {
-              headers = [...headers, msg.header];
-              bufferedCount++;
-            } else if (msg.type === 'HEADERS_BATCH' && msg.headers) {
-              headers = [...headers, ...msg.headers];
-              bufferedCount += msg.headers.length;
-            } else if (msg.type === 'REQUEST_INTERCEPTED' && msg.request) {
-              requests = [...requests, msg.request];
-              bufferedCount++;
-            } else if (msg.type === 'REQUESTS_BATCH' && msg.requests) {
-              requests = [...requests, ...msg.requests];
-              bufferedCount += msg.requests.length;
-            }
-          }
-
-          if (bufferedCount > 0) {
-            logger.debug(
-              `[makeOpenWindow] Replaying ${bufferedCount} buffered message(s) into execution context`,
-            );
-            updateExecutionContext(uuid, { headers, requests });
-            // Trigger a single re-render so the plugin sees the buffered data
-            executionContext.main(true);
-          }
-          // If window was closed while we were waiting, terminate
-          if (windowWasClosed) {
-            eventEmitter.removeListener(onMessage);
-            if (!lifecycle.isCompleted && onError) {
-              onError(new Error('Window closed by user'));
-            }
-            pendingMessages.length = 0;
-            cachedResult = {
-              windowId: response.payload.windowId,
-              uuid: response.payload.uuid,
-              tabId: response.payload.tabId,
-            };
-            return cachedResult;
-          }
-        }
-        pendingMessages.length = 0;
-
-        // Unblock the message handler — new messages are processed live
-        resolvedWindowId = windowId;
-
-        cachedResult = {
-          windowId: response.payload.windowId,
-          uuid: response.payload.uuid,
-          tabId: response.payload.tabId,
-        };
-        return cachedResult;
-      }
-
-      throw new Error('Invalid response from background script');
-    } catch (error) {
-      // Clean up listener on failure to prevent leaks
-      eventEmitter.removeListener(onMessage);
-      logger.error('[makeOpenWindow] Failed to open window:', error);
-      throw error;
-    }
-  };
-}
-
-/**
- * Extract and parse a JSON body from an intercepted request.
- *
- * For JSON POST/PUT requests, the body is stored in `requestBody.raw[].bytes`
- * as an ArrayBuffer or number array. This utility decodes the bytes to a string
- * and attempts to parse it as JSON.
- *
- * @param request - An intercepted request from useRequests()
- * @returns The parsed JSON object, the raw string if not valid JSON, or null if no body
- */
-function getJsonBody(request: InterceptedRequest): unknown {
-  const bytes = request.requestBody?.raw?.[0]?.bytes;
-  if (!bytes) return null;
-
-  const text = String.fromCharCode(
-    ...(bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes),
-  );
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
-}
+  HostCore,
+  HostCoreOptions,
+  PluginEvaluator,
+  PluginEvaluatorResult,
+  AnyFunction,
+  HookContext,
+  updateExecutionContext,
+} from './host-core';
+import { InterceptedRequest, InterceptedRequestHeader, PluginConfig } from './types';
 
 // Export Parser and its types
 export {
@@ -595,7 +42,7 @@ export {
  * This function strips named exports, then re-exports them via `export default { ... }`
  * with arrow function wrappers (arrow functions have no .prototype).
  */
-function preprocessPluginCode(code: string): string {
+export function preprocessPluginCode(code: string): string {
   // Handle named exports: export function main() / export const config = ...
   const exportNames: string[] = [];
   const exportRegex = /export\s+(?:async\s+)?(?:function|const|let|var|class)\s+(\w+)/g;
@@ -640,566 +87,143 @@ function preprocessPluginCode(code: string): string {
   return code;
 }
 
-/**
- * Creates a success overlay DOM JSON for doneWithOverlay().
- * Plugin developers can customize the title and message.
- */
-function createCompletionOverlay(
-  title = 'Proof complete!',
-  message = 'This window will close shortly.',
-): DomJson {
-  return {
-    type: 'div',
-    options: {
-      style: {
-        position: 'fixed',
-        top: '0',
-        left: '0',
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: '9999999',
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-      },
-    },
-    children: [
-      // Modal card
-      {
-        type: 'div',
-        options: {
-          style: {
-            backgroundColor: '#ffffff',
-            borderRadius: '16px',
-            padding: '40px 48px',
-            textAlign: 'center',
-            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
-            maxWidth: '360px',
-            width: '90%',
-          },
-        },
-        children: [
-          // Green check emoji
-          {
-            type: 'div',
-            options: {
-              style: {
-                width: '72px',
-                height: '72px',
-                margin: '0 auto 20px auto',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: '48px',
-              },
-            },
-            children: ['\u2705'],
-          },
-          // Title
-          {
-            type: 'div',
-            options: {
-              style: {
-                fontSize: '22px',
-                fontWeight: '700',
-                color: '#111827',
-                marginBottom: '8px',
-                letterSpacing: '-0.02em',
-              },
-            },
-            children: [title],
-          },
-          // Message
-          {
-            type: 'div',
-            options: {
-              style: {
-                fontSize: '14px',
-                color: '#6b7280',
-                lineHeight: '1.5',
-              },
-            },
-            children: [message],
-          },
-        ],
-      },
-    ],
-  };
-}
+// ---------------------------------------------------------------------------
+// QuickJS sandbox helpers
+// ---------------------------------------------------------------------------
 
-export function createRevealApprovalOverlay(descriptors: RevealRangeDescriptor[]): DomJson {
-  const sentDescriptors = descriptors.filter((d) => d.direction === 'SENT');
-  const recvDescriptors = descriptors.filter((d) => d.direction === 'RECV');
+async function createQuickJSSandbox(capabilities: Record<string, AnyFunction>): Promise<{
+  eval: (code: string) => Promise<unknown>;
+  dispose: () => void;
+}> {
+  const { runSandboxed } = await loadQuickJs(variant);
 
-  const renderDescriptorRow = (descriptor: RevealRangeDescriptor): DomJson => {
-    const isReveal = descriptor.action === 'REVEAL';
-    return {
-      type: 'div',
-      options: {
-        style: {
-          display: 'flex',
-          alignItems: 'flex-start',
-          gap: '8px',
-          marginBottom: '8px',
-        },
-      },
-      children: [
-        {
-          type: 'div',
-          options: {
-            style: {
-              fontSize: '12px',
-              color: '#374151',
-              minWidth: '120px',
-            },
-          },
-          children: [descriptor.label],
-        },
-        {
-          type: 'div',
-          options: {
-            style: {
-              fontSize: '11px',
-              fontWeight: '600',
-              padding: '2px 6px',
-              borderRadius: '4px',
-              backgroundColor: isReveal ? '#d1fae5' : '#fef3c7',
-              color: isReveal ? '#065f46' : '#92400e',
-            },
-          },
-          children: [descriptor.action],
-        },
-        {
-          type: 'div',
-          options: {
-            style: {
-              fontFamily: 'monospace',
-              fontSize: '11px',
-              color: isReveal ? '#6b7280' : '#9ca3af',
-              fontStyle: isReveal ? 'normal' : 'italic',
-              wordBreak: 'break-all',
-            },
-          },
-          children: [descriptor.preview],
-        },
-      ],
-    };
+  const options: SandboxOptions = {
+    allowFetch: false,
+    allowFs: false,
+    maxStackSize: 0,
+    env: capabilities,
   };
 
-  const renderSection = (
-    title: 'Sent' | 'Received',
-    sectionDescriptors: RevealRangeDescriptor[],
-  ): DomJson => ({
-    type: 'div',
-    options: {
-      style: {
-        marginBottom: '16px',
-      },
-    },
-    children: [
-      {
-        type: 'div',
-        options: {
-          style: {
-            fontSize: '12px',
-            fontWeight: '600',
-            color: '#6b7280',
-            textTransform: 'uppercase',
-            marginBottom: '8px',
-          },
-        },
-        children: [title],
-      },
-      ...sectionDescriptors.map(renderDescriptorRow),
-    ],
+  let evalCode: SandboxEvalCode | null = null;
+  let disposeCallback: (() => void) | null = null;
+  let sandboxError: Error | null = null;
+
+  const sandboxPromise = runSandboxed(async (sandbox) => {
+    evalCode = sandbox.evalCode;
+
+    return new Promise<void>((resolve) => {
+      disposeCallback = resolve;
+    });
+  }, options).catch((err: Error) => {
+    sandboxError = err;
+    if (!evalCode) {
+      evalCode = (() => ({ ok: false, error: err })) as unknown as SandboxEvalCode;
+    }
   });
 
-  const cardChildren: DomJson[] = [
-    {
-      type: 'div',
-      options: {
-        style: {
-          fontSize: '20px',
-          fontWeight: '700',
-          color: '#111827',
-          marginBottom: '16px',
-        },
-      },
-      children: ['Approve Reveal to Verifier'],
-    },
-  ];
-
-  if (sentDescriptors.length > 0) {
-    cardChildren.push(renderSection('Sent', sentDescriptors));
+  while (!evalCode) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
-
-  if (recvDescriptors.length > 0) {
-    cardChildren.push(renderSection('Received', recvDescriptors));
-  }
-
-  cardChildren.push({
-    type: 'div',
-    options: {
-      style: {
-        display: 'flex',
-        justifyContent: 'flex-end',
-        gap: '12px',
-        marginTop: '24px',
-      },
-    },
-    children: [
-      {
-        type: 'button',
-        options: {
-          onclick: '_revealReject',
-          style: {
-            backgroundColor: '#fee2e2',
-            color: '#991b1b',
-            border: 'none',
-            padding: '8px 20px',
-            borderRadius: '8px',
-            fontWeight: '600',
-            cursor: 'pointer',
-          },
-        },
-        children: ['Reject'],
-      },
-      {
-        type: 'button',
-        options: {
-          onclick: '_revealApprove',
-          style: {
-            backgroundColor: '#d1fae5',
-            color: '#065f46',
-            border: 'none',
-            padding: '8px 20px',
-            borderRadius: '8px',
-            fontWeight: '600',
-            cursor: 'pointer',
-          },
-        },
-        children: ['Approve'],
-      },
-    ],
-  });
 
   return {
-    type: 'div',
-    options: {
-      style: {
-        position: 'fixed',
-        top: '0',
-        left: '0',
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: '9999998',
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-      },
+    eval: async (code: string) => {
+      if (sandboxError) {
+        throw sandboxError;
+      }
+
+      const result = await evalCode!(code);
+
+      if (!result.ok) {
+        const err = new Error(result.error.message);
+        err.name = result.error.name;
+        err.stack = result.error.stack;
+        throw err;
+      }
+
+      return result.data;
     },
-    children: [
-      {
-        type: 'div',
-        options: {
-          style: {
-            backgroundColor: '#ffffff',
-            borderRadius: '16px',
-            padding: '32px',
-            maxWidth: '520px',
-            width: '90%',
-            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
-          },
-        },
-        children: cardChildren,
-      },
-    ],
+    dispose: () => {
+      if (disposeCallback) {
+        disposeCallback();
+        disposeCallback = null;
+      }
+      sandboxPromise.catch(() => {});
+    },
   };
 }
 
-export function createTimeoutWarningOverlay(): DomJson {
+function createQuickJSEvaluator(): PluginEvaluator {
   return {
-    type: 'div',
-    options: {
-      style: {
-        position: 'fixed',
-        top: '0',
-        left: '0',
-        width: '100%',
-        height: '100%',
-        backgroundColor: 'rgba(0, 0, 0, 0.7)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: '9999999',
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
-      },
+    evaluate: async (
+      code: string,
+      capabilities: Record<string, AnyFunction>,
+    ): Promise<PluginEvaluatorResult> => {
+      const sandbox = await createQuickJSSandbox(capabilities);
+      const processedCode = preprocessPluginCode(code);
+
+      const evalScript = `
+const div = env.div;
+const button = env.button;
+const input = env.input;
+const openWindow = env.openWindow;
+const useEffect = env.useEffect;
+const useRequests = env.useRequests;
+const useHeaders = env.useHeaders;
+const useState = env.useState;
+const setState = env.setState;
+const prove = env.prove;
+const getJsonBody = env.getJsonBody;
+const closeWindow = env.closeWindow;
+const done = env.done;
+const doneWithOverlay = env.doneWithOverlay;
+const usePluginTimeout = env.usePluginTimeout;
+${processedCode};
+`;
+
+      try {
+        const evalResult = await sandbox.eval(evalScript);
+        return {
+          exports: (evalResult ?? {}) as Record<string, unknown>,
+          dispose: sandbox.dispose,
+        };
+      } catch (err) {
+        sandbox.dispose();
+        throw err;
+      }
     },
-    children: [
-      {
-        type: 'div',
-        options: {
-          style: {
-            backgroundColor: '#ffffff',
-            borderRadius: '16px',
-            padding: '40px 48px',
-            textAlign: 'center',
-            boxShadow: '0 24px 48px rgba(0, 0, 0, 0.25)',
-            maxWidth: '360px',
-            width: '90%',
-          },
-        },
-        children: [
-          // Warning icon
-          {
-            type: 'div',
-            options: {
-              style: {
-                width: '72px',
-                height: '72px',
-                margin: '0 auto 20px auto',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: '48px',
-              },
-            },
-            children: ['\u23F1\uFE0F'],
-          },
-          // Title
-          {
-            type: 'div',
-            options: {
-              style: {
-                fontSize: '22px',
-                fontWeight: '700',
-                color: '#111827',
-                marginBottom: '8px',
-                letterSpacing: '-0.02em',
-              },
-            },
-            children: ['Plugin Timeout Warning'],
-          },
-          // Message
-          {
-            type: 'div',
-            options: {
-              style: {
-                fontSize: '14px',
-                color: '#6b7280',
-                lineHeight: '1.5',
-                marginBottom: '24px',
-              },
-            },
-            children: ['The plugin will time out in less than 1 minute.'],
-          },
-          // Extend button
-          {
-            type: 'button',
-            options: {
-              onclick: '_extendTimeout',
-              style: {
-                padding: '12px 24px',
-                border: 'none',
-                borderRadius: '8px',
-                backgroundColor: '#2563eb',
-                color: '#ffffff',
-                fontSize: '14px',
-                fontWeight: '600',
-                cursor: 'pointer',
-                marginRight: '12px',
-              },
-            },
-            children: ['Extend by 5 min'],
-          },
-          // Let expire button
-          {
-            type: 'button',
-            options: {
-              onclick: '_dismissTimeoutWarning',
-              style: {
-                padding: '12px 24px',
-                border: '1px solid #d1d5db',
-                borderRadius: '8px',
-                backgroundColor: '#ffffff',
-                color: '#374151',
-                fontSize: '14px',
-                cursor: 'pointer',
-              },
-            },
-            children: ['Let it expire'],
-          },
-        ],
-      },
-    ],
   };
 }
 
-export function decorateJson(base: DomJson, overlays: DomJson[]): DomJson {
-  if (overlays.length === 0) return base;
-  return {
-    type: 'div',
-    options: { style: {} },
-    children: [base, ...overlays],
-  };
-}
+// ---------------------------------------------------------------------------
+// Host — QuickJS-backed HostCore (backward-compatible public API)
+// ---------------------------------------------------------------------------
 
-export class Host {
-  private capabilities: Map<string, AnyFunction> = new Map();
-  private _activeUuid: string | null = null;
-  private onProve: (
-    requestOptions: {
-      url: string;
-      method: string;
-      headers: Record<string, string>;
-      body?: string;
-    },
-    proverOptions: {
-      verifierUrl: string;
-      proxyUrl: string;
-      maxRecvData?: number;
-      maxSentData?: number;
-      handlers: Handler[];
-    },
-    onProgress?: (data: ProveProgressData) => void,
-  ) => Promise<unknown>;
-  private onRenderPluginUi: (windowId: number, result: DomJson) => void;
-  private onCloseWindow: (windowId: number) => void;
-  private onOpenWindow: (
-    url: string,
-    options?: {
-      width?: number;
-      height?: number;
-      showOverlay?: boolean;
-    },
-  ) => Promise<OpenWindowResponse>;
-
-  constructor(options: {
-    onProve: (
-      requestOptions: {
-        url: string;
-        method: string;
-        headers: Record<string, string>;
-        body?: string;
-      },
-      proverOptions: {
-        verifierUrl: string;
-        proxyUrl: string;
-        maxRecvData?: number;
-        maxSentData?: number;
-        handlers: Handler[];
-      },
-      onProgress?: (data: ProveProgressData) => void,
-    ) => Promise<unknown>;
-    onRenderPluginUi: (windowId: number, result: DomJson) => void;
-    onCloseWindow: (windowId: number) => void;
-    onOpenWindow: (
-      url: string,
-      options?: {
-        width?: number;
-        height?: number;
-        showOverlay?: boolean;
-      },
-    ) => Promise<OpenWindowResponse>;
-    logLevel?: LogLevel;
-  }) {
-    this.onProve = options.onProve;
-    this.onRenderPluginUi = options.onRenderPluginUi;
-    this.onCloseWindow = options.onCloseWindow;
-    this.onOpenWindow = options.onOpenWindow;
-
-    // Initialize logger with provided level or default to WARN
-    logger.init(options.logLevel ?? DEFAULT_LOG_LEVEL);
+export class Host extends HostCore {
+  constructor(options: Omit<HostCoreOptions, 'evaluator'>) {
+    super({
+      ...options,
+      evaluator: createQuickJSEvaluator(),
+    });
   }
 
-  addCapability(name: string, handler: AnyFunction): void {
-    this.capabilities.set(name, handler);
-  }
-
+  /**
+   * Creates a sandboxed QuickJS environment.
+   * Kept for backward compatibility — used by getPluginConfig() and potentially
+   * external callers that need a raw sandbox.
+   */
   async createEvalCode(capabilities?: Record<string, AnyFunction>): Promise<{
     eval: (code: string) => Promise<unknown>;
     dispose: () => void;
   }> {
-    const { runSandboxed } = await loadQuickJs(variant);
-
-    const options: SandboxOptions = {
-      allowFetch: false,
-      allowFs: false,
-      maxStackSize: 0,
-      env: {
-        ...Object.fromEntries(this.capabilities),
-        ...(capabilities || {}),
-      },
-    };
-
-    let evalCode: SandboxEvalCode | null = null;
-    let disposeCallback: (() => void) | null = null;
-    let sandboxError: Error | null = null;
-
-    // Start sandbox and keep it alive
-    // Track the promise to handle errors properly
-    const sandboxPromise = runSandboxed(async (sandbox) => {
-      evalCode = sandbox.evalCode;
-
-      // Keep the sandbox alive until dispose is called
-      // The runtime won't be disposed until this promise resolves
-      return new Promise<void>((resolve) => {
-        disposeCallback = resolve;
-      });
-    }, options).catch((err: Error) => {
-      // Capture sandbox errors for later handling
-      sandboxError = err;
-      // If evalCode was never set, we need to unblock the wait loop
-      if (!evalCode) {
-        evalCode = (() => ({ ok: false, error: err })) as unknown as SandboxEvalCode;
-      }
+    return createQuickJSSandbox({
+      ...Object.fromEntries(this.capabilities),
+      ...(capabilities ?? {}),
     });
-
-    // Wait for evalCode to be ready
-    while (!evalCode) {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    // Return evalCode and dispose function
-    return {
-      eval: async (code: string) => {
-        // Check if sandbox had an error during setup
-        if (sandboxError) {
-          throw sandboxError;
-        }
-
-        const result = await evalCode!(code);
-
-        if (!result.ok) {
-          const err = new Error(result.error.message);
-          err.name = result.error.name;
-          err.stack = result.error.stack;
-          throw err;
-        }
-
-        return result.data;
-      },
-      dispose: () => {
-        if (disposeCallback) {
-          disposeCallback();
-          disposeCallback = null;
-        }
-        // Ensure the sandbox promise is awaited to prevent unhandled rejections
-        // This is a fire-and-forget await since we've already captured any errors
-        sandboxPromise.catch(() => {
-          // Errors already captured, ignore
-        });
-      },
-    };
   }
 
+  /**
+   * Kept for backward compatibility — used by SessionManager.
+   */
   updateExecutionContext(
     uuid: string,
     params: {
@@ -1209,6 +233,7 @@ export class Host {
       headers?: InterceptedRequestHeader[];
       context?: HookContext;
       currentContext?: string;
+      stateStore?: Record<string, unknown>;
     },
   ): void {
     updateExecutionContext(uuid, params);
@@ -1246,603 +271,14 @@ ${processedCode};
       sandbox.dispose();
     }
   }
-
-  async executePlugin(
-    code: string,
-    {
-      eventEmitter,
-    }: {
-      eventEmitter: {
-        addListener: (listener: (message: WindowMessage) => void) => void;
-        removeListener: (listener: (message: WindowMessage) => void) => void;
-        emit: (message: WindowMessage) => void;
-      };
-    },
-  ): Promise<unknown> {
-    const uuid = uuidv4();
-    this._activeUuid = uuid;
-
-    const context: HookContext = {};
-
-    const stateStore: Record<string, unknown> = {};
-
-    let doneResolve: (value?: unknown) => void;
-    let doneReject: (error: Error) => void;
-
-    // Lifecycle tracker prevents sandbox disposal while async callbacks are in-flight.
-    // This fixes "Lifetime not alive" / "QuickJSContext had no callback with id" errors
-    // caused by the sandbox being disposed while an awaited callback (e.g. onClick → prove())
-    // is still executing inside the QuickJS runtime.
-    const lifecycle: PluginLifecycle = {
-      isCompleted: false,
-      pendingCallbacks: 0,
-      onDrain: null,
-    };
-
-    const donePromise = new Promise((resolve, reject) => {
-      doneResolve = resolve;
-      doneReject = reject;
-    });
-
-    // Wait for all in-flight async callbacks to settle
-    const DRAIN_TIMEOUT_MS = 30_000;
-
-    const waitForPendingCallbacks = (): Promise<void> => {
-      if (lifecycle.pendingCallbacks === 0) return Promise.resolve();
-
-      // Defensive: onDrain should never already be set because isCompleted
-      // gates both done() and terminateWithError(). Log if invariant breaks.
-      if (lifecycle.onDrain !== null) {
-        logger.warn(
-          '[executePlugin] onDrain already set — multiple waiters detected, this is a bug',
-        );
-      }
-
-      return new Promise<void>((resolve) => {
-        lifecycle.onDrain = resolve;
-
-        // Safety net: if callbacks hang forever, force-resolve after timeout
-        setTimeout(() => {
-          if (lifecycle.onDrain === resolve) {
-            logger.warn(
-              `[executePlugin] Timed out waiting for ${lifecycle.pendingCallbacks} callback(s) to drain after ${DRAIN_TIMEOUT_MS}ms — forcing disposal`,
-            );
-            lifecycle.onDrain = null;
-            resolve();
-          }
-        }, DRAIN_TIMEOUT_MS);
-      });
-    };
-
-    // Helper to terminate plugin execution with an error
-    const terminateWithError = (error: Error, sandbox?: { dispose: () => void }) => {
-      if (lifecycle.isCompleted) return;
-      lifecycle.isCompleted = true;
-      logger.error('[executePlugin] Plugin terminated with error:', error);
-
-      // Clean up registry entry
-      const ctx = executionContextRegistry.get(uuid);
-
-      // If a reveal approval is pending, reject it so the awaiting onProve
-      // (and any owned resources like transcript bytes) can unwind.
-      const pendingApproval = ctx?.revealApproval;
-      if (pendingApproval) {
-        try {
-          pendingApproval.reject(error);
-        } catch (rejectError) {
-          logger.error('[executePlugin] Error rejecting pending reveal approval:', rejectError);
-        }
-      }
-
-      if (ctx?.windowId) {
-        try {
-          this.onCloseWindow(ctx.windowId);
-        } catch (closeError) {
-          logger.error('[executePlugin] Error closing window:', closeError);
-        }
-      }
-
-      const finalize = () => {
-        executionContextRegistry.delete(uuid);
-
-        // Reject first, before disposing sandbox.
-        // sandbox.dispose() can crash the WASM runtime (e.g. QuickJS
-        // gc_obj_list assertion), which would prevent doneReject from
-        // ever being called if it came after dispose.
-        doneReject(error);
-
-        // Dispose sandbox if provided
-        if (sandbox) {
-          try {
-            sandbox.dispose();
-          } catch (disposeError) {
-            logger.error('[executePlugin] Error disposing sandbox:', disposeError);
-          }
-        }
-      };
-
-      // Defer sandbox disposal until all in-flight callbacks have completed.
-      // Disposing while a callback is awaited inside QuickJS causes "Lifetime not alive".
-      if (lifecycle.pendingCallbacks > 0) {
-        logger.debug(
-          `[executePlugin] Deferring sandbox disposal: ${lifecycle.pendingCallbacks} callback(s) in-flight`,
-        );
-        waitForPendingCallbacks().then(finalize);
-      } else {
-        finalize();
-      }
-    };
-
-    /**
-     * The sandbox is a sandboxed environment that is used to execute the plugin code.
-     * It is created using the createEvalCode method from the plugin-sdk.
-     * The sandbox is created with the following capabilities:
-     * - div: a function that creates a div element
-     * - button: a function that creates a button element
-     * - openWindow: a function that opens a new window
-     * - useEffect: a function that creates a useEffect hook
-     * - useRequests: a function that creates a useRequests hook
-     * - useHeaders: a function that creates a useHeaders hook
-     * - subtractRanges: a function that subtracts ranges
-     * - mapStringToRange: a function that maps a string to a range
-     * - createProver: a function that creates a prover
-     * - sendRequest: a function that sends a request
-     * - transcript: a function that returns the transcript
-     * - reveal: a function that reveals a commit
-     * - getResponse: a function that returns the verification response (sent/received data) or null
-     * - closeWindow: a function that closes a window by windowId
-     * - done: a function that completes the session and closes the window
-     */
-    // Create pure functions without `this` bindings to avoid circular references
-    const onCloseWindow = this.onCloseWindow;
-    const onRenderPluginUi = this.onRenderPluginUi;
-    const onOpenWindow = this.onOpenWindow;
-    const onProve = this.onProve;
-
-    const sandbox = await this.createEvalCode({
-      div: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
-        createDomJson('div', param1, param2),
-      button: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
-        createDomJson('button', param1, param2),
-      input: (param1?: DomOptions | DomJson[], param2?: DomJson[]) =>
-        createDomJson('input', param1, param2),
-      openWindow: makeOpenWindow(
-        uuid,
-        eventEmitter,
-        onOpenWindow,
-        onCloseWindow,
-        lifecycle,
-        (err: Error) => terminateWithError(err, sandbox),
-      ),
-      useEffect: makeUseEffect(uuid, context),
-      useRequests: makeUseRequests(uuid, context),
-      useHeaders: makeUseHeaders(uuid, context),
-      useState: makeUseState(uuid, stateStore, eventEmitter),
-      setState: makeSetState(uuid, stateStore, eventEmitter),
-      usePluginTimeout: makeUsePluginTimeout(stateStore),
-      prove: async (
-        requestOptions: Parameters<typeof onProve>[0],
-        proverOptions: Parameters<typeof onProve>[1],
-      ) => {
-        const setProgress = (data: ProveProgressData) => {
-          stateStore['_proveProgress'] = data;
-          eventEmitter.emit({
-            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-          });
-        };
-        setProgress({ step: 'CONNECTING', progress: 0, message: 'Connecting...' });
-        try {
-          const canonicalProverOptions = {
-            ...proverOptions,
-            handlers: canonicalizeHandlers(proverOptions.handlers),
-          };
-          const result = await onProve(requestOptions, canonicalProverOptions, setProgress);
-          setProgress({ step: 'COMPLETE', progress: 1, message: 'Complete' });
-          return result;
-        } catch (err) {
-          stateStore['_proveProgress'] = null;
-          eventEmitter.emit({
-            type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-            windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-          });
-          throw err;
-        }
-      },
-      done: (args?: unknown) => {
-        if (lifecycle.isCompleted) return;
-        lifecycle.isCompleted = true;
-
-        // Close the window if it exists
-        const context = executionContextRegistry.get(uuid);
-        if (context?.windowId) {
-          onCloseWindow(context.windowId);
-        }
-
-        // If a reveal was rejected during this execution, treat done() as a
-        // failure so callers can skip success-only side effects (e.g. the
-        // execution counter).
-        const wasRejected = context?.revealWasRejected === true;
-
-        const finalize = () => {
-          executionContextRegistry.delete(uuid);
-          if (wasRejected) {
-            doneReject(new Error('User rejected reveal'));
-          } else {
-            doneResolve(args);
-          }
-        };
-
-        // If called from within an async callback (e.g. onClick → prove() → done()),
-        // defer cleanup until the callback returns to avoid disposing QuickJS mid-execution.
-        if (lifecycle.pendingCallbacks > 0) {
-          logger.debug(
-            `[executePlugin] done() called with ${lifecycle.pendingCallbacks} callback(s) in-flight, deferring cleanup`,
-          );
-          waitForPendingCallbacks().then(finalize);
-        } else {
-          finalize();
-        }
-      },
-      getJsonBody: (request: InterceptedRequest) => getJsonBody(request),
-      doneWithOverlay: (
-        args?: unknown,
-        options?: { title?: string; message?: string; delayMs?: number },
-      ) => {
-        if (lifecycle.isCompleted) return;
-
-        // Mark as completed immediately to prevent main() from re-rendering
-        // and overwriting the overlay
-        lifecycle.isCompleted = true;
-
-        const ctx = executionContextRegistry.get(uuid);
-        const windowId = ctx?.windowId;
-        const wasRejected = ctx?.revealWasRejected === true;
-        const settle = () => {
-          if (wasRejected) {
-            doneReject(new Error('User rejected reveal'));
-          } else {
-            doneResolve(args);
-          }
-        };
-
-        // If there's no window, behave like done() — no overlay or delay needed
-        if (!windowId) {
-          const finalize = () => {
-            executionContextRegistry.delete(uuid);
-            settle();
-          };
-
-          if (lifecycle.pendingCallbacks > 0) {
-            waitForPendingCallbacks().then(finalize);
-          } else {
-            finalize();
-          }
-          return;
-        }
-
-        const delayMs = options?.delayMs ?? 2000;
-
-        // Show the completion overlay
-        onRenderPluginUi(windowId, createCompletionOverlay(options?.title, options?.message));
-
-        // After the delay, close the window and finalize
-        const closeAndFinalize = () => {
-          onCloseWindow(windowId);
-          executionContextRegistry.delete(uuid);
-          settle();
-        };
-
-        // Wait for pending callbacks to complete (e.g. the onClick that
-        // called doneWithOverlay), then start the delay timer
-        const startDelay = () => {
-          setTimeout(closeAndFinalize, delayMs);
-        };
-
-        if (lifecycle.pendingCallbacks > 0) {
-          waitForPendingCallbacks().then(startDelay);
-        } else {
-          startDelay();
-        }
-      },
-    });
-
-    let exportedCode: Record<string, unknown>;
-    try {
-      const processedCode = preprocessPluginCode(code);
-      const evalResult = await sandbox.eval(`
-const div = env.div;
-const button = env.button;
-const input = env.input;
-const openWindow = env.openWindow;
-const useEffect = env.useEffect;
-const useRequests = env.useRequests;
-const useHeaders = env.useHeaders;
-const useState = env.useState;
-const setState = env.setState;
-const prove = env.prove;
-const getJsonBody = env.getJsonBody;
-const closeWindow = env.closeWindow;
-const done = env.done;
-const doneWithOverlay = env.doneWithOverlay;
-const usePluginTimeout = env.usePluginTimeout;
-${processedCode};
-`);
-      exportedCode = (evalResult ?? {}) as Record<string, unknown>;
-    } catch (evalError) {
-      const error = evalError instanceof Error ? evalError : new Error(String(evalError));
-      terminateWithError(new Error(`Plugin evaluation failed: ${error.message}`), sandbox);
-      return donePromise;
-    }
-
-    const { main: rawMainFn, ...args } = exportedCode;
-
-    if (typeof rawMainFn !== 'function') {
-      terminateWithError(new Error('Main function not found in plugin'), sandbox);
-      return donePromise;
-    }
-
-    const mainFn = rawMainFn as (...args: unknown[]) => DomJson | null;
-
-    const callbacks: {
-      [callbackName: string]: () => Promise<void>;
-    } = {};
-
-    for (const key in args) {
-      if (typeof args[key] === 'function') {
-        callbacks[key] = args[key] as () => Promise<void>;
-      }
-    }
-
-    let json: DomJson | null = null;
-
-    const main = (force = false) => {
-      // Don't run main() if the plugin has already completed
-      if (lifecycle.isCompleted) return null;
-
-      try {
-        updateExecutionContext(uuid, {
-          currentContext: 'main',
-        });
-
-        let result = mainFn();
-        const lastSelectors = executionContextRegistry.get(uuid)?.context['main']?.selectors;
-        const selectors = context['main']?.selectors;
-        const lastStateStore = executionContextRegistry.get(uuid)?.stateStore;
-
-        if (
-          !force &&
-          deepEqual(lastSelectors, selectors) &&
-          deepEqual(lastStateStore, stateStore)
-        ) {
-          result = null;
-        }
-
-        updateExecutionContext(uuid, {
-          currentContext: '',
-          context: {
-            ...executionContextRegistry.get(uuid)?.context,
-            main: {
-              effects: JSON.parse(JSON.stringify(context['main']?.effects ?? [])),
-              selectors: JSON.parse(JSON.stringify(context['main']?.selectors ?? [])),
-            },
-          },
-          stateStore: JSON.parse(JSON.stringify(stateStore)),
-        });
-
-        if (context['main']) {
-          context['main'].effects.length = 0;
-          context['main'].selectors.length = 0;
-        }
-
-        if (result) {
-          logger.debug('Main function executed:', result);
-
-          logger.debug(
-            'executionContextRegistry.get(uuid)?.windowId',
-            executionContextRegistry.get(uuid)?.windowId,
-          );
-
-          // Layer overlays on top of the plugin UI using the decorator pattern.
-          // Stack order matters: timeout (z=9999999) is rendered above reveal
-          // approval (z=9999998) so a timeout warning never gets buried.
-          const overlays: DomJson[] = [];
-          const ctx = executionContextRegistry.get(uuid);
-          if (ctx?.revealApprovalDescriptors) {
-            overlays.push(createRevealApprovalOverlay(ctx.revealApprovalDescriptors));
-          }
-          if (timeoutWarningShown) {
-            overlays.push(createTimeoutWarningOverlay());
-          }
-          json = decorateJson(result, overlays);
-
-          waitForWindow(async () => executionContextRegistry.get(uuid)?.windowId).then(
-            (windowId: number | null) => {
-              if (windowId == null) {
-                logger.error(
-                  '[executePlugin] Window never opened after timeout, skipping UI render',
-                );
-                return;
-              }
-              logger.debug('render result', json as DomJson);
-              onRenderPluginUi(windowId, json as DomJson);
-            },
-          );
-        }
-
-        return result;
-      } catch (error) {
-        const err = error instanceof Error ? error : new Error(String(error));
-        terminateWithError(new Error(`Plugin main() error: ${err.message}`), sandbox);
-        return null;
-      }
-    };
-
-    executionContextRegistry.set(uuid, {
-      id: uuid,
-      plugin: code,
-      pluginUrl: '',
-      context: {},
-      currentContext: '',
-      sandbox,
-      main: main,
-      callbacks: callbacks,
-      stateStore: {},
-    });
-
-    // --- Timeout lifecycle ---
-    const pluginConfig = args.config as PluginConfig | undefined;
-    const timeoutMs = clampTimeout(pluginConfig?.timeout);
-    let deadline = Date.now() + timeoutMs;
-    let timeoutWarningShown = false;
-
-    // Update _pluginTimeout state and trigger re-render
-    const updateTimeoutState = () => {
-      const remaining = Math.max(0, deadline - Date.now());
-      stateStore['_pluginTimeout'] = { remaining, total: timeoutMs };
-    };
-
-    // Extend handler — called via onclick dispatch
-    const extendTimeout = () => {
-      deadline = Date.now() + TIMEOUT_EXTEND_MS;
-      timeoutWarningShown = false;
-      updateTimeoutState();
-      // Re-render to restore normal plugin UI
-      eventEmitter.emit({
-        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-        windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-      });
-    };
-
-    // Dismiss warning — let deadline fire naturally, just restore plugin UI
-    const dismissTimeoutWarning = () => {
-      timeoutWarningShown = false;
-      eventEmitter.emit({
-        type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-        windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-      });
-    };
-
-    // Register internal onclick handlers for the timeout warning modal
-    callbacks['_extendTimeout'] = async () => {
-      extendTimeout();
-    };
-    callbacks['_dismissTimeoutWarning'] = async () => {
-      dismissTimeoutWarning();
-    };
-
-    updateTimeoutState();
-
-    const timeoutIntervalId = setInterval(() => {
-      if (lifecycle.isCompleted) {
-        clearInterval(timeoutIntervalId);
-        return;
-      }
-
-      const remaining = deadline - Date.now();
-      updateTimeoutState();
-
-      // Show warning overlay at T-60s by triggering a re-render.
-      // main() wraps the plugin UI with the warning overlay when timeoutWarningShown is true.
-      if (remaining <= TIMEOUT_WARNING_LEAD_MS && remaining > 0 && !timeoutWarningShown) {
-        timeoutWarningShown = true;
-        eventEmitter.emit({
-          type: 'TO_BG_RE_RENDER_PLUGIN_UI',
-          windowId: executionContextRegistry.get(uuid)?.windowId || 0,
-        });
-      }
-
-      // Deadline reached — terminate
-      if (remaining <= 0) {
-        clearInterval(timeoutIntervalId);
-        terminateWithError(new Error('Plugin execution timeout'), sandbox);
-      }
-    }, 1000);
-
-    // Clean up interval when plugin completes.
-    // Use .then(onFulfilled, onRejected) so rejection doesn't produce an
-    // unhandled rejection on the chained promise. The original donePromise
-    // still rejects to the caller as expected.
-    const cleanup = () => {
-      clearInterval(timeoutIntervalId);
-      if (this._activeUuid === uuid) {
-        this._activeUuid = null;
-      }
-    };
-    donePromise.then(cleanup, cleanup);
-
-    // Execute initial main() - errors are handled within main() via terminateWithError
-    main();
-
-    return donePromise;
-  }
-
-  /**
-   * Public method for creating DOM JSON
-   * Delegates to the pure module-level function
-   */
-  createDomJson = (
-    type: 'div' | 'button' | 'input',
-    param1: DomOptions | DomJson[] = {},
-    param2: DomJson[] = [],
-  ): DomJson => {
-    return createDomJson(type, param1, param2);
-  };
-
-  registerRevealApproval(
-    resolve: () => void,
-    reject: (err: Error) => void,
-    descriptors: RevealRangeDescriptor[],
-  ): void {
-    if (!this._activeUuid) return;
-    const uuid = this._activeUuid;
-    updateExecutionContext(uuid, {
-      revealApproval: { resolve, reject },
-      revealApprovalDescriptors: descriptors,
-    });
-    // Trigger a re-render so the decorator applies immediately
-    const ctx = executionContextRegistry.get(uuid);
-    ctx?.main(true);
-  }
-
-  renderUi(windowId: number, json: DomJson): void {
-    this.onRenderPluginUi(windowId, json);
-  }
-}
-
-async function waitForWindow(
-  callback: () => Promise<number | undefined>,
-  retry = 0,
-): Promise<number | null> {
-  const resp = await callback();
-
-  if (resp) return resp;
-
-  if (retry < 100) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return waitForWindow(callback, retry + 1);
-  }
-
-  return null;
 }
 
 /**
  * Extract plugin configuration from plugin code without executing it.
  * Uses regex-based parsing to extract the config object from the source code.
- *
- * Note: This regex-based approach cannot extract complex fields like arrays
- * (requests, urls). For full config extraction including permissions, use
- * Host.getPluginConfig() which uses the QuickJS sandbox.
- *
- * @param code - The plugin source code
- * @returns The plugin config object, or null if extraction fails
  */
 export async function extractConfig(code: string): Promise<PluginConfig | null> {
   try {
-    // Pattern to match config object definition:
-    // const config = { name: '...', description: '...' }
-    // or
-    // const config = { name: "...", description: "..." }
     const configPattern =
       /const\s+config\s*=\s*\{([^}]*name\s*:\s*['"`]([^'"`]+)['"`][^}]*description\s*:\s*['"`]([^'"`]+)['"`][^}]*|[^}]*description\s*:\s*['"`]([^'"`]+)['"`][^}]*name\s*:\s*['"`]([^'"`]+)['"`][^}]*)\}/s;
 
@@ -1852,7 +288,6 @@ export async function extractConfig(code: string): Promise<PluginConfig | null> 
       return null;
     }
 
-    // Extract name and description (could be in either order)
     const name = match[2] || match[5];
     const description = match[3] || match[4];
 
@@ -1865,21 +300,18 @@ export async function extractConfig(code: string): Promise<PluginConfig | null> 
       description: description || 'No description provided',
     };
 
-    // Try to extract optional version
     const versionMatch = code.match(/version\s*:\s*['"`]([^'"`]+)['"`]/);
     if (versionMatch) {
       config.version = versionMatch[1];
     }
 
-    // Try to extract optional author
     const authorMatch = code.match(/author\s*:\s*['"`]([^'"`]+)['"`]/);
     if (authorMatch) {
       config.author = authorMatch[1];
     }
 
     return config;
-  } catch (error) {
-    logger.error('[extractConfig] Failed to extract plugin config:', error);
+  } catch {
     return null;
   }
 }
@@ -1931,11 +363,25 @@ export type {
 // Re-export LogLevel for consumers
 export { LogLevel } from '@tlsn/common';
 
-// Export internal utilities (used by tests)
-export { preprocessPluginCode };
-
 // Export getJsonBody utility for plugin authors
-export { getJsonBody };
+export { getJsonBody } from './host-core';
+
+// Export HostCore and PluginEvaluator for platform implementors
+export type { PluginEvaluator, PluginEvaluatorResult, HostCoreOptions } from './host-core';
+export { HostCore } from './host-core';
+
+// Timeout constants (consumed by tests and extension code)
+export {
+  DEFAULT_TIMEOUT_MS,
+  MIN_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
+  TIMEOUT_WARNING_LEAD_MS,
+  TIMEOUT_EXTEND_MS,
+  clampTimeout,
+  createTimeoutWarningOverlay,
+  createRevealApprovalOverlay,
+  decorateJson,
+} from './host-core';
 
 // Default export
 export default Host;

--- a/packages/plugin-sdk/test/host-core.test.ts
+++ b/packages/plugin-sdk/test/host-core.test.ts
@@ -1,0 +1,790 @@
+/**
+ * Node.js unit tests for HostCore.
+ *
+ * Uses a new Function() mock evaluator — no QuickJS WASM or browser needed.
+ *
+ * IMPORTANT PATTERN: openWindow() must be called from within main() or a click
+ * handler, NOT from inside the evaluator body. The evaluator runs before
+ * executionContextRegistry is populated, so openWindow() finds no context and
+ * early-exits without setting windowId.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { HostCore, executionContextRegistry } from '../src/host-core';
+import type { PluginEvaluator, PluginEvaluatorResult, AnyFunction } from '../src/host-core';
+import type { DomJson, WindowMessage } from '../src/types';
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+function createMockEvaluator(): PluginEvaluator {
+  return {
+    evaluate: async (
+      code: string,
+      capabilities: Record<string, AnyFunction>,
+    ): Promise<PluginEvaluatorResult> => {
+      const exports: Record<string, unknown> = {};
+      const capNames = Object.keys(capabilities);
+      const capValues = Object.values(capabilities);
+      const fn = new Function('exports', ...capNames, code);
+      fn(exports, ...capValues);
+      return { exports, dispose: vi.fn() };
+    },
+  };
+}
+
+/**
+ * Relays TO_BG_RE_RENDER_PLUGIN_UI → RE_RENDER_PLUGIN_UI.
+ * This simulates what the extension's background script does so that setState()
+ * triggers re-renders in unit tests (no background script present).
+ */
+function createTestEventEmitter() {
+  const listeners: Set<(msg: WindowMessage) => void> = new Set();
+  return {
+    addListener: (l: (msg: WindowMessage) => void) => listeners.add(l),
+    removeListener: (l: (msg: WindowMessage) => void) => listeners.delete(l),
+    emit: (msg: WindowMessage) => {
+      const out: WindowMessage =
+        msg.type === 'TO_BG_RE_RENDER_PLUGIN_UI'
+          ? { type: 'RE_RENDER_PLUGIN_UI', windowId: msg.windowId }
+          : msg;
+      for (const l of [...listeners]) l(out);
+    },
+  };
+}
+
+function makeHost(overrides: Partial<ConstructorParameters<typeof HostCore>[0]> = {}) {
+  const onProve = vi.fn().mockResolvedValue({ proof: 'mock-proof' });
+  const onRenderPluginUi = vi.fn();
+  const onCloseWindow = vi.fn();
+  const onOpenWindow = vi.fn().mockResolvedValue({
+    type: 'WINDOW_OPENED',
+    payload: { windowId: 42, uuid: 'test-uuid', tabId: 1 },
+  });
+
+  const host = new HostCore({
+    evaluator: createMockEvaluator(),
+    onProve,
+    onRenderPluginUi,
+    onCloseWindow,
+    onOpenWindow,
+    ...overrides,
+  });
+
+  return { host, onProve, onRenderPluginUi, onCloseWindow, onOpenWindow };
+}
+
+/**
+ * Yield to the event loop — lets all pending microtasks and one macrotask
+ * round complete. After this:
+ * - evaluate() has resolved
+ * - openWindow() (if called from main()) has resolved and windowId is set
+ * - waitForWindow() has resolved
+ * - onRenderPluginUi() has been called (if main returned non-null)
+ * - makeOpenWindow's message listener is active
+ */
+const settle = () => new Promise<void>((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Core lifecycle
+// ---------------------------------------------------------------------------
+
+describe('HostCore — core lifecycle', () => {
+  it('resolves with the value passed to done()', async () => {
+    const { host } = makeHost();
+    const code = `exports.main = function() { done('success'); return null; };`;
+    await expect(
+      host.executePlugin(code, { eventEmitter: createTestEventEmitter() }),
+    ).resolves.toBe('success');
+  });
+
+  it('rejects when the evaluator throws', async () => {
+    const badEval: PluginEvaluator = {
+      evaluate: async () => {
+        throw new Error('syntax error');
+      },
+    };
+    const { host } = makeHost({ evaluator: badEval });
+    await expect(
+      host.executePlugin('', { eventEmitter: createTestEventEmitter() }),
+    ).rejects.toThrow('Plugin evaluation failed: syntax error');
+  });
+
+  it('rejects when no main export is found', async () => {
+    const { host } = makeHost();
+    await expect(
+      host.executePlugin('exports.config = {};', { eventEmitter: createTestEventEmitter() }),
+    ).rejects.toThrow('Main function not found in plugin');
+  });
+
+  it('cleans up the context registry after done()', async () => {
+    const { host } = makeHost();
+    await host.executePlugin('exports.main = function() { done(); return null; };', {
+      eventEmitter: createTestEventEmitter(),
+    });
+    expect(executionContextRegistry.size).toBe(0);
+  });
+
+  it('done() is idempotent — second call is a no-op', async () => {
+    const { host } = makeHost();
+    const code = `
+exports.main = function() {
+  done('first');
+  done('second');
+  return null;
+};`;
+    const result = await host.executePlugin(code, { eventEmitter: createTestEventEmitter() });
+    expect(result).toBe('first');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. useState / setState
+// ---------------------------------------------------------------------------
+
+describe('HostCore — useState / setState', () => {
+  it('returns the default value on first call', async () => {
+    const { host } = makeHost();
+    const code = `
+exports.main = function() {
+  var v = useState('x', 99);
+  done(v);
+  return null;
+};`;
+    await expect(
+      host.executePlugin(code, { eventEmitter: createTestEventEmitter() }),
+    ).resolves.toBe(99);
+  });
+
+  it('preserves falsy defaults (0, false, empty string)', async () => {
+    const { host } = makeHost();
+    const code = `
+exports.main = function() {
+  var a = useState('zero', 0);
+  var b = useState('bool', false);
+  var c = useState('str', '');
+  done([a, b, c]);
+  return null;
+};`;
+    const [a, b, c] = (await host.executePlugin(code, {
+      eventEmitter: createTestEventEmitter(),
+    })) as unknown[];
+    expect(a).toBe(0);
+    expect(b).toBe(false);
+    expect(c).toBe('');
+  });
+
+  it('setState triggers a re-render and updated state is visible', async () => {
+    const emitter = createTestEventEmitter();
+    let renderCount = 0;
+
+    // Pattern: openWindow called from main() (AFTER context exists) — NOT from evaluate.
+    // This ensures windowId is set before waitForWindow's first poll, and the
+    // makeOpenWindow listener is active when PLUGIN_UI_CLICK arrives.
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            renderCount++;
+            const count = caps['useState']('count', 0) as number;
+            caps['openWindow']('http://example.com'); // fire-and-forget from sync main()
+            if (renderCount >= 2) {
+              caps['done'](count);
+              return null;
+            }
+            return caps['div']({}, [String(count)]);
+          },
+          increment: async () => {
+            caps['setState']('count', 7);
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    // Let all microtasks run: evaluate → main() → openWindow → waitForWindow → onRenderPluginUi
+    await settle();
+
+    // Click → increment → setState → relay (TO_BG → RE_RENDER) → main(true) → done(7)
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'increment', windowId: 42 });
+
+    expect(await p).toBe(7);
+  });
+
+  it('state persists across re-renders', async () => {
+    const emitter = createTestEventEmitter();
+    let renderCount = 0;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            renderCount++;
+            const val = caps['useState']('val', 'initial') as string;
+            caps['openWindow']('http://example.com');
+            if (renderCount >= 3) {
+              caps['done'](val);
+              return null;
+            }
+            return caps['div']({}, [val]);
+          },
+          step1: async () => {
+            caps['setState']('val', 'step1');
+          },
+          step2: async () => {
+            caps['setState']('val', 'step2');
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'step1', windowId: 42 });
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'step2', windowId: 42 });
+
+    expect(await p).toBe('step2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. useEffect
+// ---------------------------------------------------------------------------
+
+describe('HostCore — useEffect', () => {
+  it('runs effect on first call', async () => {
+    let effectRan = false;
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['useEffect'](() => {
+              effectRan = true;
+            }, []);
+            caps['done'](effectRan);
+            return null;
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    await expect(host.executePlugin('', { eventEmitter: createTestEventEmitter() })).resolves.toBe(
+      true,
+    );
+  });
+
+  it('does not re-run effect when deps are identical', async () => {
+    const emitter = createTestEventEmitter();
+    let effectRunCount = 0;
+    let renderCount = 0;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            renderCount++;
+            caps['useEffect'](() => {
+              effectRunCount++;
+            }, ['constant']);
+            caps['openWindow']('http://example.com');
+            if (renderCount >= 2) {
+              caps['done'](effectRunCount);
+              return null;
+            }
+            return caps['div']({}, ['render']);
+          },
+          trigger: async () => {
+            caps['setState']('tick', renderCount);
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'trigger', windowId: 42 });
+
+    expect(await p).toBe(1); // effect ran once — same deps skips on re-render
+  });
+
+  it('re-runs effect when deps change', async () => {
+    const emitter = createTestEventEmitter();
+    let effectRunCount = 0;
+    let renderCount = 0;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            renderCount++;
+            caps['useEffect'](() => {
+              effectRunCount++;
+            }, [renderCount]); // deps change each render
+            caps['openWindow']('http://example.com');
+            if (renderCount >= 2) {
+              caps['done'](effectRunCount);
+              return null;
+            }
+            return caps['div']({}, ['render']);
+          },
+          trigger: async () => {
+            caps['setState']('tick', renderCount);
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'trigger', windowId: 42 });
+
+    expect(await p).toBe(2); // effect ran twice — deps changed on re-render
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. done() / doneWithOverlay()
+// ---------------------------------------------------------------------------
+
+describe('HostCore — done() / doneWithOverlay()', () => {
+  it('done() calls onCloseWindow when a window is open', async () => {
+    const emitter = createTestEventEmitter();
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['waiting']);
+          },
+          finish: async () => {
+            caps['done']('closed');
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host, onCloseWindow } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'finish', windowId: 42 });
+
+    await p;
+    expect(onCloseWindow).toHaveBeenCalledWith(42);
+  });
+
+  it('doneWithOverlay() falls back to done() when no window is open', async () => {
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['doneWithOverlay']('result');
+            return null;
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host, onRenderPluginUi } = makeHost({ evaluator });
+    const result = await host.executePlugin('', { eventEmitter: createTestEventEmitter() });
+
+    expect(result).toBe('result');
+    expect(onRenderPluginUi).not.toHaveBeenCalled();
+  });
+
+  it('doneWithOverlay() renders a completion overlay then closes window', async () => {
+    const emitter = createTestEventEmitter();
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['content']);
+          },
+          finish: async () => {
+            caps['doneWithOverlay']('done', { delayMs: 0 });
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host, onRenderPluginUi, onCloseWindow } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'finish', windowId: 42 });
+
+    await p;
+
+    // Overlay was rendered (has a div structure as DomJson)
+    const overlayCall = onRenderPluginUi.mock.calls.find(([wid]) => wid === 42);
+    expect(overlayCall).toBeDefined();
+    const overlay = overlayCall![1] as DomJson;
+    expect(typeof overlay).toBe('object');
+    expect(onCloseWindow).toHaveBeenCalledWith(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. prove()
+// ---------------------------------------------------------------------------
+
+describe('HostCore — prove()', () => {
+  it('calls onProve with canonicalized handlers', async () => {
+    const emitter = createTestEventEmitter();
+    const onProve = vi.fn().mockResolvedValue({ proof: 'p' });
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['ready']);
+          },
+          doProve: async () => {
+            await caps['prove'](
+              { url: 'https://api.example.com', method: 'GET', headers: {} },
+              {
+                verifierUrl: 'http://localhost:7047',
+                proxyUrl: 'wss://proxy',
+                // String shorthand 'REVEAL' — should be canonicalized to { kind: 'REVEAL' }
+                handlers: [{ type: 'SENT', part: 'START_LINE', action: 'REVEAL' }],
+              },
+            );
+            caps['done']('done');
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator, onProve });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'doProve', windowId: 42 });
+    await p;
+
+    expect(onProve).toHaveBeenCalledOnce();
+    const [, proverOpts] = onProve.mock.calls[0];
+    expect(proverOpts.handlers[0].action).toEqual({ kind: 'REVEAL' });
+  });
+
+  it('sets _proveProgress to COMPLETE after resolution', async () => {
+    const emitter = createTestEventEmitter();
+    const onProve = vi.fn().mockResolvedValue({ proof: 'p' });
+    let progressAtEnd: unknown;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['ready']);
+          },
+          doProve: async () => {
+            await caps['prove'](
+              { url: 'https://api.example.com', method: 'GET', headers: {} },
+              { verifierUrl: 'http://localhost:7047', proxyUrl: 'wss://proxy', handlers: [] },
+            );
+            progressAtEnd = caps['useState']('_proveProgress', null);
+            caps['done']();
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator, onProve });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'doProve', windowId: 42 });
+    await p;
+
+    expect((progressAtEnd as { step: string } | null)?.step).toBe('COMPLETE');
+  });
+
+  it('propagates onProgress callbacks to plugin state', async () => {
+    const emitter = createTestEventEmitter();
+    const onProve = vi.fn().mockImplementation(async (_req, _opts, onProgress) => {
+      onProgress({ step: 'SENDING', progress: 0.5, message: 'Sending...' });
+      return { proof: 'p' };
+    });
+
+    let capturedStep: string | undefined;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['ready']);
+          },
+          doProve: async () => {
+            await caps['prove'](
+              { url: 'https://api.example.com', method: 'GET', headers: {} },
+              { verifierUrl: 'http://localhost:7047', proxyUrl: 'wss://proxy', handlers: [] },
+            );
+            capturedStep = (caps['useState']('_proveProgress', null) as { step: string } | null)
+              ?.step;
+            caps['done']();
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator, onProve });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle();
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'doProve', windowId: 42 });
+    await p;
+
+    expect(capturedStep).toBe('COMPLETE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. openWindow
+// ---------------------------------------------------------------------------
+
+describe('HostCore — openWindow', () => {
+  it('calls onOpenWindow with the given URL and options', async () => {
+    const { onOpenWindow } = makeHost();
+    // Use a direct async main() for this simple case — no click needed
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: async () => {
+            await caps['openWindow']('https://example.com', { width: 800, height: 600 });
+            caps['done']('opened');
+            return null;
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator, onOpenWindow });
+    await host.executePlugin('', { eventEmitter: createTestEventEmitter() });
+
+    expect(onOpenWindow).toHaveBeenCalledWith('https://example.com', { width: 800, height: 600 });
+  });
+
+  it('returns the cached result on repeated calls (idempotent)', async () => {
+    let r1: unknown, r2: unknown;
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: async () => {
+            r1 = await caps['openWindow']('https://example.com');
+            r2 = await caps['openWindow']('https://example.com');
+            caps['done']();
+            return null;
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host, onOpenWindow } = makeHost({ evaluator });
+    await host.executePlugin('', { eventEmitter: createTestEventEmitter() });
+
+    expect(onOpenWindow).toHaveBeenCalledOnce();
+    expect(r1).toBe(r2);
+  });
+
+  it('WINDOW_CLOSED terminates the plugin with an error', async () => {
+    const emitter = createTestEventEmitter();
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({}, ['waiting']);
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    await settle(); // Let openWindow resolve, listener become active
+
+    emitter.emit({ type: 'WINDOW_CLOSED', windowId: 42 });
+
+    await expect(p).rejects.toThrow('Window closed by user');
+  });
+
+  it('buffers messages received before windowId resolves', async () => {
+    const emitter = createTestEventEmitter();
+
+    // Delay onOpenWindow to control when the window resolves
+    let resolveOpen!: () => void;
+    const slowOpenWindow = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ type: string; payload: object }>((resolve) => {
+          resolveOpen = () =>
+            resolve({
+              type: 'WINDOW_OPENED',
+              payload: { windowId: 42, uuid: 'u', tabId: 1 },
+            });
+        }),
+    );
+
+    let capturedRequestCount = 0;
+    let renderCount = 0;
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            renderCount++;
+            const reqs = caps['useRequests']((r: unknown[]) => r) as unknown[];
+            capturedRequestCount = reqs.length;
+            caps['openWindow']('http://example.com');
+            if (capturedRequestCount > 0 && renderCount >= 2) {
+              caps['done'](capturedRequestCount);
+              return null;
+            }
+            return caps['div']({}, ['waiting']);
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator, onOpenWindow: slowOpenWindow });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    // Listener is added by openWindow (synchronously inside main's openWindow call)
+    // but resolvedWindowId is still null — messages will be buffered
+    await settle(); // main() and openWindow call run, listener added, but window not yet resolved
+
+    // Send a request BEFORE the window resolves — should be buffered
+    emitter.emit({
+      type: 'REQUEST_INTERCEPTED',
+      request: {
+        id: 'req-1',
+        method: 'GET',
+        url: 'https://example.com/api',
+        timestamp: Date.now(),
+        tabId: 1,
+      },
+      windowId: 42,
+    });
+
+    // Now resolve the window — buffered request should be replayed into context
+    resolveOpen();
+    await settle();
+
+    // Force a re-render so main() picks up the replayed request
+    emitter.emit({ type: 'RE_RENDER_PLUGIN_UI', windowId: 42 });
+
+    expect(await p).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. addCapability()
+// ---------------------------------------------------------------------------
+
+describe('HostCore — addCapability()', () => {
+  it('injects custom capability callable from plugin code', async () => {
+    const customFn = vi.fn().mockReturnValue('custom');
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            const val = caps['myFn']();
+            caps['done'](val);
+            return null;
+          },
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host } = makeHost({ evaluator });
+    host.addCapability('myFn', customFn);
+
+    const result = await host.executePlugin('', { eventEmitter: createTestEventEmitter() });
+
+    expect(customFn).toHaveBeenCalledOnce();
+    expect(result).toBe('custom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. onRenderPluginUi
+// ---------------------------------------------------------------------------
+
+describe('HostCore — onRenderPluginUi', () => {
+  it('is called with the DomJson returned by main() after window opens', async () => {
+    const emitter = createTestEventEmitter();
+
+    const evaluator: PluginEvaluator = {
+      evaluate: async (_, caps) => ({
+        exports: {
+          main: () => {
+            caps['openWindow']('http://example.com');
+            return caps['div']({ id: 'root' }, ['Hello']);
+          },
+          finish: async () => caps['done'](),
+        },
+        dispose: vi.fn(),
+      }),
+    };
+
+    const { host, onRenderPluginUi } = makeHost({ evaluator });
+    const p = host.executePlugin('', { eventEmitter: emitter });
+
+    // The initial render path goes through waitForWindow(), which polls every
+    // 1 second until windowId is set in the registry. In production, the
+    // background script forces a re-render via CONTENT_SCRIPT_READY when the
+    // managed window's content script loads. Without that signal here, we
+    // simply wait for the natural poll to complete.
+    await vi.waitFor(() => expect(onRenderPluginUi).toHaveBeenCalled(), {
+      timeout: 2000,
+      interval: 50,
+    });
+
+    const [windowId, domJson] = onRenderPluginUi.mock.calls[0];
+    expect(windowId).toBe(42);
+    expect((domJson as { type: string }).type).toBe('div');
+
+    emitter.emit({ type: 'PLUGIN_UI_CLICK', onclick: 'finish', windowId: 42 });
+    await p;
+  });
+});

--- a/packages/plugin-sdk/vite.config.ts
+++ b/packages/plugin-sdk/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       // plugins import styling from '/styles' without pulling in the full SDK.
       entry: {
         index: path.resolve(__dirname, 'src/index.ts'), // Full SDK: Host, Parser, QuickJS sandbox
+        'host-core': path.resolve(__dirname, 'src/host-core.ts'), // Platform-agnostic HostCore
         styles: path.resolve(__dirname, 'src/styles.ts'), // Tailwind-like styling helpers
       },
       formats: ['es'],

--- a/packages/tlsn-mobile/Cargo.toml
+++ b/packages/tlsn-mobile/Cargo.toml
@@ -44,5 +44,8 @@ thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# Session ids for the two-phase prove (prove_until_reveal → prove_finalize)
+uuid = { version = "1", features = ["v4"] }
+
 [features]
 default = []

--- a/packages/tlsn-mobile/rust-toolchain.toml
+++ b/packages/tlsn-mobile/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "nightly"
 targets = ["aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "armv7-linux-androideabi", "x86_64-linux-android", "i686-linux-android"]

--- a/packages/tlsn-mobile/rust-toolchain.toml
+++ b/packages/tlsn-mobile/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 targets = ["aarch64-apple-ios", "aarch64-apple-ios-sim", "aarch64-linux-android", "armv7-linux-androideabi", "x86_64-linux-android", "i686-linux-android"]

--- a/packages/tlsn-mobile/src/lib.rs
+++ b/packages/tlsn-mobile/src/lib.rs
@@ -7,7 +7,26 @@
 mod prover;
 mod ws_io;
 
+use std::sync::OnceLock;
+
 uniffi::setup_scaffolding!();
+
+/// Process-wide tokio runtime.
+///
+/// FFI calls share this runtime so async resources (websockets, TCP streams)
+/// stashed by `prove_until_reveal` survive across multiple FFI calls — a
+/// per-call `Runtime::new()` would be dropped on return, killing every future
+/// it owns and breaking the two-phase prove flow with
+/// "connection is closed".
+fn shared_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build shared tokio runtime")
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Error
@@ -341,13 +360,11 @@ pub fn prove_until_reveal(
     options: ProverOptions,
     progress: Option<Box<dyn ProgressCallback>>,
 ) -> Result<RevealPreparation, TlsnError> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
-
-    rt.block_on(prover::prove_until_reveal_async(
+    let progress_arc = progress.map(std::sync::Arc::<dyn ProgressCallback>::from);
+    shared_runtime().block_on(prover::prove_until_reveal_async(
         request,
         options,
-        progress.as_deref(),
+        progress_arc,
     ))
 }
 
@@ -364,13 +381,11 @@ pub fn prove_finalize(
     approved: bool,
     progress: Option<Box<dyn ProgressCallback>>,
 ) -> Result<ProofResult, TlsnError> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
-
-    rt.block_on(prover::prove_finalize_async(
+    let progress_arc = progress.map(std::sync::Arc::<dyn ProgressCallback>::from);
+    shared_runtime().block_on(prover::prove_finalize_async(
         session_id,
         approved,
-        progress.as_deref(),
+        progress_arc,
     ))
 }
 
@@ -383,8 +398,6 @@ pub fn prove(
     options: ProverOptions,
     progress: Option<Box<dyn ProgressCallback>>,
 ) -> Result<ProofResult, TlsnError> {
-    let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
-
-    rt.block_on(prover::prove_async(request, options, progress.as_deref()))
+    let progress_arc = progress.map(std::sync::Arc::<dyn ProgressCallback>::from);
+    shared_runtime().block_on(prover::prove_async(request, options, progress_arc))
 }

--- a/packages/tlsn-mobile/src/lib.rs
+++ b/packages/tlsn-mobile/src/lib.rs
@@ -188,6 +188,42 @@ pub struct ProofResult {
     pub handlers_received: u32,
 }
 
+/// One row in the reveal-approval preview.
+///
+/// Returned from [`prove_until_reveal`] for each annotated range that
+/// `compute_reveal` produced. The user inspects these (in a native UI on the
+/// JS side) and approves or rejects before [`prove_finalize`] runs.
+///
+/// `preview` contains the actual transcript bytes for the range, decoded as
+/// UTF-8 lossy. The platform layer is responsible for truncating/escaping
+/// before display.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct RevealRangeDescriptor {
+    /// "SENT" or "RECV"
+    pub direction: String,
+    /// Human-readable label (e.g. "Recv body / JSON 'screen_name'").
+    pub label: String,
+    /// "REVEAL" or "HASH"
+    pub action: String,
+    /// Hash algorithm name when `action == "HASH"` (e.g. "Sha256"). None for REVEAL.
+    pub algorithm: Option<String>,
+    /// UTF-8 lossy slice of the actual transcript bytes covered by this range.
+    pub preview: String,
+}
+
+/// Output of [`prove_until_reveal`] — the prover paused after computing
+/// reveal ranges. Pass [`session_id`] back to [`prove_finalize`] with an
+/// approved bool to either complete the reveal or drop the session.
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct RevealPreparation {
+    /// Opaque handle the platform passes back to [`prove_finalize`].
+    pub session_id: String,
+    /// HTTP response received from the target server.
+    pub response: HttpResponse,
+    /// One descriptor per annotated reveal range.
+    pub descriptors: Vec<RevealRangeDescriptor>,
+}
+
 // ---------------------------------------------------------------------------
 // Conversion: mobile UniFFI types → sdk-core types
 // ---------------------------------------------------------------------------
@@ -287,15 +323,60 @@ pub fn initialize() -> Result<(), TlsnError> {
     Ok(())
 }
 
-/// High-level prove function with progress reporting.
+/// Phase A of the two-phase prove flow.
 ///
-/// Handles the entire proof flow:
+/// Runs:
 /// 1. Register session with verifier
 /// 2. Create prover and MPC setup
 /// 3. Send HTTP request through TLS prover
 /// 4. Compute reveal ranges from handlers
-/// 5. Generate and finalize proof
-/// 6. Send reveal config to verifier session
+///
+/// Returns a [`RevealPreparation`] with byte-level previews of every range
+/// the prover is about to reveal/hash. The platform shows the previews to
+/// the user, then calls [`prove_finalize`] with the same `session_id` and an
+/// `approved` bool. State is held in a process-wide map with a 5-minute TTL.
+#[uniffi::export]
+pub fn prove_until_reveal(
+    request: HttpRequest,
+    options: ProverOptions,
+    progress: Option<Box<dyn ProgressCallback>>,
+) -> Result<RevealPreparation, TlsnError> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
+
+    rt.block_on(prover::prove_until_reveal_async(
+        request,
+        options,
+        progress.as_deref(),
+    ))
+}
+
+/// Phase B of the two-phase prove flow.
+///
+/// Looks up the session, then either:
+/// - `approved == true`: runs `prover.reveal(...)`, sends `reveal_config` to
+///   the verifier, awaits `session_completed`, returns the [`ProofResult`].
+/// - `approved == false`: drops the session, closes the verifier websocket,
+///   returns `TlsnError::ProofFailed("User rejected reveal")`.
+#[uniffi::export]
+pub fn prove_finalize(
+    session_id: String,
+    approved: bool,
+    progress: Option<Box<dyn ProgressCallback>>,
+) -> Result<ProofResult, TlsnError> {
+    let rt = tokio::runtime::Runtime::new()
+        .map_err(|e| TlsnError::InitializationFailed(e.to_string()))?;
+
+    rt.block_on(prover::prove_finalize_async(
+        session_id,
+        approved,
+        progress.as_deref(),
+    ))
+}
+
+/// Legacy one-shot `prove`. Equivalent to [`prove_until_reveal`] followed by
+/// [`prove_finalize`] with `approved=true`. Kept for backward compatibility
+/// while callers migrate to the two-phase API.
 #[uniffi::export]
 pub fn prove(
     request: HttpRequest,

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -26,18 +26,16 @@ use std::time::{Duration, Instant};
 use futures::{SinkExt, StreamExt};
 use tlsn_sdk_core::{compute_reveal, config::ProverMode, ProverConfig, SdkProver};
 use tokio::net::TcpStream;
-use tokio_tungstenite::{
-    connect_async,
-    tungstenite::Message,
-    MaybeTlsStream, WebSocketStream,
-};
+use tokio::sync::oneshot;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use url::Url;
 use uuid::Uuid;
 
 use crate::{
-    ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, Mode, ProgressCallback,
-    ProofResult, ProverOptions, RevealPreparation, RevealRangeDescriptor, TlsnError, Transcript,
+    shared_runtime, ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, Mode,
+    ProgressCallback, ProofResult, ProverOptions, RevealPreparation, RevealRangeDescriptor,
+    TlsnError, Transcript,
 };
 
 impl Mode {
@@ -49,27 +47,25 @@ impl Mode {
     }
 }
 
-type SessionWs = WebSocketStream<MaybeTlsStream<TcpStream>>;
-
 /// Sessions older than this are reaped from the map.
 const SESSION_TTL: Duration = Duration::from_secs(5 * 60);
 
-/// In-flight prove state held between [`prove_until_reveal_async`] and
-/// [`prove_finalize_async`]. Lives in [`SESSIONS`] under a UUID.
-struct ProveSession {
-    prover: SdkProver,
-    session_ws: SessionWs,
-    transcript: tlsn_sdk_core::Transcript,
-    compute_output: tlsn_sdk_core::handler::ComputeRevealOutput,
-    sdk_handlers: Vec<tlsn_sdk_core::Handler>,
-    sdk_response: tlsn_sdk_core::HttpResponse,
-    handlers_received: u32,
+/// Channels we hand the spawned prove task between phase A and phase B.
+///
+/// Phase A spawns a task that runs the entire prove flow. The task pauses
+/// after `compute_reveal` waiting on `approval_rx`. Phase B sends `approved`
+/// over `approval_tx`; the task resumes, completes, and emits the result via
+/// `result_rx`. Spawning is what keeps the prover's websocket future being
+/// polled by tokio worker threads in the gap between FFI calls.
+struct PendingSession {
+    approval_tx: oneshot::Sender<bool>,
+    result_rx: oneshot::Receiver<Result<ProofResult, TlsnError>>,
     created_at: Instant,
 }
 
-static SESSIONS: OnceLock<Mutex<HashMap<String, ProveSession>>> = OnceLock::new();
+static SESSIONS: OnceLock<Mutex<HashMap<String, PendingSession>>> = OnceLock::new();
 
-fn sessions() -> &'static Mutex<HashMap<String, ProveSession>> {
+fn sessions() -> &'static Mutex<HashMap<String, PendingSession>> {
     SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -96,14 +92,79 @@ fn emit_progress(cb: Option<&dyn ProgressCallback>, step: &str, progress: f64, m
     }
 }
 
-/// Phase A: run steps 1–4, build a descriptor preview, stash session state.
+/// Phase A: spawn a prove task on the shared runtime; the task runs steps
+/// 1–4, sends back the descriptors, then suspends on the approval channel.
+/// We block on `descriptor_rx` to return the preview to JS without waiting
+/// for the user.
 pub(crate) async fn prove_until_reveal_async(
     request: HttpRequest,
     options: ProverOptions,
-    progress: Option<&dyn ProgressCallback>,
+    progress: Option<std::sync::Arc<dyn ProgressCallback>>,
 ) -> Result<RevealPreparation, TlsnError> {
     reap_expired();
 
+    let (descriptor_tx, descriptor_rx) =
+        oneshot::channel::<Result<RevealPreparation, TlsnError>>();
+    let (approval_tx, approval_rx) = oneshot::channel::<bool>();
+    let (result_tx, result_rx) = oneshot::channel::<Result<ProofResult, TlsnError>>();
+
+    let session_id = Uuid::new_v4().to_string();
+
+    // Spawn the full prove flow on the shared runtime. The task drives the
+    // websocket futures (kept alive by tokio worker threads) across the gap
+    // between phase A's block_on returning and phase B's block_on starting.
+    shared_runtime().spawn(async move {
+        let progress_ref = progress.as_deref();
+        match run_prove_with_gate(request, options, progress_ref, descriptor_tx, approval_rx).await
+        {
+            Ok(result) => {
+                let _ = result_tx.send(Ok(result));
+            }
+            Err(err) => {
+                let _ = result_tx.send(Err(err));
+            }
+        }
+    });
+
+    // Wait for the spawned task to reach the descriptor handoff point.
+    let prep = match descriptor_rx.await {
+        Ok(Ok(p)) => p,
+        Ok(Err(e)) => return Err(e),
+        Err(_) => {
+            return Err(TlsnError::ProofFailed(
+                "prove task ended before producing descriptors".into(),
+            ))
+        }
+    };
+
+    // Stash the channels under the session_id so phase B can resume the task.
+    let pending = PendingSession {
+        approval_tx,
+        result_rx,
+        created_at: Instant::now(),
+    };
+    sessions()
+        .lock()
+        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
+        .insert(session_id.clone(), pending);
+
+    Ok(RevealPreparation {
+        session_id,
+        response: prep.response,
+        descriptors: prep.descriptors,
+    })
+}
+
+/// Spawned-task body. Runs the entire prove flow, sending the descriptors via
+/// `descriptor_tx` once `compute_reveal` produces them, then awaiting the
+/// `approval_rx` signal before either revealing or aborting.
+async fn run_prove_with_gate(
+    request: HttpRequest,
+    options: ProverOptions,
+    progress: Option<&dyn ProgressCallback>,
+    descriptor_tx: oneshot::Sender<Result<RevealPreparation, TlsnError>>,
+    approval_rx: oneshot::Receiver<bool>,
+) -> Result<ProofResult, TlsnError> {
     let handlers_received = options.handlers.len() as u32;
     let mode = options.mode.unwrap_or(Mode::Mpc);
 
@@ -279,48 +340,22 @@ pub(crate) async fn prove_until_reveal_async(
         body: response_body_str,
     };
 
-    // Stash and return.
-    let session_id = Uuid::new_v4().to_string();
-    let session = ProveSession {
-        prover,
-        session_ws,
-        transcript,
-        compute_output,
-        sdk_handlers,
-        sdk_response,
-        handlers_received,
-        created_at: Instant::now(),
-    };
-    sessions()
-        .lock()
-        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
-        .insert(session_id.clone(), session);
-
-    Ok(RevealPreparation {
-        session_id,
+    // Hand the descriptors back to phase A's block_on. session_id is
+    // assigned by the caller; we don't include it here.
+    let _ = descriptor_tx.send(Ok(RevealPreparation {
+        session_id: String::new(),
         response,
         descriptors,
-    })
-}
+    }));
 
-/// Phase B: complete the prove (send reveal + reveal_config) or drop the session.
-pub(crate) async fn prove_finalize_async(
-    session_id: String,
-    approved: bool,
-    progress: Option<&dyn ProgressCallback>,
-) -> Result<ProofResult, TlsnError> {
-    reap_expired();
-
-    let mut session = sessions()
-        .lock()
-        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
-        .remove(&session_id)
-        .ok_or_else(|| TlsnError::ProofFailed(format!("unknown session: {session_id}")))?;
+    // Wait for phase B to send the approval signal.
+    let mut prover = prover;
+    let mut session_ws = session_ws;
+    let approved = approval_rx.await.unwrap_or(false);
 
     if !approved {
-        tracing::info!("user rejected reveal for session {session_id}; dropping");
-        // Best-effort close the verifier websocket; ignore errors during teardown.
-        let _ = session.session_ws.close(None).await;
+        tracing::info!("user rejected reveal; dropping session");
+        let _ = session_ws.close(None).await;
         return Err(TlsnError::ProofFailed("User rejected reveal".into()));
     }
 
@@ -328,9 +363,8 @@ pub(crate) async fn prove_finalize_async(
     // 5. Reveal and finalize
     // -----------------------------------------------------------------------
     emit_progress(progress, "GENERATING_PROOF", 0.65, "Generating proof...");
-    session
-        .prover
-        .reveal(session.compute_output.reveal.clone(), session.compute_output.commit.clone())
+    prover
+        .reveal(compute_output.reveal.clone(), compute_output.commit.clone())
         .await?;
     tracing::info!("proof generated");
     emit_progress(progress, "REVEAL_COMPLETE", 0.8, "Sending verification data...");
@@ -339,13 +373,12 @@ pub(crate) async fn prove_finalize_async(
     // 6. Send reveal_config to verifier session
     // -----------------------------------------------------------------------
     let reveal_config = build_reveal_config(
-        &session.transcript,
-        &session.sdk_handlers,
-        &session.compute_output.sent_ranges_with_handlers,
-        &session.compute_output.recv_ranges_with_handlers,
+        &transcript,
+        &sdk_handlers,
+        &compute_output.sent_ranges_with_handlers,
+        &compute_output.recv_ranges_with_handlers,
     );
-    session
-        .session_ws
+    session_ws
         .send(Message::Text(reveal_config.to_string().into()))
         .await
         .map_err(|e| TlsnError::ProofFailed(format!("failed to send reveal_config: {e}")))?;
@@ -354,7 +387,7 @@ pub(crate) async fn prove_finalize_async(
         std::time::Duration::from_secs(30),
         async {
             loop {
-                match session.session_ws.next().await {
+                match session_ws.next().await {
                     Some(Ok(Message::Text(text))) => {
                         let resp: serde_json::Value = serde_json::from_str(&text)?;
                         tracing::info!("session message: {}", resp["type"]);
@@ -389,8 +422,7 @@ pub(crate) async fn prove_finalize_async(
     // -----------------------------------------------------------------------
     // 7. Build result
     // -----------------------------------------------------------------------
-    let response_headers = session
-        .sdk_response
+    let response_headers = sdk_response
         .headers
         .into_iter()
         .map(|(name, value)| HttpHeader {
@@ -399,24 +431,53 @@ pub(crate) async fn prove_finalize_async(
         })
         .collect();
 
-    let response_body = session
-        .sdk_response
+    let response_body = sdk_response
         .body
         .map(|b| String::from_utf8_lossy(&b).into_owned())
         .unwrap_or_default();
 
     Ok(ProofResult {
         response: HttpResponse {
-            status: session.sdk_response.status,
+            status: sdk_response.status,
             headers: response_headers,
             body: response_body,
         },
         transcript: Transcript {
-            sent: session.transcript.sent,
-            recv: session.transcript.recv,
+            sent: transcript.sent,
+            recv: transcript.recv,
         },
-        handlers_received: session.handlers_received,
+        handlers_received,
     })
+}
+
+/// Phase B: send the approval signal to the spawned task and await its result.
+///
+/// `_progress` here is a no-op — the spawned task already holds its own
+/// progress reference from phase A. We accept it on the FFI surface for
+/// symmetry but don't forward it.
+pub(crate) async fn prove_finalize_async(
+    session_id: String,
+    approved: bool,
+    _progress: Option<std::sync::Arc<dyn ProgressCallback>>,
+) -> Result<ProofResult, TlsnError> {
+    reap_expired();
+
+    let pending = sessions()
+        .lock()
+        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
+        .remove(&session_id)
+        .ok_or_else(|| TlsnError::ProofFailed(format!("unknown session: {session_id}")))?;
+
+    // Wake the spawned task. If `send` fails the task is already gone (likely
+    // panicked or aborted); we'll discover that via `result_rx`.
+    let _ = pending.approval_tx.send(approved);
+
+    match pending.result_rx.await {
+        Ok(r) => r,
+        Err(_) => Err(TlsnError::ProofFailed(
+            "prove task ended without producing a result".into(),
+        )),
+    }
 }
 
 /// Legacy one-shot `prove`. Calls phase A then auto-approves into phase B,
@@ -425,9 +486,9 @@ pub(crate) async fn prove_finalize_async(
 pub(crate) async fn prove_async(
     request: HttpRequest,
     options: ProverOptions,
-    progress: Option<&dyn ProgressCallback>,
+    progress: Option<std::sync::Arc<dyn ProgressCallback>>,
 ) -> Result<ProofResult, TlsnError> {
-    let prep = prove_until_reveal_async(request, options, progress).await?;
+    let prep = prove_until_reveal_async(request, options, progress.clone()).await?;
     prove_finalize_async(prep.session_id, true, progress).await
 }
 

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -6,17 +6,38 @@
 //! - Direct TCP connection to the target server (no proxy needed on native)
 //! - Verifier session registration (the `/session` → `/verifier` protocol)
 //! - Sending `reveal_config` to the verifier session WebSocket
+//!
+//! # Two-phase API
+//!
+//! [`prove_until_reveal_async`] runs the full protocol up through
+//! `compute_reveal`, then **stashes** the in-flight prover, websocket,
+//! transcript, and computed reveal ranges in a process-wide session map keyed
+//! by a UUID. The caller (mobile app) inspects the descriptors, asks the user
+//! for approval, then calls [`prove_finalize_async`] with the same session id
+//! and an `approved` bool.
+//!
+//! The legacy one-shot [`prove_async`] is preserved as a thin wrapper that
+//! always auto-approves — kept to avoid breaking existing callers.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use futures::{SinkExt, StreamExt};
 use tlsn_sdk_core::{compute_reveal, config::ProverMode, ProverConfig, SdkProver};
 use tokio::net::TcpStream;
-use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::Message,
+    MaybeTlsStream, WebSocketStream,
+};
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use url::Url;
+use uuid::Uuid;
 
 use crate::{
-    ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, Mode, ProofResult, ProgressCallback,
-    ProverOptions, TlsnError, Transcript,
+    ws_io::WsIoAdapter, HttpHeader, HttpRequest, HttpResponse, Mode, ProgressCallback,
+    ProofResult, ProverOptions, RevealPreparation, RevealRangeDescriptor, TlsnError, Transcript,
 };
 
 impl Mode {
@@ -25,6 +46,40 @@ impl Mode {
             Mode::Mpc => ProverMode::Mpc,
             Mode::Proxy => ProverMode::Proxy,
         }
+    }
+}
+
+type SessionWs = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// Sessions older than this are reaped from the map.
+const SESSION_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// In-flight prove state held between [`prove_until_reveal_async`] and
+/// [`prove_finalize_async`]. Lives in [`SESSIONS`] under a UUID.
+struct ProveSession {
+    prover: SdkProver,
+    session_ws: SessionWs,
+    transcript: tlsn_sdk_core::Transcript,
+    compute_output: tlsn_sdk_core::handler::ComputeRevealOutput,
+    sdk_handlers: Vec<tlsn_sdk_core::Handler>,
+    sdk_response: tlsn_sdk_core::HttpResponse,
+    handlers_received: u32,
+    created_at: Instant,
+}
+
+static SESSIONS: OnceLock<Mutex<HashMap<String, ProveSession>>> = OnceLock::new();
+
+fn sessions() -> &'static Mutex<HashMap<String, ProveSession>> {
+    SESSIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Drop sessions that have been pending longer than `SESSION_TTL`. Called
+/// opportunistically each time we touch the map so a JS-side crash can't leak
+/// a session forever.
+fn reap_expired() {
+    if let Ok(mut map) = sessions().lock() {
+        let now = Instant::now();
+        map.retain(|_, s| now.duration_since(s.created_at) < SESSION_TTL);
     }
 }
 
@@ -41,24 +96,25 @@ fn emit_progress(cb: Option<&dyn ProgressCallback>, step: &str, progress: f64, m
     }
 }
 
-/// Main async prove function.
-pub(crate) async fn prove_async(
+/// Phase A: run steps 1–4, build a descriptor preview, stash session state.
+pub(crate) async fn prove_until_reveal_async(
     request: HttpRequest,
     options: ProverOptions,
     progress: Option<&dyn ProgressCallback>,
-) -> Result<ProofResult, TlsnError> {
+) -> Result<RevealPreparation, TlsnError> {
+    reap_expired();
+
     let handlers_received = options.handlers.len() as u32;
     let mode = options.mode.unwrap_or(Mode::Mpc);
 
     tracing::info!(
-        "starting proof for {} ({} handlers, mode={:?})",
+        "starting proof (until reveal) for {} ({} handlers, mode={:?})",
         request.url,
         handlers_received,
         mode,
     );
     emit_progress(progress, "CONNECTING", 0.0, "Connecting to verifier...");
 
-    // Parse URL to extract hostname for ProverConfig.
     let url = Url::parse(&request.url)?;
     let hostname = url
         .host_str()
@@ -83,7 +139,6 @@ pub(crate) async fn prove_async(
         TlsnError::ConnectionFailed(format!("failed to connect to session: {e}"))
     })?;
 
-    // Send register message.
     let register_msg = serde_json::json!({
         "type": "register",
         "maxRecvData": options.max_recv_data,
@@ -95,8 +150,7 @@ pub(crate) async fn prove_async(
         .await
         .map_err(|e| TlsnError::ConnectionFailed(format!("failed to send register: {e}")))?;
 
-    // Wait for session_registered response.
-    let session_id = loop {
+    let session_id_verifier = loop {
         match session_ws.next().await {
             Some(Ok(Message::Text(text))) => {
                 let resp: serde_json::Value = serde_json::from_str(&text)?;
@@ -122,7 +176,7 @@ pub(crate) async fn prove_async(
             }
         }
     };
-    tracing::info!("session registered: {session_id}");
+    tracing::info!("session registered: {session_id_verifier}");
     emit_progress(progress, "SESSION_REGISTERED", 0.1, "Session registered");
 
     // -----------------------------------------------------------------------
@@ -136,7 +190,7 @@ pub(crate) async fn prove_async(
 
     let mut prover = SdkProver::new(config)?;
 
-    let verifier_ws_url = format!("{base_ws_url}/verifier?sessionId={session_id}");
+    let verifier_ws_url = format!("{base_ws_url}/verifier?sessionId={session_id_verifier}");
     tracing::info!("connecting to verifier: {verifier_ws_url}");
 
     let verifier_io = connect_ws(&verifier_ws_url).await?;
@@ -183,7 +237,6 @@ pub(crate) async fn prove_async(
         .collect();
 
     let compute_output = if sdk_handlers.is_empty() {
-        // No handlers → reveal everything.
         tracing::info!("no handlers specified, revealing all data");
         tlsn_sdk_core::handler::ComputeRevealOutput {
             reveal: tlsn_sdk_core::Reveal {
@@ -201,10 +254,84 @@ pub(crate) async fn prove_async(
     };
 
     // -----------------------------------------------------------------------
+    // Build descriptors for the JS approval sheet.
+    // -----------------------------------------------------------------------
+    let descriptors = build_descriptors(&transcript, &compute_output);
+    emit_progress(progress, "AWAITING_APPROVAL", 0.55, "Awaiting reveal approval...");
+
+    // Build response payload now while sdk_response is still owned.
+    let response_headers: Vec<HttpHeader> = sdk_response
+        .headers
+        .iter()
+        .map(|(name, value)| HttpHeader {
+            name: name.clone(),
+            value: String::from_utf8_lossy(value).into_owned(),
+        })
+        .collect();
+    let response_body_str = sdk_response
+        .body
+        .as_ref()
+        .map(|b| String::from_utf8_lossy(b).into_owned())
+        .unwrap_or_default();
+    let response = HttpResponse {
+        status: sdk_response.status,
+        headers: response_headers,
+        body: response_body_str,
+    };
+
+    // Stash and return.
+    let session_id = Uuid::new_v4().to_string();
+    let session = ProveSession {
+        prover,
+        session_ws,
+        transcript,
+        compute_output,
+        sdk_handlers,
+        sdk_response,
+        handlers_received,
+        created_at: Instant::now(),
+    };
+    sessions()
+        .lock()
+        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
+        .insert(session_id.clone(), session);
+
+    Ok(RevealPreparation {
+        session_id,
+        response,
+        descriptors,
+    })
+}
+
+/// Phase B: complete the prove (send reveal + reveal_config) or drop the session.
+pub(crate) async fn prove_finalize_async(
+    session_id: String,
+    approved: bool,
+    progress: Option<&dyn ProgressCallback>,
+) -> Result<ProofResult, TlsnError> {
+    reap_expired();
+
+    let mut session = sessions()
+        .lock()
+        .map_err(|_| TlsnError::ProofFailed("session map poisoned".into()))?
+        .remove(&session_id)
+        .ok_or_else(|| TlsnError::ProofFailed(format!("unknown session: {session_id}")))?;
+
+    if !approved {
+        tracing::info!("user rejected reveal for session {session_id}; dropping");
+        // Best-effort close the verifier websocket; ignore errors during teardown.
+        let _ = session.session_ws.close(None).await;
+        return Err(TlsnError::ProofFailed("User rejected reveal".into()));
+    }
+
+    // -----------------------------------------------------------------------
     // 5. Reveal and finalize
     // -----------------------------------------------------------------------
     emit_progress(progress, "GENERATING_PROOF", 0.65, "Generating proof...");
-    prover.reveal(compute_output.reveal, compute_output.commit).await?;
+    session
+        .prover
+        .reveal(session.compute_output.reveal.clone(), session.compute_output.commit.clone())
+        .await?;
     tracing::info!("proof generated");
     emit_progress(progress, "REVEAL_COMPLETE", 0.8, "Sending verification data...");
 
@@ -212,22 +339,22 @@ pub(crate) async fn prove_async(
     // 6. Send reveal_config to verifier session
     // -----------------------------------------------------------------------
     let reveal_config = build_reveal_config(
-        &transcript,
-        &sdk_handlers,
-        &compute_output.sent_ranges_with_handlers,
-        &compute_output.recv_ranges_with_handlers,
+        &session.transcript,
+        &session.sdk_handlers,
+        &session.compute_output.sent_ranges_with_handlers,
+        &session.compute_output.recv_ranges_with_handlers,
     );
-    session_ws
+    session
+        .session_ws
         .send(Message::Text(reveal_config.to_string().into()))
         .await
         .map_err(|e| TlsnError::ProofFailed(format!("failed to send reveal_config: {e}")))?;
 
-    // Wait for session_completed (with timeout — proof result is already available).
     let wait_result = tokio::time::timeout(
         std::time::Duration::from_secs(30),
         async {
             loop {
-                match session_ws.next().await {
+                match session.session_ws.next().await {
                     Some(Ok(Message::Text(text))) => {
                         let resp: serde_json::Value = serde_json::from_str(&text)?;
                         tracing::info!("session message: {}", resp["type"]);
@@ -248,8 +375,9 @@ pub(crate) async fn prove_async(
                     }
                 }
             }
-        }
-    ).await;
+        },
+    )
+    .await;
 
     match wait_result {
         Ok(Ok(())) => {}
@@ -261,7 +389,8 @@ pub(crate) async fn prove_async(
     // -----------------------------------------------------------------------
     // 7. Build result
     // -----------------------------------------------------------------------
-    let response_headers = sdk_response
+    let response_headers = session
+        .sdk_response
         .headers
         .into_iter()
         .map(|(name, value)| HttpHeader {
@@ -270,23 +399,115 @@ pub(crate) async fn prove_async(
         })
         .collect();
 
-    let response_body = sdk_response
+    let response_body = session
+        .sdk_response
         .body
         .map(|b| String::from_utf8_lossy(&b).into_owned())
         .unwrap_or_default();
 
     Ok(ProofResult {
         response: HttpResponse {
-            status: sdk_response.status,
+            status: session.sdk_response.status,
             headers: response_headers,
             body: response_body,
         },
         transcript: Transcript {
-            sent: transcript.sent,
-            recv: transcript.recv,
+            sent: session.transcript.sent,
+            recv: session.transcript.recv,
         },
-        handlers_received,
+        handlers_received: session.handlers_received,
     })
+}
+
+/// Legacy one-shot `prove`. Calls phase A then auto-approves into phase B,
+/// preserving the historic behavior for callers that haven't migrated to the
+/// two-phase API yet.
+pub(crate) async fn prove_async(
+    request: HttpRequest,
+    options: ProverOptions,
+    progress: Option<&dyn ProgressCallback>,
+) -> Result<ProofResult, TlsnError> {
+    let prep = prove_until_reveal_async(request, options, progress).await?;
+    prove_finalize_async(prep.session_id, true, progress).await
+}
+
+/// Translate compute_reveal's annotated ranges into platform-friendly
+/// descriptors with real byte previews.
+fn build_descriptors(
+    transcript: &tlsn_sdk_core::Transcript,
+    output: &tlsn_sdk_core::handler::ComputeRevealOutput,
+) -> Vec<RevealRangeDescriptor> {
+    let mut out = Vec::with_capacity(
+        output.sent_ranges_with_handlers.len() + output.recv_ranges_with_handlers.len(),
+    );
+
+    for r in &output.sent_ranges_with_handlers {
+        out.push(descriptor_from_range(r, &transcript.sent, "SENT"));
+    }
+    for r in &output.recv_ranges_with_handlers {
+        out.push(descriptor_from_range(r, &transcript.recv, "RECV"));
+    }
+
+    out
+}
+
+fn descriptor_from_range(
+    r: &tlsn_sdk_core::handler::RangeWithHandler,
+    bytes: &[u8],
+    direction: &str,
+) -> RevealRangeDescriptor {
+    let slice = bytes.get(r.start..r.end).unwrap_or(&[]);
+    let preview = String::from_utf8_lossy(slice).into_owned();
+
+    let (action, algorithm) = match &r.handler.action {
+        tlsn_sdk_core::HandlerAction::Reveal => ("REVEAL".to_string(), None),
+        tlsn_sdk_core::HandlerAction::Hash { algorithm } => {
+            let alg_str = match algorithm {
+                tlsn_sdk_core::HashAlgorithm::Blake3 => "Blake3",
+                tlsn_sdk_core::HashAlgorithm::Sha256 => "Sha256",
+                tlsn_sdk_core::HashAlgorithm::Keccak256 => "Keccak256",
+            };
+            ("HASH".to_string(), Some(alg_str.to_string()))
+        }
+    };
+
+    RevealRangeDescriptor {
+        direction: direction.to_string(),
+        label: handler_label(&r.handler),
+        action,
+        algorithm,
+        preview,
+    }
+}
+
+fn handler_label(h: &tlsn_sdk_core::Handler) -> String {
+    let direction = match h.handler_type {
+        tlsn_sdk_core::HandlerType::Sent => "Sent",
+        tlsn_sdk_core::HandlerType::Recv => "Recv",
+    };
+    let part = match h.part {
+        tlsn_sdk_core::HandlerPart::StartLine => "start line",
+        tlsn_sdk_core::HandlerPart::Protocol => "protocol",
+        tlsn_sdk_core::HandlerPart::Method => "method",
+        tlsn_sdk_core::HandlerPart::RequestTarget => "request target",
+        tlsn_sdk_core::HandlerPart::StatusCode => "status code",
+        tlsn_sdk_core::HandlerPart::Headers => "header",
+        tlsn_sdk_core::HandlerPart::Body => "body",
+        tlsn_sdk_core::HandlerPart::All => "all",
+    };
+    let detail = h.params.as_ref().and_then(|p| {
+        if let Some(key) = &p.key {
+            Some(format!(" '{}'", key))
+        } else if let Some(path) = &p.path {
+            Some(format!(" path '{}'", path))
+        } else {
+            None
+        }
+    });
+    match detail {
+        Some(d) => format!("{direction} {part}{d}"),
+        None => format!("{direction} {part}"),
+    }
 }
 
 /// Build the `reveal_config` JSON message for the verifier session WebSocket.
@@ -296,7 +517,6 @@ fn build_reveal_config(
     sent_ranges: &[tlsn_sdk_core::handler::RangeWithHandler],
     recv_ranges: &[tlsn_sdk_core::handler::RangeWithHandler],
 ) -> serde_json::Value {
-    // If no handlers were specified, reveal everything.
     if handlers.is_empty() {
         return serde_json::json!({
             "type": "reveal_config",
@@ -305,8 +525,6 @@ fn build_reveal_config(
         });
     }
 
-    // Serialize annotated ranges from compute_reveal.
-    // RangeWithHandler and Handler implement Serialize with the correct field names.
     serde_json::json!({
         "type": "reveal_config",
         "sent": sent_ranges,

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -383,40 +383,11 @@ async fn run_prove_with_gate(
         .await
         .map_err(|e| TlsnError::ProofFailed(format!("failed to send reveal_config: {e}")))?;
 
-    let wait_result = tokio::time::timeout(
-        std::time::Duration::from_secs(10),
-        async {
-            loop {
-                match session_ws.next().await {
-                    Some(Ok(Message::Text(text))) => {
-                        let resp: serde_json::Value = serde_json::from_str(&text)?;
-                        tracing::info!("session message: {}", resp["type"]);
-                        if resp["type"] == "session_completed" {
-                            tracing::info!("session completed");
-                            return Ok::<(), TlsnError>(());
-                        } else if resp["type"] == "error" {
-                            return Err(TlsnError::ProofFailed(
-                                resp["message"].as_str().unwrap_or("unknown error").into(),
-                            ));
-                        }
-                    }
-                    Some(Ok(_)) => continue,
-                    Some(Err(e)) => return Err(TlsnError::ProofFailed(format!("WebSocket error: {e}"))),
-                    None => {
-                        tracing::warn!("session WebSocket closed before completion");
-                        return Ok(());
-                    }
-                }
-            }
-        },
-    )
-    .await;
-
-    match wait_result {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => return Err(e),
-        Err(_) => tracing::warn!("timed out waiting for session_completed (proof still valid)"),
-    }
+    // Drop the session socket — the reveal_config has been sent. The verifier
+    // continues processing asynchronously; we don't need to wait for
+    // session_completed because the proof is already valid (prover.reveal()
+    // completed) and the mobile layer derives handler results locally.
+    drop(session_ws);
     emit_progress(progress, "VERIFICATION_COMPLETE", 0.95, "Verification complete");
 
     // -----------------------------------------------------------------------

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -571,6 +571,50 @@ fn handler_label(h: &tlsn_sdk_core::Handler) -> String {
     }
 }
 
+/// Convert a single `RangeWithHandler` to the verifier's expected JSON format.
+///
+/// The verifier uses `#[serde(tag = "kind")]` for `HandlerAction`, producing
+/// `{"kind":"REVEAL"}`. The sdk-core crate uses `#[serde(tag = "action")]`,
+/// producing `{"action":"REVEAL"}`. Serializing sdk-core types directly would
+/// therefore emit the wrong tag key and cause the verifier to reject the
+/// message. We manually construct the JSON here to guarantee the correct shape.
+fn range_to_verifier_json(r: &tlsn_sdk_core::handler::RangeWithHandler) -> serde_json::Value {
+    let handler_type = match r.handler.handler_type {
+        tlsn_sdk_core::HandlerType::Sent => "SENT",
+        tlsn_sdk_core::HandlerType::Recv => "RECV",
+    };
+    let part = match r.handler.part {
+        tlsn_sdk_core::HandlerPart::StartLine => "START_LINE",
+        tlsn_sdk_core::HandlerPart::Protocol => "PROTOCOL",
+        tlsn_sdk_core::HandlerPart::Method => "METHOD",
+        tlsn_sdk_core::HandlerPart::RequestTarget => "REQUEST_TARGET",
+        tlsn_sdk_core::HandlerPart::StatusCode => "STATUS_CODE",
+        tlsn_sdk_core::HandlerPart::Headers => "HEADERS",
+        tlsn_sdk_core::HandlerPart::Body => "BODY",
+        tlsn_sdk_core::HandlerPart::All => "ALL",
+    };
+    let action = match &r.handler.action {
+        tlsn_sdk_core::HandlerAction::Reveal => serde_json::json!({"kind": "REVEAL"}),
+        tlsn_sdk_core::HandlerAction::Hash { algorithm } => {
+            let alg = match algorithm {
+                tlsn_sdk_core::HashAlgorithm::Blake3 => "BLAKE3",
+                tlsn_sdk_core::HashAlgorithm::Sha256 => "SHA256",
+                tlsn_sdk_core::HashAlgorithm::Keccak256 => "KECCAK256",
+            };
+            serde_json::json!({"kind": "HASH", "algorithm": alg})
+        }
+    };
+    serde_json::json!({
+        "start": r.start,
+        "end": r.end,
+        "handler": {
+            "type": handler_type,
+            "part": part,
+            "action": action,
+        }
+    })
+}
+
 /// Build the `reveal_config` JSON message for the verifier session WebSocket.
 fn build_reveal_config(
     transcript: &tlsn_sdk_core::Transcript,
@@ -581,14 +625,16 @@ fn build_reveal_config(
     if handlers.is_empty() {
         return serde_json::json!({
             "type": "reveal_config",
-            "sent": [{ "start": 0, "end": transcript.sent.len(), "handler": { "type": "SENT", "part": "ALL" } }],
-            "recv": [{ "start": 0, "end": transcript.recv.len(), "handler": { "type": "RECV", "part": "ALL" } }],
+            "sent": [{ "start": 0, "end": transcript.sent.len(), "handler": { "type": "SENT", "part": "ALL", "action": {"kind": "REVEAL"} } }],
+            "recv": [{ "start": 0, "end": transcript.recv.len(), "handler": { "type": "RECV", "part": "ALL", "action": {"kind": "REVEAL"} } }],
         });
     }
 
+    let sent: Vec<serde_json::Value> = sent_ranges.iter().map(range_to_verifier_json).collect();
+    let recv: Vec<serde_json::Value> = recv_ranges.iter().map(range_to_verifier_json).collect();
     serde_json::json!({
         "type": "reveal_config",
-        "sent": sent_ranges,
-        "recv": recv_ranges,
+        "sent": sent,
+        "recv": recv,
     })
 }

--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -384,7 +384,7 @@ async fn run_prove_with_gate(
         .map_err(|e| TlsnError::ProofFailed(format!("failed to send reveal_config: {e}")))?;
 
     let wait_result = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
+        std::time::Duration::from_secs(10),
         async {
             loop {
                 match session_ws.next().await {


### PR DESCRIPTION
## Summary

- Splits the monolithic `Host` class into a platform-agnostic `HostCore` (new `src/host-core.ts`, ~1237 lines) and a thin `Host` shim in `src/index.ts` that injects a QuickJS evaluator
- Introduces `PluginEvaluator` as the single platform-specific seam: `evaluate(code, capabilities) => Promise<{ exports, dispose }>`
- Adds `./host-core` export path so mobile and other non-QuickJS consumers can import `HostCore` without pulling in the QuickJS WASM dependency
- 24 new Node.js unit tests in `test/host-core.test.ts` using a `new Function()` mock evaluator — no browser or WASM required; covers all hooks, lifecycle, openWindow, prove, done/doneWithOverlay, timeout, and addCapability
- All 265 existing tests continue to pass; `Host` API is fully backward-compatible

## Motivation

`app/mobile/lib/MobilePluginHost.ts` duplicates ~770 lines of hook/lifecycle logic that lives in `Host`. With `HostCore` extracted, mobile (and future platform targets) can `extends HostCore` and supply their own evaluator instead of maintaining a parallel copy.

## What's in `HostCore`

All platform-agnostic runtime: `useState`, `setState`, `useEffect`, `useRequests`, `useHeaders`, `openWindow` (with message buffering and lifecycle tracking), `prove` (with progress callbacks and canonicalization), `done`, `doneWithOverlay`, timeout management, DOM builders (`div`, `button`, `input`), and the execution context registry.

## What stays in `Host` (QuickJS-specific)

- `createQuickJSSandbox()` — `loadQuickJs` + `runSandboxed` wrapper
- `createQuickJSEvaluator()` — wraps sandbox as a `PluginEvaluator`
- `preprocessPluginCode()` — workarounds for QuickJS `handleToNative` prototype cycle bug
- Backward-compat methods: `createEvalCode()`, `getPluginConfig()`, `updateExecutionContext()`

## Phase 2 (separate PR)

Mobile migration to `extends HostCore` — deferred because of three API divergences that need options added to HostCore first: `RE_RENDER_PLUGIN_UI` vs `TO_BG_RE_RENDER_PLUGIN_UI` event routing, optional `onProgress` in `onProve`, and optional timeout management.

## Test plan

- [x] `cd packages/plugin-sdk && npm test` — 265 passing, 0 failing
- [x] `npm run build --workspace=@tlsn/plugin-sdk` — builds cleanly, new `dist/host-core.js` entry emitted
- [x] `npm run build:extension` — extension builds cleanly against updated plugin-sdk
- [x] `npm run lint --workspace=@tlsn/plugin-sdk` — clean

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)