### PR TITLE
fix(mobile): propagate Result from ProverConfigBuilder::build()

### DIFF
--- a/packages/tlsn-mobile/src/prover.rs
+++ b/packages/tlsn-mobile/src/prover.rs
@@ -116,7 +116,7 @@ pub(crate) async fn prove_async(
     let config = ProverConfig::builder(hostname)
         .max_sent_data(options.max_sent_data as usize)
         .max_recv_data(options.max_recv_data as usize)
-        .build();
+        .build()?;
 
     let mut prover = SdkProver::new(config)?;
 


### PR DESCRIPTION
## Summary
- Upstream `tlsn-sdk-core`'s `ProverConfigBuilder::build()` now returns `Result<ProverConfig, SdkError>` instead of `ProverConfig` directly.
- Adds `?` at [packages/tlsn-mobile/src/prover.rs:119](packages/tlsn-mobile/src/prover.rs#L119) to compile against current tlsn `main`. `From<SdkError> for TlsnError` is already implemented, so the error converts cleanly.

## Why CI started failing
`packages/tlsn-mobile/Cargo.toml` declares `tlsn-sdk-core` with `branch = "main"`, and `packages/tlsn-mobile/Cargo.lock` is gitignored. Local builds reused the old locked commit (`4dada85`) and compiled fine; CI has no lockfile, re-resolved against the latest `branch = "main"` (`1cd76444`), and hit the new API.

## Test plan
- [x] `cargo check --manifest-path packages/tlsn-mobile/Cargo.toml` passes locally with no `Cargo.lock` (simulates CI's fresh resolve)
- [x] CI: `mobile-check`, `android-build`, `ios-build` go green