### PR TITLE
fix(tlsn-wasm): use awk instead of sed for macOS portability

### DIFF
--- a/packages/tlsn-wasm/build.sh
+++ b/packages/tlsn-wasm/build.sh
@@ -78,13 +78,18 @@ fi
 if [ "$NO_LOGGING" = "--no-logging" ]; then
     echo "Applying no-logging configuration..."
     
-    # Add it to the wasm32 target section (after the section header)
-    sed -i.bak '/^\[target\.\x27cfg(target_arch = "wasm32")\x27\.dependencies\]$/a\
-# Disable tracing events as a workaround for issue 959.\
-tracing = { workspace = true, features = ["release_max_level_off"] }' Cargo.toml
-    
-    # Clean up backup file
-    rm Cargo.toml.bak
+    # Add it to the wasm32 target section (after the section header).
+    # Uses awk for portability — BSD sed (macOS) drops the trailing newline
+    # after `a\` text, jamming the inserted key into the next existing key.
+    awk '
+/^\[target\.'"'"'cfg\(target_arch = "wasm32"\)'"'"'\.dependencies\]$/ {
+  print
+  print "# Disable tracing events as a workaround for issue 959."
+  print "tracing = { workspace = true, features = [\"release_max_level_off\"] }"
+  next
+}
+{ print }
+' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 fi
 
 # On NixOS, the wrapped clang injects host glibc headers when cross-compiling


### PR DESCRIPTION
## Summary

- Replace `sed -i.bak ... | rm Cargo.toml.bak` with an equivalent `awk` one-liner in `build.sh`'s `--no-logging` path

## Problem

BSD `sed` (macOS) silently drops the trailing newline after `a\` text, jamming the inserted key directly into the next existing key in `Cargo.toml`. GNU `sed` (Linux) handles it correctly, so the bug only surfaces on macOS builds.

## Fix

`awk` prints each inserted line explicitly and is portable across both macOS and Linux without any flags or backup files.

## Test plan

- [ ] Run `./build.sh --no-logging` on macOS — verify the two inserted lines appear on separate lines in `Cargo.toml`
- [ ] Run `./build.sh --no-logging` on Linux — verify same output

> Extracted from PR #334 per reviewer request.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)