### PR TITLE
fix(swissbank): unify auth check + add source link to home

### DIFF
--- a/servers/swissbank/src/dashboard.css
+++ b/servers/swissbank/src/dashboard.css
@@ -1,182 +1,199 @@
 body {
-    font-family: Arial, sans-serif;
-    margin: 0;
-    padding: 20px;
-    background: white;
-    color: black;
-    font-size: 18px;
-    line-height: 1.6;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 20px;
+  background: white;
+  color: black;
+  font-size: 18px;
+  line-height: 1.6;
 }
 
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .header {
-    text-align: center;
-    margin-bottom: 40px;
-    padding: 30px;
-    border-bottom: 3px solid #333;
+  text-align: center;
+  margin-bottom: 40px;
+  padding: 30px;
+  border-bottom: 3px solid #333;
 }
 
 .header h1 {
-    font-size: 4rem;
-    margin: 0 0 20px 0;
-    color: #2c5aa0;
+  font-size: 4rem;
+  margin: 0 0 20px 0;
+  color: #2c5aa0;
 }
 
 .header p {
-    font-size: 1.5rem;
-    margin: 0;
-    color: #666;
+  font-size: 1.5rem;
+  margin: 0;
+  color: #666;
 }
 
 .section {
-    margin: 40px 0;
-    padding: 30px;
-    border: 2px solid #ddd;
-    border-radius: 10px;
+  margin: 40px 0;
+  padding: 30px;
+  border: 2px solid #ddd;
+  border-radius: 10px;
 }
 
 .content-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
 }
 
 @media (min-width: 1024px) {
-    .content-grid {
-        flex-direction: row;
-        align-items: flex-start;
-    }
+  .content-grid {
+    flex-direction: row;
+    align-items: flex-start;
+  }
 
-    .content-grid .section {
-        flex: 1;
-        margin: 0;
-    }
+  .content-grid .section {
+    flex: 1;
+    margin: 0;
+  }
 }
 
 .section h2 {
-    font-size: 2.5rem;
-    margin-top: 0;
-    color: #333;
-    border-bottom: 2px solid #333;
-    padding-bottom: 10px;
+  font-size: 2.5rem;
+  margin-top: 0;
+  color: #333;
+  border-bottom: 2px solid #333;
+  padding-bottom: 10px;
 }
 
 .log-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 1.2rem;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 1.2rem;
 }
 
 .log-table th,
 .log-table td {
-    padding: 12px;
-    text-align: left;
-    border-bottom: 1px solid #ddd;
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
 }
 
 .log-table th {
-    background-color: #f8f9fa;
-    font-weight: bold;
-    font-size: 1.3rem;
+  background-color: #f8f9fa;
+  font-weight: bold;
+  font-size: 1.3rem;
 }
 
 .log-table tbody tr:nth-child(even) {
-    background-color: #f8f9fa;
+  background-color: #f8f9fa;
 }
 
 .status-authorized {
-    color: #28a745;
-    font-weight: bold;
+  color: #28a745;
+  font-weight: bold;
 }
 
 .status-unauthorized {
-    color: #dc3545;
-    font-weight: bold;
+  color: #dc3545;
+  font-weight: bold;
 }
 
 .footer {
-    text-align: center;
-    margin-top: 40px;
-    padding: 20px;
-    background-color: #f8f9fa;
-    border-radius: 10px;
-    font-size: 1.3rem;
+  text-align: center;
+  margin-top: 40px;
+  padding: 20px;
+  background-color: #f8f9fa;
+  border-radius: 10px;
+  font-size: 1.3rem;
 }
 
 .footer code {
-    background: #e9ecef;
-    padding: 5px 10px;
-    border-radius: 5px;
-    font-family: monospace;
+  background: #e9ecef;
+  padding: 5px 10px;
+  border-radius: 5px;
+  font-family: monospace;
 }
 
 /* Home page styles */
 .home-body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    max-width: 800px;
-    margin: 50px auto;
-    padding: 20px;
-    background: #f5f5f5;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  max-width: 800px;
+  margin: 50px auto;
+  padding: 20px;
+  background: #f5f5f5;
 }
 
 .home-container {
-    background: white;
-    padding: 40px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  background: white;
+  padding: 40px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .home-container h1 {
-    color: #333;
-    margin-bottom: 20px;
+  color: #333;
+  margin-bottom: 20px;
 }
 
 .description {
-    margin-bottom: 30px;
-    padding: 20px;
-    background: #f8f9fa;
-    border-left: 4px solid #007bff;
-    border-radius: 4px;
+  margin-bottom: 30px;
+  padding: 20px;
+  background: #f8f9fa;
+  border-left: 4px solid #007bff;
+  border-radius: 4px;
 }
 
 .description p {
-    margin: 10px 0;
-    color: #555;
-    line-height: 1.6;
+  margin: 10px 0;
+  color: #555;
+  line-height: 1.6;
 }
 
 .links {
-    display: flex;
-    flex-direction: column;
-    gap: 15px;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
 .link-item {
-    padding: 20px;
-    border: 2px solid #e0e0e0;
-    border-radius: 6px;
-    text-decoration: none;
-    color: #333;
-    transition: all 0.2s;
+  padding: 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 6px;
+  text-decoration: none;
+  color: #333;
+  transition: all 0.2s;
 }
 
 .link-item:hover {
-    border-color: #007bff;
-    background: #f8f9fa;
+  border-color: #007bff;
+  background: #f8f9fa;
 }
 
 .link-title {
-    font-size: 1.2em;
-    font-weight: bold;
-    margin-bottom: 5px;
-    color: #007bff;
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-bottom: 5px;
+  color: #007bff;
 }
 
 .link-desc {
-    font-size: 0.9em;
-    color: #666;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.source-footer {
+  margin-top: 40px;
+  text-align: center;
+  font-size: 0.85em;
+  color: #888;
+}
+
+.source-footer a {
+  color: #007bff;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.source-footer a:hover {
+  text-decoration: underline;
 }

--- a/servers/swissbank/src/lib.rs
+++ b/servers/swissbank/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
 
 use axum::{
     extract::{ConnectInfo, Form},
-    http::Request,
+    http::{HeaderMap, Request},
     middleware::{self, Next},
     response::{Html, IntoResponse, Redirect},
     routing::{get, post},
@@ -37,6 +37,27 @@ const HARDCODED_USERS: [(&str, &str); 2] = [
 ];
 const DASHBOARD_CSS: &str = include_str!("dashboard.css");
 const HTMX_JS: &str = include_str!("htmx.min.js");
+const SOURCE_URL: &str =
+    "https://github.com/tlsnotary/tlsn-extension/tree/main/servers/swissbank";
+
+/// Single source of truth for authorization: a request is authorized if it
+/// presents either a valid session cookie (set by dashboard login) or a valid
+/// `Authorization: Bearer …` header. Used by both the access-log middleware
+/// and the `AuthenticatedUser` extractor so they can't drift.
+fn is_authorized(headers: &HeaderMap) -> bool {
+    let cookies = CookieJar::from_headers(headers);
+    if cookies
+        .get(SESSION_COOKIE)
+        .is_some_and(|c| c.value() == AUTH_TOKEN)
+    {
+        return true;
+    }
+
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|h| h.trim_start_matches("Bearer ") == AUTH_TOKEN)
+}
 
 fn get_local_ip() -> String {
     if let Ok(ip) = local_ip_address::local_ip() {
@@ -168,18 +189,7 @@ async fn access_log_middleware(
                     .unwrap_or_else(|| "<unknown>".to_string())
             });
 
-        // Check authorization header
-        let is_authorized = req
-            .headers()
-            .get("authorization")
-            .and_then(|value| value.to_str().ok())
-            .map(|auth_token| {
-                let token = auth_token.trim_start_matches("Bearer ");
-                token == AUTH_TOKEN
-            })
-            .unwrap_or(false);
-
-        let message = if is_authorized {
+        let message = if is_authorized(req.headers()) {
             format!("✅ Authorized access to /balances from {}", ip)
         } else {
             format!("❌ Unauthorized access attempt to /balances from {}", ip)
@@ -211,28 +221,11 @@ where
         req: axum::extract::Request,
         _state: &S,
     ) -> Result<Self, Self::Rejection> {
-        // First check for session cookie
-        let cookies = CookieJar::from_headers(req.headers());
-        if let Some(session_cookie) = cookies.get(SESSION_COOKIE) {
-            if session_cookie.value() == AUTH_TOKEN {
-                return Ok(AuthenticatedUser);
-            }
+        if is_authorized(req.headers()) {
+            Ok(AuthenticatedUser)
+        } else {
+            Err((StatusCode::UNAUTHORIZED, "Invalid or missing token"))
         }
-
-        // Fallback to Bearer token for API access
-        let auth_header = req
-            .headers()
-            .get(header::AUTHORIZATION)
-            .and_then(|value| value.to_str().ok());
-
-        if let Some(auth_token) = auth_header {
-            let token = auth_token.trim_start_matches("Bearer ");
-            if token == AUTH_TOKEN {
-                return Ok(AuthenticatedUser);
-            }
-        }
-
-        Err((StatusCode::UNAUTHORIZED, "Invalid or missing token"))
     }
 }
 
@@ -402,6 +395,10 @@ pub fn HomePage() -> Element {
                         div { class: "link-title", "Logs" }
                         div { class: "link-desc", "View access logs in JSON format" }
                     }
+                }
+                footer { class: "source-footer",
+                    "Source: "
+                    a { href: SOURCE_URL, target: "_blank", rel: "noopener noreferrer", "{SOURCE_URL}" }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Bugfix:** the access-log middleware only checked the `Authorization: Bearer …` header, while the actual `AuthenticatedUser` extractor accepted *either* a Bearer header **or** a session cookie. Cookie-authenticated requests therefore logged `❌ Unauthorized access attempt to /balances` even though the handler returned 200. Extracted a single `is_authorized(headers)` helper used by both, so they can't drift again.
- Added a small footer on the home page (`/`) linking to this crate's GitHub source. Doubles as a visual confirmation that the deployed image is built from this repo, not `devconnect25_demo`.

## Test plan

- [x] Local smoke test against `cargo run --release -p swissbank`:
  - Unauthenticated `GET /balances` → 401, log: `❌ Unauthorized`
  - `Authorization: Bearer random_auth_token` → 200, log: `✅ Authorized`
  - `Cookie: bank_session=random_auth_token` → 200, log: `✅ Authorized` (previously logged `❌` — the bug)
  - `GET /` includes `github.com/tlsnotary/tlsn-extension/tree/main/servers/swissbank` link
- [x] `cargo clippy -p swissbank --all-targets -- -D warnings` clean
- [x] `cargo test -p swissbank` passes
- [ ] After merge: workflow `swissbank.yml` triggers (paths under `servers/swissbank/**` changed), new `:latest` image is published, devops's deploy picks it up, and the home page on https://swissbank.tlsnotary.org shows the source link