### PR TITLE
fix(verifier): drop stale -pre suffix from /info tlsn_version

### DIFF
--- a/servers/verifier/src/main.rs
+++ b/servers/verifier/src/main.rs
@@ -418,7 +418,7 @@ pub(crate) async fn info_handler() -> impl IntoResponse {
     axum::Json(InfoResponse {
         version: env!("CARGO_PKG_VERSION"),
         git_hash,
-        tlsn_version: "0.1.0-alpha.15-pre",
+        tlsn_version: "0.1.0-alpha.15",
     })
 }
 


### PR DESCRIPTION
## Summary

- Cargo.toml + Cargo.lock pin to released tag `v0.1.0-alpha.15`, but the `/info` handler's hardcoded literal still read `alpha.15-pre`.
- Result: https://demo.tlsnotary.org/info reports `tlsn_version: 0.1.0-alpha.15-pre` even after the alpha.15 bump merged.
- Fix the literal to `0.1.0-alpha.15`.

Caught while reviewing the demo deploy that followed the `0.1.0.1500` extension release prep.

## Test plan

- [ ] CI green (`cargo build -p tlsn-verifier-server` passes locally).
- [ ] After merge + demo redeploy, `curl https://demo.tlsnotary.org/info` reports `tlsn_version: 0.1.0-alpha.15` (no `-pre`).