### PR TITLE
fix: treat user-rejected reveal as cancellation, not error

### DIFF
--- a/app/mobile/app/plugin/[id].tsx
+++ b/app/mobile/app/plugin/[id].tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { View, Text, StyleSheet, Alert, ScrollView, TouchableOpacity } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import { isUserRejectedRevealError } from '@tlsn/plugin-sdk/host-core';
 import { PluginScreen } from '@/components/tlsn/PluginScreen';
 import { getPluginById } from '../../assets/plugins/registry';
 import { useVerifierUrl, useProxyMode } from '@/lib/useVerifierUrl';
@@ -183,6 +184,9 @@ export default function PluginRunnerScreen() {
             setResult(typeof res === 'string' ? res : JSON.stringify(res, null, 2));
           }}
           onError={(err) => {
+            // PluginScreen surfaces its own graceful cancelled state for
+            // reveal-rejection; defensive check in case it leaks through.
+            if (isUserRejectedRevealError(err)) return;
             Alert.alert('Plugin Error', err.message);
           }}
         />

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -226,7 +226,13 @@ function NativeProverComponent(
       try {
         return await module.proveFinalize(sessionId, approved);
       } catch (e) {
-        console.error('[NativeProver] proveFinalize failed:', e);
+        // When `approved` is false the native side is expected to reject with
+        // ProofFailed("User rejected reveal") — log at info, not error.
+        if (!approved) {
+          console.log('[NativeProver] proveFinalize cancelled by user');
+        } else {
+          console.error('[NativeProver] proveFinalize failed:', e);
+        }
         throw e;
       }
     },

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -14,6 +14,7 @@ import {
   WindowMessage,
   RevealRangeDescriptor,
 } from '../../lib/MobilePluginHost';
+import { UserRejectedRevealError, isUserRejectedRevealError } from '@tlsn/plugin-sdk/host-core';
 
 /**
  * Resolve a dot-separated path (e.g. "items.0.name") against a JSON value.
@@ -138,6 +139,10 @@ export function PluginScreen({
   const [proverReady, setProverReady] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set when the user taps Reject on the reveal-approval sheet. The plugin's
+  // prove() call will throw, but that's an expected user action — we surface
+  // a graceful "cancelled" UI instead of an error.
+  const [revealRejected, setRevealRejected] = useState(false);
 
   // Pre-execution approval gate: null until the user picks a mode.
   const [approvalMode, setApprovalMode] = useState<ApprovalMode | null>(null);
@@ -315,8 +320,13 @@ export function PluginScreen({
         onComplete?.(result);
       })
       .catch((err) => {
-        console.error('[PluginScreen] Plugin error:', err);
         const error = err instanceof Error ? err : new Error(String(err));
+        if (isUserRejectedRevealError(error)) {
+          console.log('[PluginScreen] Plugin cancelled: user rejected reveal');
+          setRevealRejected(true);
+          return;
+        }
+        console.error('[PluginScreen] Plugin error:', err);
         setError(error.message);
         onError?.(error);
       })
@@ -345,7 +355,7 @@ export function PluginScreen({
       />
 
       {/* WebView for login/header interception */}
-      {webViewUrl && (
+      {webViewUrl && !revealRejected && (
         <View style={styles.webViewContainer}>
           <PluginWebView
             url={webViewUrl}
@@ -358,7 +368,7 @@ export function PluginScreen({
       {/* Plugin UI overlay — hidden while any bottom-sheet gate is active so
           the sheet (absolute-positioned) is always visually on top without
           relying on z-index competition against plugin CSS. */}
-      {domJson && revealApproval == null && timeoutWarning == null && (
+      {domJson && revealApproval == null && timeoutWarning == null && !revealRejected && (
         <View style={styles.pluginUiContainer}>
           <PluginRenderer domJson={domJson} onPluginAction={handlePluginAction} />
         </View>
@@ -388,6 +398,18 @@ export function PluginScreen({
         </View>
       )}
 
+      {/* "Reveal rejected" surface — shown when the user taps Reject on the
+          reveal-approval sheet. The proof was prepared locally but no reveal
+          was sent to the verifier. */}
+      {revealRejected && (
+        <View style={styles.rejectedContainer}>
+          <Text style={styles.rejectedTitle}>Proof cancelled</Text>
+          <Text style={styles.rejectedSubtitle}>
+            You rejected the reveal. No data was revealed to the verifier.
+          </Text>
+        </View>
+      )}
+
       {/* Pre-execution approval sheet — visible until the user picks a mode.
           Rendered last so it stacks above the rest. */}
       <PluginApprovalSheet
@@ -408,7 +430,10 @@ export function PluginScreen({
           setRevealApproval(null);
         }}
         onReject={() => {
-          revealApproval?.reject(new Error('User rejected reveal'));
+          // Mark the cancelled state up front so the catch handler can
+          // suppress the error UI when the plugin's prove() inevitably throws.
+          setRevealRejected(true);
+          revealApproval?.reject(new UserRejectedRevealError());
           setRevealApproval(null);
         }}
       />

--- a/app/mobile/lib/MobilePluginHost.ts
+++ b/app/mobile/lib/MobilePluginHost.ts
@@ -215,6 +215,10 @@ export class MobilePluginHost {
             });
           } catch (e) {
             approved = false;
+            // Mark the execution context as rejected so done()/doneWithOverlay()
+            // also reject — matches the extension's `_revealReject` path and
+            // guards against plugins that swallow the prove() throw.
+            this.core.markRevealRejected();
             // Surface the rejection up-stack after we drop the native session.
             void options.onProveFinalize(prep.sessionId, false).catch(() => {});
             throw e instanceof Error ? e : new Error(String(e));

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import browser from 'webextension-polyfill';
 import { SessionManager } from '../../offscreen/SessionManager';
 import { logger } from '@tlsn/common';
+import { isUserRejectedRevealError } from '@tlsn/plugin-sdk';
 import { getStoredLogLevel } from '../../utils/logLevelStorage';
 import { sha256 } from '../../utils/cryptoHash';
 import { getPluginCount, incrementPluginCount } from '../../utils/pluginExecutionCounts';
@@ -75,7 +76,11 @@ const OffscreenApp: React.FC = () => {
             };
           })
           .catch((error) => {
-            logger.error('Plugin execution error:', error);
+            if (isUserRejectedRevealError(error)) {
+              logger.info('Plugin cancelled: user rejected reveal');
+            } else {
+              logger.error('Plugin execution error:', error);
+            }
             return {
               success: false,
               error: error.message,

--- a/packages/plugin-sdk/src/host-core.ts
+++ b/packages/plugin-sdk/src/host-core.ts
@@ -26,6 +26,37 @@ import {
 import deepEqual from 'fast-deep-equal';
 
 // ---------------------------------------------------------------------------
+// User-rejection signal
+//
+// Rejecting the reveal-approval gate is an expected user action, not an error.
+// Two complementary mechanisms model this:
+//
+//   - `ctx.revealWasRejected` (internal): set by the extension's
+//     `_revealReject` PLUGIN_UI_CLICK handler or mobile's
+//     `markRevealRejected()`. The SDK uses the flag for its own decisions
+//     (log severity, `done()` rejecting even when the plugin swallows the
+//     prove() throw) — robust to sandbox boundaries that strip prototypes.
+//
+//   - `UserRejectedRevealError` (external): the class constructed at every
+//     `doneReject` site. Always built in host code, so the prototype reaches
+//     downstream callers (PluginScreen, Offscreen, …) intact for `instanceof`.
+// ---------------------------------------------------------------------------
+
+const USER_REJECTED_REVEAL_MESSAGE = 'User rejected reveal';
+
+export class UserRejectedRevealError extends Error {
+  constructor() {
+    super(USER_REJECTED_REVEAL_MESSAGE);
+    this.name = 'UserRejectedRevealError';
+    Object.setPrototypeOf(this, UserRejectedRevealError.prototype);
+  }
+}
+
+export function isUserRejectedRevealError(err: unknown): boolean {
+  return err instanceof UserRejectedRevealError;
+}
+
+// ---------------------------------------------------------------------------
 // Shared types
 // ---------------------------------------------------------------------------
 
@@ -448,7 +479,7 @@ export function makeOpenWindow(
                 revealApprovalDescriptors: null,
                 revealWasRejected: true,
               });
-              approval.reject(new Error('User rejected reveal'));
+              approval.reject(new UserRejectedRevealError());
             }
             return;
           }
@@ -487,7 +518,15 @@ export function makeOpenWindow(
           Promise.resolve().then(() => executionContext.main(true));
         }
       } catch (error) {
-        logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);
+        // The error came from inside the sandbox and may have been stripped
+        // of its prototype crossing the QuickJS/Hermes boundary — check the
+        // execution-context flag instead of the error object's class.
+        const ctxAfter = executionContextRegistry.get(uuid);
+        if (ctxAfter?.revealWasRejected) {
+          logger.debug(`[makeOpenWindow] Message ${message.type} cancelled: user rejected reveal`);
+        } else {
+          logger.error(`[makeOpenWindow] Error handling message ${message.type}:`, error);
+        }
         eventEmitter.removeListener(onMessage);
         const err = error instanceof Error ? error : new Error(String(error));
         if (onError) {
@@ -1100,9 +1139,19 @@ export class HostCore {
     const terminateWithError = (error: Error) => {
       if (lifecycle.isCompleted) return;
       lifecycle.isCompleted = true;
-      logger.error('[executePlugin] Plugin terminated with error:', error);
-
       const ctx = executionContextRegistry.get(uuid);
+      // The execution-context flag is the source of truth for "user rejected
+      // reveal" — the incoming `error` may have lost its prototype crossing
+      // the sandbox boundary. When the flag is set, canonicalize the error
+      // so downstream callers (PluginScreen, Offscreen, …) can rely on
+      // `isUserRejectedRevealError(err)`.
+      if (ctx?.revealWasRejected) {
+        logger.info('[executePlugin] Plugin cancelled: user rejected reveal');
+        error = new UserRejectedRevealError();
+      } else {
+        logger.error('[executePlugin] Plugin terminated with error:', error);
+      }
+
       const pendingApproval = ctx?.revealApproval;
       if (pendingApproval) {
         try {
@@ -1209,7 +1258,7 @@ export class HostCore {
         const finalize = () => {
           executionContextRegistry.delete(uuid);
           if (wasRejected) {
-            doneReject(new Error('User rejected reveal'));
+            doneReject(new UserRejectedRevealError());
           } else {
             doneResolve(args);
           }
@@ -1242,7 +1291,7 @@ export class HostCore {
         const wasRejected = ctx?.revealWasRejected === true;
         const settle = () => {
           if (wasRejected) {
-            doneReject(new Error('User rejected reveal'));
+            doneReject(new UserRejectedRevealError());
           } else {
             doneResolve(args);
           }
@@ -1529,6 +1578,23 @@ export class HostCore {
     });
     const ctx = executionContextRegistry.get(uuid);
     ctx?.main(true);
+  }
+
+  /**
+   * Mark the active execution context as having had its reveal rejected.
+   *
+   * When a host's onProve callback rejects with USER_REJECTED_REVEAL_MESSAGE
+   * (e.g. mobile's native bottom-sheet flow, which doesn't go through the
+   * in-plugin `_revealReject` DOM button), the plugin's prove() will throw.
+   * If the plugin catches that throw and calls `done(value)` normally, the
+   * outer executePlugin promise would resolve as success — masking a
+   * cancelled proof as completed. Setting this flag here makes `done()` and
+   * `doneWithOverlay()` reject the outer promise instead, matching the
+   * `_revealReject` PLUGIN_UI_CLICK path used by the extension.
+   */
+  markRevealRejected(): void {
+    if (!this._activeUuid) return;
+    updateExecutionContext(this._activeUuid, { revealWasRejected: true });
   }
 
   renderUi(windowId: number, json: DomJson): void {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -332,7 +332,12 @@ export { getJsonBody } from './host-core';
 
 // Export HostCore and PluginEvaluator for platform implementors
 export type { PluginEvaluator, PluginEvaluatorResult, HostCoreOptions } from './host-core';
-export { HostCore, NativeFunctionEvaluator } from './host-core';
+export {
+  HostCore,
+  NativeFunctionEvaluator,
+  UserRejectedRevealError,
+  isUserRejectedRevealError,
+} from './host-core';
 
 // Timeout constants (consumed by tests and extension code)
 export {


### PR DESCRIPTION
## Summary
- Rejecting the reveal-approval gate is an expected user action, but it surfaced on mobile as a red `Plugin Error: User rejected reveal` Alert and a stack of `console.error` lines at each layer (NativeProver → makeOpenWindow → executePlugin → PluginScreen).
- Introduces `UserRejectedRevealError` + `isUserRejectedRevealError` in `@tlsn/plugin-sdk`. External callers detect cancellation via `instanceof`; the SDK keeps `ctx.revealWasRejected` as the internal source of truth (robust to sandbox boundaries that strip prototypes).
- New `HostCore.markRevealRejected()` lets mobile's native bottom-sheet flow set the same ctx flag the extension's `_revealReject` PLUGIN_UI_CLICK handler sets — so `done()`/`doneWithOverlay()` reject the `executePlugin` promise even when a plugin swallows the `prove()` throw.
- Mobile now shows a graceful "Proof cancelled" panel mirroring the existing pre-execution rejection screen; `plugin/[id].tsx` no longer fires the `Alert.alert` for cancellation. Extension offscreen log demoted to `info`.

Closes #347.

## Test plan
- [x] `npm run lint` + `npm run test` pass in `packages/plugin-sdk` (271), `packages/extension` (184), and `app/mobile` (33).
- [ ] On mobile, run a plugin and tap **Reject** on the reveal-approval sheet → "Proof cancelled" panel renders, no red Alert, no `console.error` toasts in LogBox.
- [ ] On mobile, tap **Approve** → proof flow completes as before.
- [ ] In the extension, reject the reveal overlay → offscreen logs `Plugin cancelled: user rejected reveal` at info, not error.