### PR TITLE
fix(mobile): replace broken source viewer with GitHub link

### DIFF
--- a/app/mobile/app/plugin/[id].tsx
+++ b/app/mobile/app/plugin/[id].tsx
@@ -177,6 +177,7 @@ export default function PluginRunnerScreen() {
         <PluginScreen
           pluginCode={plugin.getPluginCode()}
           pluginConfig={plugin.pluginConfig}
+          sourceUrl={plugin.sourceUrl}
           verifierUrlOverride={verifierUrl}
           mode={proxyMode ? 'Proxy' : 'Mpc'}
           onComplete={(res) => {

--- a/app/mobile/assets/plugins/registry.ts
+++ b/app/mobile/assets/plugins/registry.ts
@@ -12,6 +12,8 @@ export interface PluginEntry {
   accentColor: string;
   pluginConfig: PluginConfig;
   getPluginCode: () => string;
+  /** GitHub URL pointing at the plugin's source on `main`. */
+  sourceUrl: string;
 }
 
 // Static require map — Metro needs static require() calls for bundling.
@@ -32,6 +34,8 @@ const CODE_MAP: Record<string, () => string> = {
 
 const DEFAULT_VERIFIER_URL = 'https://demo.tlsnotary.org';
 
+const SOURCE_BASE = 'https://github.com/tlsnotary/tlsn-extension/blob/main/packages/plugins/src';
+
 function toPluginEntry(meta: PluginMetadata, verifierUrl: string): PluginEntry {
   return {
     id: meta.id,
@@ -51,6 +55,7 @@ function toPluginEntry(meta: PluginMetadata, verifierUrl: string): PluginEntry {
       oauthHosts: meta.pluginConfig.oauthHosts,
     },
     getPluginCode: CODE_MAP[meta.id] || (() => ''),
+    sourceUrl: `${SOURCE_BASE}/${meta.id}.plugin.ts`,
   };
 }
 

--- a/app/mobile/components/tlsn/PluginApprovalSheet.tsx
+++ b/app/mobile/components/tlsn/PluginApprovalSheet.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React from 'react';
+import { Linking, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { PluginConfig } from '@tlsn/plugin-sdk';
 import { BottomSheetCard } from './BottomSheetCard';
 
@@ -15,7 +15,8 @@ export type ApprovalMode = 'manual' | 'all-session' | 'rejected';
 interface PluginApprovalSheetProps {
   visible: boolean;
   pluginConfig: PluginConfig;
-  pluginCode: string;
+  /** GitHub URL of the plugin's source file, opened in the system browser. */
+  sourceUrl?: string;
   onApprove: (mode: 'manual' | 'all-session') => void;
   onReject: () => void;
 }
@@ -27,12 +28,10 @@ interface PluginApprovalSheetProps {
 export function PluginApprovalSheet({
   visible,
   pluginConfig,
-  pluginCode,
+  sourceUrl,
   onApprove,
   onReject,
 }: PluginApprovalSheetProps) {
-  const [sourceExpanded, setSourceExpanded] = useState(false);
-
   const requests = pluginConfig.requests ?? [];
 
   return (
@@ -63,18 +62,10 @@ export function PluginApprovalSheet({
           </View>
         ) : null}
 
-        <TouchableOpacity style={styles.sourceToggle} onPress={() => setSourceExpanded((v) => !v)}>
-          <Text style={styles.sourceToggleText}>
-            {sourceExpanded ? '▾ Hide source' : '▸ View source'}
-          </Text>
-        </TouchableOpacity>
-
-        {sourceExpanded ? (
-          <View style={styles.sourceBox}>
-            <ScrollView horizontal style={styles.sourceScroll} showsHorizontalScrollIndicator>
-              <Text style={styles.sourceText}>{pluginCode}</Text>
-            </ScrollView>
-          </View>
+        {sourceUrl ? (
+          <TouchableOpacity style={styles.sourceToggle} onPress={() => Linking.openURL(sourceUrl)}>
+            <Text style={styles.sourceToggleText}>View source on GitHub ↗</Text>
+          </TouchableOpacity>
         ) : null}
       </ScrollView>
 
@@ -140,14 +131,6 @@ const styles = StyleSheet.create({
   path: { color: '#6b7280' },
   sourceToggle: { marginTop: 16, paddingVertical: 6 },
   sourceToggleText: { fontSize: 14, color: '#2563eb', fontWeight: '500' },
-  sourceBox: {
-    marginTop: 8,
-    backgroundColor: '#f3f4f6',
-    borderRadius: 8,
-    maxHeight: 200,
-  },
-  sourceScroll: { padding: 12 },
-  sourceText: { fontFamily: 'SpaceMono', fontSize: 11, color: '#1f2937' },
   footer: {
     flexDirection: 'column',
     paddingTop: 16,

--- a/app/mobile/components/tlsn/PluginScreen.tsx
+++ b/app/mobile/components/tlsn/PluginScreen.tsx
@@ -95,6 +95,8 @@ interface PluginScreenProps {
   pluginCode: string;
   /** Plugin configuration (extracted from plugin code) */
   pluginConfig: PluginConfig;
+  /** GitHub URL for the plugin's source — shown on the approval sheet. */
+  sourceUrl?: string;
   /** Called when the plugin completes (calls done()) */
   onComplete?: (result: unknown) => void;
   /** Called when the plugin encounters an error */
@@ -117,6 +119,7 @@ interface PluginScreenProps {
 export function PluginScreen({
   pluginCode,
   pluginConfig,
+  sourceUrl,
   onComplete,
   onError,
   verifierUrlOverride,
@@ -393,7 +396,7 @@ export function PluginScreen({
       <PluginApprovalSheet
         visible={proverReady && approvalMode == null}
         pluginConfig={pluginConfig}
-        pluginCode={pluginCode}
+        sourceUrl={sourceUrl}
         onApprove={(mode) => setApprovalMode(mode)}
         onReject={() => setApprovalMode('rejected')}
       />


### PR DESCRIPTION
## Summary

- The on-device source viewer showed the transpiled mobile bundle, which starts with ~22 lines of esbuild's `__async` helper. Combined with a scroll bug in the bottom sheet, users only ever saw the helper, never the plugin code.
- Why the helper exists: Hermes' runtime parser (used by `new Function()` in `NativeFunctionEvaluator`) rejects `async` syntax, so the mobile bundle has to keep `target: 'es2016'`. That constraint isn't going away.
- Fix: drop the embedded code box; show a single "View source on GitHub ↗" link that opens the developer-written `.plugin.ts` on `main` in the system browser.

Closes #346

## Test plan

- [ ] Open any plugin (e.g. Swiss Bank) → approval sheet shows "View source on GitHub ↗"
- [ ] Tap the link → opens `https://github.com/tlsnotary/tlsn-extension/blob/main/packages/plugins/src/<id>.plugin.ts` in the browser
- [ ] Approve / Reject buttons still work as before