### PR TITLE
chore(extension): version 0.1.0.1409

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23288,7 +23288,7 @@
       }
     },
     "packages/extension": {
-      "version": "0.1.0.1408",
+      "version": "0.1.0.1409",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",

--- a/packages/demo/src/config.ts
+++ b/packages/demo/src/config.ts
@@ -13,4 +13,4 @@ export const config = {
 // Bump this only after a new extension build is approved on the Chrome Web Store,
 // so users with the previously-released extension don't get falsely flagged as outdated.
 // Extensions exposing no `version` field are treated as outdated.
-export const MIN_EXTENSION_VERSION = '0.1.0.1408';
+export const MIN_EXTENSION_VERSION = '0.1.0.1409';

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "0.1.0.1408",
+  "version": "0.1.0.1409",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.1.0.1408",
+  "version": "0.1.0.1409",
   "name": "TLSNotary",
   "description": "A Chrome extension for TLSNotary",
   "options_page": "options.html",


### PR DESCRIPTION
## Summary

Bumps the extension to `0.1.0.1409`.

This release also bumps `MIN_EXTENSION_VERSION` in [packages/demo/src/config.ts](packages/demo/src/config.ts) — #315 added new extension APIs that the demo now uses (Proxy mode and `window.tlsn.version`), so per [RELEASING.md](RELEASING.md) step 1 the floor must move in the same commit. The demo deploys on every push to `main`; during the Chrome Web Store approval window users on 0.1.0.1408 will see the "update extension" StatusBar message, which is the intended UX.

### What's in 0.1.0.1409 vs 0.1.0.1408

- #315 feat: Proxy protocol mode alongside MPC
- #338 fix(tlsn-wasm): use awk instead of sed for macOS portability
- #331 feat(demo): rewrite landing page narrative and polish layout
- #336 fix(mobile): propagate Result from `ProverConfigBuilder::build()`
- #332 fix(tutorial): raise swissbank `maxRecvData` to 520
- #329 chore(mobile): ADI registration plugin for Play Console
- #330 fix: use `./` instead of `.` for marketplace plugin source path
- #328 perf(verifier): hot-path optimizations (oneshot, BytesMut, LTO)
- #327 perf(verifier): set TCP_NODELAY on outbound proxy connection
- #324 chore(verifier): bump non-tlsn dependencies

## Test plan

- [x] Extension lint clean
- [x] Demo lint clean
- [x] Extension tests: 174 / 174 pass
- [x] `npm run build` produces `extension-0.1.0.1409.zip` cleanly
- [x] After merge: `gh release create 0.1.0.1409 --target main --title "0.1.0.1409" --generate-notes` to trigger Chrome Web Store publish