### PR TITLE
feat(mobile): add in-app Logs screen with native log bridge and prover verbosity

### DIFF
--- a/app/mobile/app/(tabs)/settings.tsx
+++ b/app/mobile/app/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -9,27 +9,46 @@ import {
   ScrollView,
   Switch,
 } from 'react-native';
+import { useRouter } from 'expo-router';
 import {
   getVerifierUrl,
   setVerifierUrl,
   getProxyMode,
   setProxyMode,
+  getLogLevel,
+  setLogLevelPref,
   DEFAULT_VERIFIER_URL,
+  DEFAULT_LOG_LEVEL,
+  LOG_LEVELS,
+  type TlsnLogLevel,
 } from '@/lib/useVerifierUrl';
 
 export default function SettingsScreen() {
+  const router = useRouter();
   const [url, setUrl] = useState('');
   const [saved, setSaved] = useState(false);
   const [proxyMode, setProxyModeState] = useState(false);
+  const [logLevel, setLogLevelState] = useState<TlsnLogLevel>(DEFAULT_LOG_LEVEL);
+  // Don't let the async initial read clobber a tap that lands before it resolves.
+  const logLevelTouched = useRef(false);
 
   useEffect(() => {
     getVerifierUrl().then(setUrl);
     getProxyMode().then(setProxyModeState);
+    getLogLevel().then((level) => {
+      if (!logLevelTouched.current) setLogLevelState(level);
+    });
   }, []);
 
   const handleToggleProxyMode = async (value: boolean) => {
     setProxyModeState(value);
     await setProxyMode(value);
+  };
+
+  const handleSelectLogLevel = async (level: TlsnLogLevel) => {
+    logLevelTouched.current = true;
+    setLogLevelState(level);
+    await setLogLevelPref(level);
   };
 
   const handleSave = async () => {
@@ -90,6 +109,45 @@ export default function SettingsScreen() {
           />
         </View>
       </View>
+
+      <View style={[styles.card, styles.cardSpacing]}>
+        <Text style={styles.label}>Prover verbosity</Text>
+        <Text style={styles.description}>
+          How much the tlsn prover logs — captures this level and finer detail (not a display
+          filter). Use Debug or Trace to diagnose proving failures; applies on the next run.
+        </Text>
+        <View style={styles.segment}>
+          {LOG_LEVELS.map((level) => {
+            const active = logLevel === level;
+            return (
+              <TouchableOpacity
+                key={level}
+                style={[styles.segmentButton, active && styles.segmentButtonActive]}
+                onPress={() => handleSelectLogLevel(level)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
+                  {level.charAt(0).toUpperCase() + level.slice(1)}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </View>
+
+      <TouchableOpacity
+        style={[styles.card, styles.cardSpacing, styles.linkRow]}
+        onPress={() => router.push('/logs')}
+        activeOpacity={0.7}
+      >
+        <View style={styles.toggleLabelGroup}>
+          <Text style={styles.label}>Logs</Text>
+          <Text style={styles.linkDescription}>
+            View app and prover logs. Share them when reporting an issue.
+          </Text>
+        </View>
+        <Text style={styles.chevron}>›</Text>
+      </TouchableOpacity>
 
       <View style={styles.infoCard}>
         <Text style={styles.infoTitle}>Default</Text>
@@ -204,5 +262,46 @@ const styles = StyleSheet.create({
   },
   cardSpacing: {
     marginTop: 12,
+  },
+  linkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  linkDescription: {
+    fontSize: 13,
+    color: '#666',
+    lineHeight: 18,
+    marginTop: 2,
+  },
+  chevron: {
+    fontSize: 24,
+    color: '#999',
+    fontWeight: '400',
+  },
+  segment: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  segmentButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    backgroundColor: '#fafafa',
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+  segmentButtonActive: {
+    backgroundColor: '#243f5f',
+    borderColor: '#243f5f',
+  },
+  segmentText: {
+    fontSize: 14,
+    color: '#666',
+    fontWeight: '600',
+  },
+  segmentTextActive: {
+    color: '#fff',
   },
 });

--- a/app/mobile/app/(tabs)/settings.tsx
+++ b/app/mobile/app/(tabs)/settings.tsx
@@ -15,6 +15,8 @@ import {
   setVerifierUrl,
   getProxyMode,
   setProxyMode,
+  getDebugEnabled,
+  setDebugEnabled,
   getLogLevel,
   setLogLevelPref,
   DEFAULT_VERIFIER_URL,
@@ -28,6 +30,7 @@ export default function SettingsScreen() {
   const [url, setUrl] = useState('');
   const [saved, setSaved] = useState(false);
   const [proxyMode, setProxyModeState] = useState(false);
+  const [debugEnabled, setDebugEnabledState] = useState(false);
   const [logLevel, setLogLevelState] = useState<TlsnLogLevel>(DEFAULT_LOG_LEVEL);
   // Don't let the async initial read clobber a tap that lands before it resolves.
   const logLevelTouched = useRef(false);
@@ -35,6 +38,7 @@ export default function SettingsScreen() {
   useEffect(() => {
     getVerifierUrl().then(setUrl);
     getProxyMode().then(setProxyModeState);
+    getDebugEnabled().then(setDebugEnabledState);
     getLogLevel().then((level) => {
       if (!logLevelTouched.current) setLogLevelState(level);
     });
@@ -43,6 +47,11 @@ export default function SettingsScreen() {
   const handleToggleProxyMode = async (value: boolean) => {
     setProxyModeState(value);
     await setProxyMode(value);
+  };
+
+  const handleToggleDebug = async (value: boolean) => {
+    setDebugEnabledState(value);
+    await setDebugEnabled(value);
   };
 
   const handleSelectLogLevel = async (level: TlsnLogLevel) => {
@@ -111,29 +120,47 @@ export default function SettingsScreen() {
       </View>
 
       <View style={[styles.card, styles.cardSpacing]}>
-        <Text style={styles.label}>Prover verbosity</Text>
-        <Text style={styles.description}>
-          How much the tlsn prover logs — captures this level and finer detail (not a display
-          filter). Use Debug or Trace to diagnose proving failures; applies on the next run.
-        </Text>
-        <View style={styles.segment}>
-          {LOG_LEVELS.map((level) => {
-            const active = logLevel === level;
-            return (
-              <TouchableOpacity
-                key={level}
-                style={[styles.segmentButton, active && styles.segmentButtonActive]}
-                onPress={() => handleSelectLogLevel(level)}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
-                  {level.charAt(0).toUpperCase() + level.slice(1)}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleLabelGroup}>
+            <Text style={styles.label}>Debug</Text>
+            <Text style={styles.linkDescription}>
+              Show prover log detail and a live log drawer while running a plugin.
+            </Text>
+          </View>
+          <Switch
+            value={debugEnabled}
+            onValueChange={handleToggleDebug}
+            trackColor={{ false: '#ddd', true: '#243f5f' }}
+          />
         </View>
       </View>
+
+      {debugEnabled && (
+        <View style={[styles.card, styles.cardSpacing]}>
+          <Text style={styles.label}>Prover verbosity</Text>
+          <Text style={styles.description}>
+            How much the tlsn prover logs — captures this level and finer detail (not a display
+            filter). Use Debug or Trace to diagnose proving failures; applies on the next run.
+          </Text>
+          <View style={styles.segment}>
+            {LOG_LEVELS.map((level) => {
+              const active = logLevel === level;
+              return (
+                <TouchableOpacity
+                  key={level}
+                  style={[styles.segmentButton, active && styles.segmentButtonActive]}
+                  onPress={() => handleSelectLogLevel(level)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
+                    {level.charAt(0).toUpperCase() + level.slice(1)}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      )}
 
       <TouchableOpacity
         style={[styles.card, styles.cardSpacing, styles.linkRow]}

--- a/app/mobile/app/_layout.tsx
+++ b/app/mobile/app/_layout.tsx
@@ -9,6 +9,11 @@ import 'react-native-reanimated';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { useColorScheme } from '@/components/useColorScheme';
+import { installLogCapture } from '@/lib/installLogCapture';
+
+// Tee console.* into the in-app Logs screen as early as possible, so logs
+// emitted during startup and proving are captured. Idempotent.
+installLogCapture();
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -56,6 +61,7 @@ function RootLayoutNav() {
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false, title: 'Plugins' }} />
           <Stack.Screen name="plugin/[id]" options={{ presentation: 'card' }} />
+          <Stack.Screen name="logs" options={{ presentation: 'card' }} />
           <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
         </Stack>
       </ThemeProvider>

--- a/app/mobile/app/logs.tsx
+++ b/app/mobile/app/logs.tsx
@@ -1,0 +1,256 @@
+import React, { useMemo, useState, useSyncExternalStore } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, FlatList, Share, Platform } from 'react-native';
+import { Stack } from 'expo-router';
+
+import {
+  subscribe,
+  getLogs,
+  clearLogs,
+  formatLogs,
+  type LogEntry,
+  type LogLevel,
+} from '@/lib/logStore';
+
+type Filter = 'all' | LogLevel;
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'debug', label: 'Debug' },
+  { key: 'info', label: 'Info' },
+  { key: 'warn', label: 'Warn' },
+  { key: 'error', label: 'Error' },
+];
+
+const LEVEL_COLOR: Record<LogLevel, string> = {
+  debug: '#8a8f98',
+  info: '#2563eb',
+  warn: '#b45309',
+  error: '#dc2626',
+};
+
+const MONO = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
+
+function LogRow({ entry }: { entry: LogEntry }) {
+  const color = LEVEL_COLOR[entry.level];
+  return (
+    <View style={[styles.row, { borderLeftColor: color }]}>
+      <View style={styles.rowHeader}>
+        <Text style={[styles.level, { color }]}>{entry.level.toUpperCase()}</Text>
+        {entry.source === 'native' && <Text style={styles.nativeBadge}>native</Text>}
+        {entry.tag ? <Text style={styles.tag}>{entry.tag}</Text> : null}
+      </View>
+      <Text style={styles.message} selectable>
+        {entry.text}
+      </Text>
+    </View>
+  );
+}
+
+export default function LogsScreen() {
+  // Third arg (getServerSnapshot) is required for web static rendering
+  // (expo.web.output: "static"); getLogs returns a stable, env-agnostic snapshot.
+  const logs = useSyncExternalStore(subscribe, getLogs, getLogs);
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered = useMemo(
+    () => (filter === 'all' ? logs : logs.filter((l) => l.level === filter)),
+    [logs, filter],
+  );
+
+  // The list is inverted (newest at the bottom, auto-pinned, scroll up for
+  // history), so the data is newest-first. This avoids any scrollToEnd loop.
+  const inverted = useMemo(() => filtered.slice().reverse(), [filtered]);
+
+  const handleShare = async () => {
+    if (filtered.length === 0) return;
+    try {
+      await Share.share({ message: formatLogs(filtered) });
+    } catch {
+      // user dismissed share sheet — nothing to do
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Stack.Screen
+        options={{
+          title: 'Logs',
+          // Reached from the Settings tab, so show "Settings" as the back label
+          // instead of the (tabs) group's title ("Plugins").
+          headerBackTitle: 'Settings',
+          headerStyle: { backgroundColor: '#243f5f' },
+          headerTintColor: '#fff',
+          headerTitleStyle: { fontWeight: 'bold' },
+        }}
+      />
+
+      <View style={styles.toolbar}>
+        <View style={styles.filterRow}>
+          {FILTERS.map((f) => {
+            const active = filter === f.key;
+            return (
+              <TouchableOpacity
+                key={f.key}
+                style={[styles.chip, active && styles.chipActive]}
+                onPress={() => setFilter(f.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.chipText, active && styles.chipTextActive]}>{f.label}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+        <View style={styles.actionRow}>
+          <Text style={styles.count}>{filtered.length} entries</Text>
+          <View style={styles.actionButtons}>
+            <TouchableOpacity style={styles.actionButton} onPress={handleShare} activeOpacity={0.7}>
+              <Text style={styles.actionText}>Share</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.actionButton} onPress={clearLogs} activeOpacity={0.7}>
+              <Text style={styles.actionText}>Clear</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+
+      {filtered.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No logs yet.</Text>
+          <Text style={styles.emptyHint}>Run a plugin to capture proving logs here.</Text>
+        </View>
+      ) : (
+        <FlatList
+          inverted
+          data={inverted}
+          keyExtractor={(e) => String(e.id)}
+          renderItem={({ item }) => <LogRow entry={item} />}
+          contentContainerStyle={styles.listContent}
+          initialNumToRender={30}
+          windowSize={11}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f1115',
+  },
+  toolbar: {
+    backgroundColor: '#1b1f27',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#2c313c',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 14,
+    backgroundColor: '#2c313c',
+  },
+  chipActive: {
+    backgroundColor: '#3b82f6',
+  },
+  chipText: {
+    fontSize: 12,
+    color: '#c9ced8',
+    fontWeight: '600',
+  },
+  chipTextActive: {
+    color: '#fff',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: 10,
+  },
+  count: {
+    fontSize: 12,
+    color: '#8a8f98',
+  },
+  actionButtons: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  actionButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: '#2c313c',
+  },
+  actionText: {
+    fontSize: 13,
+    color: '#c9ced8',
+    fontWeight: '600',
+  },
+  listContent: {
+    paddingVertical: 6,
+  },
+  row: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderLeftWidth: 3,
+    marginHorizontal: 8,
+    marginVertical: 2,
+    backgroundColor: '#161a21',
+    borderRadius: 4,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 2,
+  },
+  level: {
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+  },
+  nativeBadge: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#0f1115',
+    backgroundColor: '#a3e635',
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  tag: {
+    fontSize: 11,
+    color: '#9aa3b2',
+    fontFamily: MONO,
+  },
+  message: {
+    fontSize: 12,
+    color: '#e6e9ef',
+    fontFamily: MONO,
+    lineHeight: 16,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#c9ced8',
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  emptyHint: {
+    fontSize: 13,
+    color: '#6b7280',
+    textAlign: 'center',
+  },
+});

--- a/app/mobile/app/logs.tsx
+++ b/app/mobile/app/logs.tsx
@@ -1,75 +1,10 @@
-import React, { useMemo, useState, useSyncExternalStore } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, FlatList, Share, Platform } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
 import { Stack } from 'expo-router';
 
-import {
-  subscribe,
-  getLogs,
-  clearLogs,
-  formatLogs,
-  type LogEntry,
-  type LogLevel,
-} from '@/lib/logStore';
-
-type Filter = 'all' | LogLevel;
-
-const FILTERS: { key: Filter; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'debug', label: 'Debug' },
-  { key: 'info', label: 'Info' },
-  { key: 'warn', label: 'Warn' },
-  { key: 'error', label: 'Error' },
-];
-
-const LEVEL_COLOR: Record<LogLevel, string> = {
-  debug: '#8a8f98',
-  info: '#2563eb',
-  warn: '#b45309',
-  error: '#dc2626',
-};
-
-const MONO = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
-
-function LogRow({ entry }: { entry: LogEntry }) {
-  const color = LEVEL_COLOR[entry.level];
-  return (
-    <View style={[styles.row, { borderLeftColor: color }]}>
-      <View style={styles.rowHeader}>
-        <Text style={[styles.level, { color }]}>{entry.level.toUpperCase()}</Text>
-        {entry.source === 'native' && <Text style={styles.nativeBadge}>native</Text>}
-        {entry.tag ? <Text style={styles.tag}>{entry.tag}</Text> : null}
-      </View>
-      <Text style={styles.message} selectable>
-        {entry.text}
-      </Text>
-    </View>
-  );
-}
+import { LogList } from '@/components/LogList';
 
 export default function LogsScreen() {
-  // Third arg (getServerSnapshot) is required for web static rendering
-  // (expo.web.output: "static"); getLogs returns a stable, env-agnostic snapshot.
-  const logs = useSyncExternalStore(subscribe, getLogs, getLogs);
-  const [filter, setFilter] = useState<Filter>('all');
-
-  const filtered = useMemo(
-    () => (filter === 'all' ? logs : logs.filter((l) => l.level === filter)),
-    [logs, filter],
-  );
-
-  // The list is inverted (newest at the bottom, auto-pinned, scroll up for
-  // history), so the data is newest-first. This avoids any scrollToEnd loop.
-  const inverted = useMemo(() => filtered.slice().reverse(), [filtered]);
-
-  const handleShare = async () => {
-    if (filtered.length === 0) return;
-    try {
-      await Share.share({ message: formatLogs(filtered) });
-    } catch {
-      // user dismissed share sheet — nothing to do
-    }
-  };
-
   return (
     <View style={styles.container}>
       <Stack.Screen
@@ -83,52 +18,7 @@ export default function LogsScreen() {
           headerTitleStyle: { fontWeight: 'bold' },
         }}
       />
-
-      <View style={styles.toolbar}>
-        <View style={styles.filterRow}>
-          {FILTERS.map((f) => {
-            const active = filter === f.key;
-            return (
-              <TouchableOpacity
-                key={f.key}
-                style={[styles.chip, active && styles.chipActive]}
-                onPress={() => setFilter(f.key)}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.chipText, active && styles.chipTextActive]}>{f.label}</Text>
-              </TouchableOpacity>
-            );
-          })}
-        </View>
-        <View style={styles.actionRow}>
-          <Text style={styles.count}>{filtered.length} entries</Text>
-          <View style={styles.actionButtons}>
-            <TouchableOpacity style={styles.actionButton} onPress={handleShare} activeOpacity={0.7}>
-              <Text style={styles.actionText}>Share</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.actionButton} onPress={clearLogs} activeOpacity={0.7}>
-              <Text style={styles.actionText}>Clear</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </View>
-
-      {filtered.length === 0 ? (
-        <View style={styles.empty}>
-          <Text style={styles.emptyText}>No logs yet.</Text>
-          <Text style={styles.emptyHint}>Run a plugin to capture proving logs here.</Text>
-        </View>
-      ) : (
-        <FlatList
-          inverted
-          data={inverted}
-          keyExtractor={(e) => String(e.id)}
-          renderItem={({ item }) => <LogRow entry={item} />}
-          contentContainerStyle={styles.listContent}
-          initialNumToRender={30}
-          windowSize={11}
-        />
-      )}
+      <LogList style={styles.list} />
     </View>
   );
 }
@@ -138,119 +28,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#0f1115',
   },
-  toolbar: {
-    backgroundColor: '#1b1f27',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#2c313c',
-  },
-  filterRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-  },
-  chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 5,
-    borderRadius: 14,
-    backgroundColor: '#2c313c',
-  },
-  chipActive: {
-    backgroundColor: '#3b82f6',
-  },
-  chipText: {
-    fontSize: 12,
-    color: '#c9ced8',
-    fontWeight: '600',
-  },
-  chipTextActive: {
-    color: '#fff',
-  },
-  actionRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: 10,
-  },
-  count: {
-    fontSize: 12,
-    color: '#8a8f98',
-  },
-  actionButtons: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  actionButton: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 8,
-    backgroundColor: '#2c313c',
-  },
-  actionText: {
-    fontSize: 13,
-    color: '#c9ced8',
-    fontWeight: '600',
-  },
-  listContent: {
-    paddingVertical: 6,
-  },
-  row: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderLeftWidth: 3,
-    marginHorizontal: 8,
-    marginVertical: 2,
-    backgroundColor: '#161a21',
-    borderRadius: 4,
-  },
-  rowHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 2,
-  },
-  level: {
-    fontSize: 10,
-    fontWeight: '800',
-    letterSpacing: 0.5,
-  },
-  nativeBadge: {
-    fontSize: 9,
-    fontWeight: '700',
-    color: '#0f1115',
-    backgroundColor: '#a3e635',
-    paddingHorizontal: 5,
-    paddingVertical: 1,
-    borderRadius: 4,
-    overflow: 'hidden',
-  },
-  tag: {
-    fontSize: 11,
-    color: '#9aa3b2',
-    fontFamily: MONO,
-  },
-  message: {
-    fontSize: 12,
-    color: '#e6e9ef',
-    fontFamily: MONO,
-    lineHeight: 16,
-  },
-  empty: {
+  list: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24,
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#c9ced8',
-    fontWeight: '600',
-    marginBottom: 6,
-  },
-  emptyHint: {
-    fontSize: 13,
-    color: '#6b7280',
-    textAlign: 'center',
   },
 });

--- a/app/mobile/app/plugin/[id].tsx
+++ b/app/mobile/app/plugin/[id].tsx
@@ -1,9 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet, Alert, ScrollView, TouchableOpacity } from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import { PluginScreen } from '@/components/tlsn/PluginScreen';
+import { LogDrawer } from '@/components/LogDrawer';
 import { getPluginById } from '../../assets/plugins/registry';
-import { useVerifierUrl, useProxyMode } from '@/lib/useVerifierUrl';
+import { useVerifierUrl, useProxyMode, getDebugEnabled } from '@/lib/useVerifierUrl';
 
 /**
  * Extract all handler result values from the proof result string.
@@ -68,6 +70,12 @@ export default function PluginRunnerScreen() {
   const [result, setResult] = useState<string | null>(null);
   const [provenExpanded, setProvenExpanded] = useState(false);
   const [rawExpanded, setRawExpanded] = useState(false);
+  const [debugEnabled, setDebugEnabled] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(false);
+
+  useEffect(() => {
+    getDebugEnabled().then(setDebugEnabled);
+  }, []);
 
   const results = useMemo(() => (result ? parseResults(result) : []), [result]);
   const keyValue = results.length > 0 ? results[results.length - 1].value : null;
@@ -93,6 +101,18 @@ export default function PluginRunnerScreen() {
           headerStyle: { backgroundColor: '#243f5f' },
           headerTintColor: '#fff',
           headerTitleStyle: { fontWeight: 'bold' },
+          // When Debug is enabled (Settings), expose a live log drawer toggle.
+          headerRight: debugEnabled
+            ? () => (
+                <TouchableOpacity
+                  onPress={() => setLogsOpen((v) => !v)}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  activeOpacity={0.7}
+                >
+                  <FontAwesome name="terminal" size={20} color="#fff" />
+                </TouchableOpacity>
+              )
+            : undefined,
         }}
       />
       {result ? (
@@ -188,6 +208,8 @@ export default function PluginRunnerScreen() {
           }}
         />
       )}
+
+      <LogDrawer visible={logsOpen} onClose={() => setLogsOpen(false)} />
     </View>
   );
 }

--- a/app/mobile/components/LogDrawer.tsx
+++ b/app/mobile/components/LogDrawer.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Animated,
+  PanResponder,
+  Dimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { LogList } from '@/components/LogList';
+
+const SCREEN_H = Dimensions.get('window').height;
+const MIN_H = 200;
+const MAX_H = Math.round(SCREEN_H * 0.8);
+const DEFAULT_H = Math.round(SCREEN_H * 0.42);
+
+const clamp = (h: number) => Math.min(MAX_H, Math.max(MIN_H, h));
+
+/**
+ * A resizable bottom-sheet log drawer that floats over the current screen
+ * (it does not resize the underlying content — important on the proof screen,
+ * whose WebView shouldn't reflow mid-proof). Drag the grab handle to resize.
+ */
+export function LogDrawer({ visible, onClose }: { visible: boolean; onClose: () => void }) {
+  const insets = useSafeAreaInsets();
+  // `committed` is the height between drags (updated on release); `height` is the
+  // live Animated value driven during a drag (so dragging doesn't re-render).
+  const [committed, setCommitted] = useState(DEFAULT_H);
+  const height = useMemo(() => new Animated.Value(DEFAULT_H), []);
+
+  // Only the grab handle drives resize, so the list inside still scrolls freely.
+  const pan = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 2,
+        onPanResponderMove: (_, g) => height.setValue(clamp(committed - g.dy)),
+        // Commit on both release and terminate so committed/height never desync
+        // (a terminated drag would otherwise leave them mismatched → next-drag jump).
+        onPanResponderRelease: (_, g) => setCommitted(clamp(committed - g.dy)),
+        onPanResponderTerminate: (_, g) => setCommitted(clamp(committed - g.dy)),
+      }),
+    [committed, height],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.drawer, { height }]}>
+      <View style={styles.handleArea} {...pan.panHandlers}>
+        <View style={styles.grabber} />
+      </View>
+      <View style={styles.header}>
+        <Text style={styles.title}>Logs</Text>
+        <TouchableOpacity
+          onPress={onClose}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.close}>Close</Text>
+        </TouchableOpacity>
+      </View>
+      <LogList style={styles.list} />
+      {insets.bottom > 0 ? (
+        <View style={{ height: insets.bottom, backgroundColor: '#0f1115' }} />
+      ) : null}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  drawer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#0f1115',
+    borderTopLeftRadius: 14,
+    borderTopRightRadius: 14,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 12,
+  },
+  handleArea: {
+    paddingVertical: 8,
+    alignItems: 'center',
+    backgroundColor: '#1b1f27',
+  },
+  grabber: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#4b5563',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+    backgroundColor: '#1b1f27',
+  },
+  title: {
+    color: '#e6e9ef',
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  close: {
+    color: '#3b82f6',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  list: {
+    flex: 1,
+  },
+});

--- a/app/mobile/components/LogList.tsx
+++ b/app/mobile/components/LogList.tsx
@@ -1,0 +1,262 @@
+import React, { useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  FlatList,
+  ScrollView,
+  Share,
+  Platform,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+
+import {
+  subscribe,
+  getLogs,
+  clearLogs,
+  formatLogs,
+  type LogEntry,
+  type LogLevel,
+} from '@/lib/logStore';
+
+type Filter = 'all' | LogLevel;
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'debug', label: 'Debug' },
+  { key: 'info', label: 'Info' },
+  { key: 'warn', label: 'Warn' },
+  { key: 'error', label: 'Error' },
+];
+
+const LEVEL_COLOR: Record<LogLevel, string> = {
+  debug: '#8a8f98',
+  info: '#2563eb',
+  warn: '#b45309',
+  error: '#dc2626',
+};
+
+const MONO = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
+
+function LogRow({ entry }: { entry: LogEntry }) {
+  const color = LEVEL_COLOR[entry.level];
+  return (
+    <View style={[styles.row, { borderLeftColor: color }]}>
+      <View style={styles.rowHeader}>
+        <Text style={[styles.level, { color }]}>{entry.level.toUpperCase()}</Text>
+        {entry.source === 'native' && <Text style={styles.nativeBadge}>native</Text>}
+        {entry.tag ? <Text style={styles.tag}>{entry.tag}</Text> : null}
+      </View>
+      <Text style={styles.message} selectable>
+        {entry.text}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Reusable log viewer backed by `logStore`: level-filter chips, Share, Clear,
+ * and an inverted (newest-at-bottom) list. Used by both the full Logs screen
+ * and the in-proof log drawer.
+ */
+export function LogList({ style }: { style?: StyleProp<ViewStyle> }) {
+  // Third arg (getServerSnapshot) is required for web static rendering
+  // (expo.web.output: "static"); getLogs returns a stable, env-agnostic snapshot.
+  const logs = useSyncExternalStore(subscribe, getLogs, getLogs);
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered = useMemo(
+    () => (filter === 'all' ? logs : logs.filter((l) => l.level === filter)),
+    [logs, filter],
+  );
+
+  // Inverted list (newest at the bottom, auto-pinned, scroll up for history), so
+  // the data is newest-first. This avoids any scrollToEnd loop.
+  const inverted = useMemo(() => filtered.slice().reverse(), [filtered]);
+
+  const handleShare = async () => {
+    if (filtered.length === 0) return;
+    try {
+      await Share.share({ message: formatLogs(filtered) });
+    } catch {
+      // user dismissed share sheet — nothing to do
+    }
+  };
+
+  return (
+    <View style={[styles.container, style]}>
+      <View style={styles.toolbar}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.filterScroll}
+          contentContainerStyle={styles.filterRow}
+        >
+          {FILTERS.map((f) => {
+            const active = filter === f.key;
+            return (
+              <TouchableOpacity
+                key={f.key}
+                style={[styles.chip, active && styles.chipActive]}
+                onPress={() => setFilter(f.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.chipText, active && styles.chipTextActive]}>{f.label}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+        <View style={styles.actionButtons}>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={handleShare}
+            activeOpacity={0.7}
+            accessibilityLabel="Share logs"
+          >
+            <FontAwesome name="share-square-o" size={18} color="#c9ced8" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={clearLogs}
+            activeOpacity={0.7}
+            accessibilityLabel="Clear logs"
+          >
+            <FontAwesome name="trash-o" size={18} color="#c9ced8" />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {filtered.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No logs yet.</Text>
+          <Text style={styles.emptyHint}>Run a plugin to capture proving logs here.</Text>
+        </View>
+      ) : (
+        <FlatList
+          inverted
+          data={inverted}
+          keyExtractor={(e) => String(e.id)}
+          renderItem={({ item }) => <LogRow entry={item} />}
+          contentContainerStyle={styles.listContent}
+          initialNumToRender={30}
+          windowSize={11}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f1115',
+  },
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#1b1f27',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#2c313c',
+  },
+  filterScroll: {
+    flex: 1,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingRight: 8,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 14,
+    backgroundColor: '#2c313c',
+  },
+  chipActive: {
+    backgroundColor: '#3b82f6',
+  },
+  chipText: {
+    fontSize: 12,
+    color: '#c9ced8',
+    fontWeight: '600',
+  },
+  chipTextActive: {
+    color: '#fff',
+  },
+  actionButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingLeft: 4,
+  },
+  iconButton: {
+    padding: 6,
+  },
+  listContent: {
+    paddingVertical: 6,
+  },
+  row: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderLeftWidth: 3,
+    marginHorizontal: 8,
+    marginVertical: 2,
+    backgroundColor: '#161a21',
+    borderRadius: 4,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 2,
+  },
+  level: {
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+  },
+  nativeBadge: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#0f1115',
+    backgroundColor: '#a3e635',
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  tag: {
+    fontSize: 11,
+    color: '#9aa3b2',
+    fontFamily: MONO,
+  },
+  message: {
+    fontSize: 12,
+    color: '#e6e9ef',
+    fontFamily: MONO,
+    lineHeight: 16,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#c9ced8',
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  emptyHint: {
+    fontSize: 13,
+    color: '#6b7280',
+    textAlign: 'center',
+  },
+});

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -19,9 +19,13 @@ import type {
   ProverOptions,
   ProveResult,
   ProveProgress,
+  NativeLogLine,
+  TlsnLogLevel,
   RevealPreparation,
   RevealRangeDescriptor,
 } from '../../modules/tlsn-native/src';
+import { addLog, type LogLevel } from '@/lib/logStore';
+import { getLogLevel } from '@/lib/useVerifierUrl';
 
 export type {
   HandlerType,
@@ -71,6 +75,21 @@ interface NativeProverProps {
   onProgress?: (progress: ProveProgress) => void;
 }
 
+/** Map a Rust `tracing` level string to the in-app console's log level. */
+function mapNativeLevel(level: string): LogLevel {
+  switch (level.toUpperCase()) {
+    case 'ERROR':
+      return 'error';
+    case 'WARN':
+      return 'warn';
+    case 'DEBUG':
+    case 'TRACE':
+      return 'debug';
+    default:
+      return 'info';
+  }
+}
+
 // Lazy load the native module to avoid errors during metro bundling
 let TlsnNative: {
   initialize: () => void;
@@ -79,6 +98,8 @@ let TlsnNative: {
   proveFinalize: (sessionId: string, approved: boolean) => Promise<ProveResult>;
   isAvailable: () => boolean;
   addProgressListener: (callback: (event: ProveProgress) => void) => { remove: () => void };
+  drainNativeLogs: () => NativeLogLine[];
+  setLogLevel: (level: TlsnLogLevel) => void;
 } | null = null;
 
 function getNativeModule() {
@@ -128,6 +149,12 @@ function NativeProverComponent(
         console.log('[NativeProver] Native module initialized successfully');
         setIsReady(true);
         onReady?.();
+
+        // Apply the persisted native log level so the Logs screen shows the
+        // verbosity the user selected in Settings.
+        getLogLevel()
+          .then((level) => module.setLogLevel(level))
+          .catch(() => {});
       } catch (e) {
         console.error('[NativeProver] Failed to initialize:', e);
         onError?.(e instanceof Error ? e.message : 'Failed to initialize native module');
@@ -137,19 +164,50 @@ function NativeProverComponent(
     initializeModule();
   }, [onReady, onError]);
 
-  // Subscribe to native progress events
+  // Subscribe to native progress events.
   useEffect(() => {
     const module = getNativeModule();
     if (!module) return;
 
-    const subscription = module.addProgressListener((event: ProveProgress) => {
+    const progressSub = module.addProgressListener((event: ProveProgress) => {
       console.log(
         `[NativeProver] Progress: ${event.step} ${Math.round(event.progress * 100)}% - ${event.message}`,
       );
       onProgressRef.current?.(event);
     });
 
-    return () => subscription.remove();
+    return () => progressSub.remove();
+  }, []);
+
+  // Poll the native log buffer into the in-app Logs screen. These lines carry
+  // the actual MPC/TLS failure detail that progress events can't convey. Pulling
+  // (vs a push callback) keeps the prover's worker threads off the JS bridge.
+  useEffect(() => {
+    const module = getNativeModule();
+    if (!module) return;
+
+    const drain = () => {
+      let lines: NativeLogLine[] = [];
+      try {
+        lines = module.drainNativeLogs();
+      } catch {
+        return;
+      }
+      for (const line of lines) {
+        addLog({
+          source: 'native',
+          level: mapNativeLevel(line.level),
+          tag: line.target,
+          text: line.message,
+        });
+      }
+    };
+
+    const id = setInterval(drain, 400);
+    return () => {
+      clearInterval(id);
+      drain(); // final flush of anything buffered since the last tick
+    };
   }, []);
 
   const buildRequestAndOptions = useCallback((params: NativeProveParams) => {

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -25,7 +25,7 @@ import type {
   RevealRangeDescriptor,
 } from '../../modules/tlsn-native/src';
 import { addLog, type LogLevel } from '@/lib/logStore';
-import { getLogLevel } from '@/lib/useVerifierUrl';
+import { getEffectiveLogLevel } from '@/lib/useVerifierUrl';
 
 export type {
   HandlerType,
@@ -150,9 +150,9 @@ function NativeProverComponent(
         setIsReady(true);
         onReady?.();
 
-        // Apply the persisted native log level so the Logs screen shows the
-        // verbosity the user selected in Settings.
-        getLogLevel()
+        // Apply the effective native log level (the selected verbosity only when
+        // Debug is enabled in Settings, otherwise the quiet default).
+        getEffectiveLogLevel()
           .then((level) => module.setLogLevel(level))
           .catch(() => {});
       } catch (e) {

--- a/app/mobile/lib/installLogCapture.ts
+++ b/app/mobile/lib/installLogCapture.ts
@@ -1,0 +1,67 @@
+/**
+ * installLogCapture
+ *
+ * Patches the global `console.*` methods so every log the app (or any library,
+ * including the `@tlsn/common` logger which writes through `console.*`) emits
+ * is also teed into `logStore` for the in-app Logs screen. The original
+ * console methods are always called too, so Metro / Xcode / logcat output is
+ * unchanged.
+ *
+ * Call once, as early as possible (top of the root layout module).
+ */
+import { addLog, type LogLevel } from './logStore';
+
+let installed = false;
+
+/** Pull a leading `[Tag]` off the first string arg, returning [tag, rest]. */
+function extractTag(first: unknown): [string | undefined, string | undefined] {
+  if (typeof first !== 'string') return [undefined, undefined];
+  const match = first.match(/^\s*\[([^\]]+)\]\s*(.*)$/s);
+  if (!match) return [undefined, first];
+  return [match[1], match[2]];
+}
+
+/** Stringify a single console argument for display. */
+function stringifyArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+  if (arg === undefined) return 'undefined';
+  if (arg === null) return 'null';
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function formatArgs(args: unknown[]): { tag?: string; text: string } {
+  if (args.length === 0) return { text: '' };
+  const [tag, rest] = extractTag(args[0]);
+  const head = rest !== undefined ? rest : stringifyArg(args[0]);
+  const tail = args.slice(1).map(stringifyArg);
+  const parts = head ? [head, ...tail] : tail;
+  return { tag, text: parts.join(' ') };
+}
+
+export function installLogCapture(): void {
+  if (installed) return;
+  installed = true;
+
+  const wrap =
+    (level: LogLevel, original: (...args: unknown[]) => void) =>
+    (...args: unknown[]) => {
+      try {
+        const { tag, text } = formatArgs(args);
+        addLog({ source: 'js', level, tag, text });
+      } catch {
+        // Never let log capture break the app or swallow the real log.
+      }
+      original(...args);
+    };
+
+  console.log = wrap('info', console.log.bind(console));
+  console.info = wrap('info', console.info.bind(console));
+  console.warn = wrap('warn', console.warn.bind(console));
+  console.error = wrap('error', console.error.bind(console));
+  console.debug = wrap('debug', console.debug.bind(console));
+}

--- a/app/mobile/lib/logStore.ts
+++ b/app/mobile/lib/logStore.ts
@@ -1,0 +1,122 @@
+/**
+ * logStore
+ *
+ * In-memory ring buffer of log entries that backs the in-app Logs screen.
+ * Everything that should be visible to a user debugging a failed prove writes
+ * here: patched `console.*` calls (see `installLogCapture`) and native Rust
+ * `tracing` lines drained from the native buffer (see `NativeProver`).
+ *
+ * The store is a module singleton so logs survive screen navigation — the
+ * Logs screen mounts/unmounts but the buffer persists. It exposes a
+ * `useSyncExternalStore`-compatible (`subscribe` + `getSnapshot`) API.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+export type LogSource = 'js' | 'native';
+
+export interface LogEntry {
+  /** Monotonically increasing id, stable list key. */
+  id: number;
+  /** Epoch ms when the entry was recorded. */
+  ts: number;
+  level: LogLevel;
+  /** Origin: JS (patched console) or native Rust (tracing bridge). */
+  source: LogSource;
+  /** Optional tag, e.g. `NativeProver` parsed from a `[NativeProver]` prefix,
+   *  or the Rust tracing target for native logs. */
+  tag?: string;
+  text: string;
+}
+
+/** Keep the buffer bounded so a long-running session can't exhaust memory. */
+export const MAX_ENTRIES = 1000;
+
+let entries: LogEntry[] = [];
+let snapshot: readonly LogEntry[] = entries;
+let nextId = 1;
+
+const listeners = new Set<() => void>();
+
+function emitToListeners(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+let notifyScheduled = false;
+
+/**
+ * Coalesce notifications: a burst of `addLog` calls — draining many native
+ * lines in one tick, or a console-warning storm — schedules a single re-render
+ * on the next tick instead of one per entry. This bounds render frequency and
+ * breaks any render→console→capture→render feedback loop.
+ */
+function scheduleNotify(): void {
+  if (notifyScheduled) return;
+  notifyScheduled = true;
+  setTimeout(() => {
+    notifyScheduled = false;
+    emitToListeners();
+  }, 0);
+}
+
+/** Append a log entry, dropping the oldest once the buffer is full. */
+export function addLog(entry: Omit<LogEntry, 'id' | 'ts'> & { ts?: number }): void {
+  const next: LogEntry = {
+    id: nextId++,
+    ts: entry.ts ?? Date.now(),
+    level: entry.level,
+    source: entry.source,
+    tag: entry.tag,
+    text: entry.text,
+  };
+  // New array reference (not in-place mutation) so the snapshot identity changes.
+  entries = entries.length >= MAX_ENTRIES ? [...entries.slice(1), next] : [...entries, next];
+  snapshot = entries; // keep getSnapshot current immediately; re-render is coalesced
+  scheduleNotify();
+}
+
+/** Remove all entries (immediate). */
+export function clearLogs(): void {
+  entries = [];
+  snapshot = entries;
+  emitToListeners();
+}
+
+/** Current immutable snapshot — safe to use as a `useSyncExternalStore` getSnapshot. */
+export function getLogs(): readonly LogEntry[] {
+  return snapshot;
+}
+
+/** Subscribe to changes; returns an unsubscribe fn. */
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const LEVEL_LABEL: Record<LogLevel, string> = {
+  debug: 'DEBUG',
+  info: 'INFO',
+  warn: 'WARN',
+  error: 'ERROR',
+};
+
+function formatTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** Render one entry as a single log line. */
+export function formatEntry(e: LogEntry): string {
+  const tag = e.tag ? ` [${e.tag}]` : '';
+  const src = e.source === 'native' ? ' [native]' : '';
+  return `[${formatTimestamp(e.ts)}] [${LEVEL_LABEL[e.level]}]${src}${tag} ${e.text}`;
+}
+
+/** Render the given entries as plain text, for Copy / Share. */
+export function formatLogs(list: readonly LogEntry[]): string {
+  return list.map(formatEntry).join('\n');
+}

--- a/app/mobile/lib/useVerifierUrl.ts
+++ b/app/mobile/lib/useVerifierUrl.ts
@@ -5,15 +5,23 @@ import type { TlsnLogLevel } from '../modules/tlsn-native/src';
 const configFile = new File(Paths.document, 'verifier-config.json');
 const DEFAULT_VERIFIER_URL = 'https://demo.tlsnotary.org';
 const DEFAULT_PROXY_MODE = false;
+const DEFAULT_DEBUG_ENABLED = false;
 const DEFAULT_LOG_LEVEL: TlsnLogLevel = 'info';
 const LOG_LEVELS: TlsnLogLevel[] = ['info', 'debug', 'trace'];
 
-export { DEFAULT_VERIFIER_URL, DEFAULT_PROXY_MODE, DEFAULT_LOG_LEVEL, LOG_LEVELS };
+export {
+  DEFAULT_VERIFIER_URL,
+  DEFAULT_PROXY_MODE,
+  DEFAULT_DEBUG_ENABLED,
+  DEFAULT_LOG_LEVEL,
+  LOG_LEVELS,
+};
 export type { TlsnLogLevel };
 
 interface Config {
   verifierUrl?: string;
   proxyMode?: boolean;
+  debugEnabled?: boolean;
   logLevel?: TlsnLogLevel;
 }
 
@@ -64,6 +72,16 @@ export async function setProxyMode(value: boolean): Promise<void> {
   await patchConfig({ proxyMode: value });
 }
 
+export async function getDebugEnabled(): Promise<boolean> {
+  const config = await loadConfig();
+  return config.debugEnabled ?? DEFAULT_DEBUG_ENABLED;
+}
+
+export async function setDebugEnabled(value: boolean): Promise<void> {
+  console.log('[useVerifierUrl] setDebugEnabled called with:', value);
+  await patchConfig({ debugEnabled: value });
+}
+
 export async function getLogLevel(): Promise<TlsnLogLevel> {
   const config = await loadConfig();
   return config.logLevel ?? DEFAULT_LOG_LEVEL;
@@ -72,6 +90,16 @@ export async function getLogLevel(): Promise<TlsnLogLevel> {
 export async function setLogLevelPref(level: TlsnLogLevel): Promise<void> {
   console.log('[useVerifierUrl] setLogLevelPref called with:', level);
   await patchConfig({ logLevel: level });
+}
+
+/**
+ * The native log level to actually apply: only honour the chosen verbosity when
+ * Debug is enabled, otherwise stay at the quiet default.
+ */
+export async function getEffectiveLogLevel(): Promise<TlsnLogLevel> {
+  const config = await loadConfig();
+  if (!(config.debugEnabled ?? DEFAULT_DEBUG_ENABLED)) return DEFAULT_LOG_LEVEL;
+  return config.logLevel ?? DEFAULT_LOG_LEVEL;
 }
 
 export function useVerifierUrl(): { url: string; loading: boolean } {

--- a/app/mobile/lib/useVerifierUrl.ts
+++ b/app/mobile/lib/useVerifierUrl.ts
@@ -1,15 +1,20 @@
 import { useState, useEffect } from 'react';
 import { File, Paths } from 'expo-file-system/next';
+import type { TlsnLogLevel } from '../modules/tlsn-native/src';
 
 const configFile = new File(Paths.document, 'verifier-config.json');
 const DEFAULT_VERIFIER_URL = 'https://demo.tlsnotary.org';
 const DEFAULT_PROXY_MODE = false;
+const DEFAULT_LOG_LEVEL: TlsnLogLevel = 'info';
+const LOG_LEVELS: TlsnLogLevel[] = ['info', 'debug', 'trace'];
 
-export { DEFAULT_VERIFIER_URL, DEFAULT_PROXY_MODE };
+export { DEFAULT_VERIFIER_URL, DEFAULT_PROXY_MODE, DEFAULT_LOG_LEVEL, LOG_LEVELS };
+export type { TlsnLogLevel };
 
 interface Config {
   verifierUrl?: string;
   proxyMode?: boolean;
+  logLevel?: TlsnLogLevel;
 }
 
 async function loadConfig(): Promise<Config> {
@@ -57,6 +62,16 @@ export async function getProxyMode(): Promise<boolean> {
 export async function setProxyMode(value: boolean): Promise<void> {
   console.log('[useVerifierUrl] setProxyMode called with:', value);
   await patchConfig({ proxyMode: value });
+}
+
+export async function getLogLevel(): Promise<TlsnLogLevel> {
+  const config = await loadConfig();
+  return config.logLevel ?? DEFAULT_LOG_LEVEL;
+}
+
+export async function setLogLevelPref(level: TlsnLogLevel): Promise<void> {
+  console.log('[useVerifierUrl] setLogLevelPref called with:', level);
+  await patchConfig({ logLevel: level });
 }
 
 export function useVerifierUrl(): { url: string; loading: boolean } {

--- a/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
+++ b/app/mobile/modules/tlsn-native/android/src/main/java/expo/modules/tlsnnative/TlsnNativeModule.kt
@@ -17,6 +17,8 @@ import uniffi.tlsn_mobile.ProgressCallback
 import uniffi.tlsn_mobile.ProofResult
 import uniffi.tlsn_mobile.RevealPreparation
 import uniffi.tlsn_mobile.initialize as rustInitialize
+import uniffi.tlsn_mobile.drainLogs as rustDrainLogs
+import uniffi.tlsn_mobile.setLogLevel as rustSetLogLevel
 import uniffi.tlsn_mobile.prove as rustProve
 import uniffi.tlsn_mobile.proveUntilReveal as rustProveUntilReveal
 import uniffi.tlsn_mobile.proveFinalize as rustProveFinalize
@@ -228,6 +230,19 @@ class TlsnNativeModule : Module() {
 
         Function("initialize") {
             rustInitialize()
+        }
+
+        // Drain buffered native tracing lines for the in-app Logs screen. The JS
+        // side polls this; pulling keeps the prover's threads off the bridge.
+        Function("drainNativeLogs") {
+            rustDrainLogs().map {
+                mapOf("level" to it.level, "target" to it.target, "message" to it.message)
+            }
+        }
+
+        // Set native (tlsn) log verbosity at runtime, e.g. "tlsn_mobile=debug,tlsn=debug".
+        Function("setLogLevel") { filter: String ->
+            rustSetLogLevel(filter)
         }
 
         // Accept JSON strings to avoid Expo Kotlin bridge type conversion issues

--- a/app/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
+++ b/app/mobile/modules/tlsn-native/ios/TlsnNativeModule.swift
@@ -229,6 +229,19 @@ public class TlsnNativeModule: Module {
             }
         }
 
+        // Drain buffered native tracing lines for the in-app Logs screen. The JS
+        // side polls this; pulling keeps the prover's threads off the bridge.
+        Function("drainNativeLogs") { () -> [[String: String]] in
+            drainLogs().map { line in
+                ["level": line.level, "target": line.target, "message": line.message]
+            }
+        }
+
+        // Set native (tlsn) log verbosity at runtime, e.g. "tlsn_mobile=debug,tlsn=debug".
+        Function("setLogLevel") { (filter: String) in
+            setLogLevel(filter: filter)
+        }
+
         // Legacy one-shot prove. Kept for backward compat.
         AsyncFunction("prove") { (requestDict: [String: Any], optionsDict: [String: Any], promise: Promise) in
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in

--- a/app/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
+++ b/app/mobile/modules/tlsn-native/src/TlsnNativeModule.ts
@@ -21,6 +21,10 @@ interface TlsnNativeModuleInterface {
    * (`approved=false`).
    */
   proveFinalize(sessionId: string, approved: boolean): Promise<Record<string, unknown>>;
+  /** Drain buffered native log lines (oldest first), clearing the native buffer. */
+  drainNativeLogs(): { level: string; target: string; message: string }[];
+  /** Set native (tlsn) log verbosity at runtime; `filter` is an EnvFilter directive string. */
+  setLogLevel(filter: string): void;
   isAvailable(): boolean;
   addListener(eventName: string): void;
   removeListeners(count: number): void;

--- a/app/mobile/modules/tlsn-native/src/index.ts
+++ b/app/mobile/modules/tlsn-native/src/index.ts
@@ -61,6 +61,18 @@ export interface ProveProgress {
 }
 
 /**
+ * A single log line from the native Rust prover's `tracing` output, retrieved
+ * by draining the native buffer via `drainNativeLogs`.
+ */
+export interface NativeLogLine {
+  /** Tracing level: "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE". */
+  level: string;
+  /** Tracing target, e.g. "tlsn_mobile::prover". */
+  target: string;
+  message: string;
+}
+
+/**
  * Per-range preview returned by `proveUntilReveal`. Each entry describes one
  * byte range that the prover is about to reveal (or hash-commit) to the
  * verifier, with the actual transcript bytes as `preview` for user review.
@@ -182,8 +194,33 @@ export function addProgressListener(callback: (event: ProveProgress) => void): S
 }
 
 /**
+ * Drain buffered native log lines from the Rust prover's `tracing` output,
+ * oldest first, clearing the native buffer. Poll this (e.g. on an interval) to
+ * stream native logs into the in-app Logs screen.
+ */
+export function drainNativeLogs(): NativeLogLine[] {
+  return TlsnNativeModule.drainNativeLogs() as NativeLogLine[];
+}
+
+/**
  * Check if the native TLSN module is available.
  */
 export function isAvailable(): boolean {
   return TlsnNativeModule.isAvailable();
+}
+
+/** User-facing native log verbosity levels. */
+export type TlsnLogLevel = 'info' | 'debug' | 'trace';
+
+/** Build the tracing EnvFilter directive string for a level. */
+export function logLevelDirectives(level: TlsnLogLevel): string {
+  return `tlsn_mobile=${level},tlsn=${level}`;
+}
+
+/**
+ * Set native (tlsn) log verbosity at runtime. Takes effect on the next emitted
+ * log line; a no-op until the native module's `initialize` has run.
+ */
+export function setLogLevel(level: TlsnLogLevel): void {
+  TlsnNativeModule.setLogLevel(logLevelDirectives(level));
 }

--- a/packages/tlsn-mobile/src/lib.rs
+++ b/packages/tlsn-mobile/src/lib.rs
@@ -7,7 +7,8 @@
 mod prover;
 mod ws_io;
 
-use std::sync::OnceLock;
+use std::collections::VecDeque;
+use std::sync::{Mutex, OnceLock};
 
 uniffi::setup_scaffolding!();
 
@@ -328,15 +329,158 @@ pub trait ProgressCallback: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Log buffer (native `tracing` → platform, pull/drain model)
+// ---------------------------------------------------------------------------
+
+/// One buffered native log line, drained by the platform via [`drain_logs`].
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct NativeLogLine {
+    /// Tracing level: "ERROR" | "WARN" | "INFO" | "DEBUG" | "TRACE".
+    pub level: String,
+    /// Tracing target, e.g. "tlsn_mobile::prover".
+    pub target: String,
+    pub message: String,
+}
+
+/// Max lines retained between drains; oldest are dropped once full. Bounds memory
+/// and bridge work when verbose levels (debug/trace) get chatty.
+const LOG_BUFFER_CAPACITY: usize = 1000;
+
+/// Process-wide ring buffer: the tracing layer pushes; the platform drains.
+static LOG_BUFFER: Mutex<VecDeque<NativeLogLine>> = Mutex::new(VecDeque::new());
+
+/// Default tracing directives applied at [`initialize`]; can be overridden at
+/// runtime via [`set_log_level`].
+const DEFAULT_LOG_FILTER: &str = "tlsn_mobile=info,tlsn=info";
+
+/// Type-erased reloader for the env filter, installed by [`initialize`]. Erasing
+/// the type avoids naming the (large) layered-subscriber type in a `static`.
+#[allow(clippy::type_complexity)]
+static RELOAD_FN: OnceLock<Box<dyn Fn(&str) + Send + Sync>> = OnceLock::new();
+
+/// Drain all buffered native log lines (oldest first), clearing the buffer.
+///
+/// The platform polls this and forwards the lines into its in-app Logs screen.
+/// Pulling (rather than a push callback) keeps the prover's worker threads off
+/// the FFI/JS bridge and batches delivery under verbose logging.
+#[uniffi::export]
+pub fn drain_logs() -> Vec<NativeLogLine> {
+    match LOG_BUFFER.lock() {
+        Ok(mut buf) => buf.drain(..).collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Change native log verbosity at runtime. `filter` is a tracing EnvFilter
+/// directive string, e.g. "tlsn_mobile=debug,tlsn=debug". Invalid directives are
+/// ignored; a no-op if called before [`initialize`].
+#[uniffi::export]
+pub fn set_log_level(filter: String) {
+    if let Some(reload) = RELOAD_FN.get() {
+        reload(&filter);
+    }
+}
+
+/// Visitor that flattens a tracing event's `message` and structured fields into
+/// a single display string.
+#[derive(Default)]
+struct MessageVisitor {
+    message: String,
+    fields: String,
+}
+
+impl MessageVisitor {
+    fn into_text(self) -> String {
+        match (self.message.is_empty(), self.fields.is_empty()) {
+            (false, false) => format!("{} {}", self.message, self.fields),
+            (true, false) => self.fields,
+            _ => self.message,
+        }
+    }
+
+    fn push(&mut self, name: &str, value: String) {
+        if name == "message" {
+            self.message = value;
+        } else {
+            if !self.fields.is_empty() {
+                self.fields.push(' ');
+            }
+            self.fields.push_str(&format!("{name}={value}"));
+        }
+    }
+}
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.push(field.name(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.push(field.name(), format!("{value:?}"));
+    }
+}
+
+/// A `tracing` layer that appends every (already env-filtered) event to the
+/// bounded [`LOG_BUFFER`]. Cheap and non-blocking — no FFI on the hot path.
+struct BufferLayer;
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for BufferLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let meta = event.metadata();
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        let line = NativeLogLine {
+            level: meta.level().to_string(),
+            target: meta.target().to_string(),
+            message: visitor.into_text(),
+        };
+
+        if let Ok(mut buf) = LOG_BUFFER.lock() {
+            if buf.len() >= LOG_BUFFER_CAPACITY {
+                buf.pop_front();
+            }
+            buf.push_back(line);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /// Initialize the TLSN library. Call this once at app startup.
 #[uniffi::export]
 pub fn initialize() -> Result<(), TlsnError> {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter("tlsn_mobile=info,tlsn=info")
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    // Wrap the env filter in a reload layer so `set_log_level` can change tlsn
+    // verbosity at runtime (e.g. from the app's Settings) without a restart.
+    let (filter, reload_handle) = tracing_subscriber::reload::Layer::new(
+        tracing_subscriber::EnvFilter::new(DEFAULT_LOG_FILTER),
+    );
+
+    // Layered subscriber:
+    //   - reloadable EnvFilter limits noise to tlsn targets (global, all layers)
+    //   - fmt layer keeps stdout output (Xcode console / logcat) as before
+    //   - BufferLayer appends lines to LOG_BUFFER for the platform to drain
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(BufferLayer)
         .try_init();
+
+    // Type-erase the reload handle for `set_log_level`. `set` only succeeds once,
+    // keeping the handle bound to the live subscriber from the first init.
+    let _ = RELOAD_FN.set(Box::new(move |directives: &str| {
+        if let Ok(new_filter) = tracing_subscriber::EnvFilter::try_new(directives) {
+            let _ = reload_handle.reload(new_filter);
+        }
+    }));
 
     tracing::info!("TLSNotary Mobile initialized (sdk-core)");
     Ok(())


### PR DESCRIPTION
## Why

Some users report MPC proving not working, but there's no way to see *why* from the device — the detail lives in the native Rust prover's logs, which only go to Xcode/logcat. This adds an in-app **Logs** screen so a user hitting a failure can see the actual MPC/TLS log lines and **Share** them in a bug report.

## What

- **Logs screen** (`app/logs.tsx`), reachable from **Settings → Logs**. Level filters, Share, Clear. Inverted list (newest at the bottom, scroll up for history).
- **JS log capture** — `lib/installLogCapture.ts` tees `console.*` into a bounded in-memory ring buffer (`lib/logStore.ts`, 1000 entries, coalesced notifications).
- **Native log bridge** — a `tracing` layer appends the Rust prover's lines to a bounded in-Rust buffer (`packages/tlsn-mobile`); the app drains it via `drain_logs` / `drainNativeLogs` and merges them into the Logs screen. Pulling (vs a push callback) keeps the prover's worker threads off the FFI/JS bridge and bounds work under verbose logging.
- **Prover verbosity** — the `tracing` `EnvFilter` is wrapped in a reload layer and exposed via `set_log_level` (`setLogLevel` in Swift/Kotlin/TS). A **"Prover verbosity"** control in Settings (Info/Debug/Trace) persists the choice; `NativeProver` applies it after `initialize`. Default is unchanged (`info`).

## ⚠️ Requires a native rebuild

This touches Rust/Swift/Kotlin, and the UniFFI bindings are gitignored (regenerated, not committed). Before building the app:

```bash
cd app/mobile
npm run build:native   # recompiles Rust + regenerates UniFFI bindings (drain_logs, set_log_level)
npm run ios            # or: npm run android
```

## Testing

- `cargo check` / `clippy` / `fmt` clean (`packages/tlsn-mobile`).
- `uniffi-bindgen` confirms `drain_logs` / `set_log_level` / `NativeLogLine`.
- Mobile ESLint clean on changed files; `vitest` 33/33 pass.
- Manually verified on device: native `tracing` lines surface in the Logs screen during a proof.

## Known follow-up

`logLevelDirectives` currently scopes debug/trace to `tlsn_mobile` + `tlsn`. The verbose MPC logs live in sibling crates (`tlsn_mpc_tls`, `tlsn_core`, `mpz_*`) that `tlsn=` doesn't match (EnvFilter matches on `::` boundaries), so `trace` is currently thin — broadening the directive is a JS-only follow-up.

<img width="1320" height="2868" alt="simulator_screenshot_C007D48A-9F1B-4CBD-80E1-BD49BAA04EB1" src="https://github.com/user-attachments/assets/ca5f4624-8006-4f29-a36a-b7af5a123a17" />

<img width="1320" height="2868" alt="simulator_screenshot_85E28062-38B4-4CA6-9A56-D23EE53DEEA1" src="https://github.com/user-attachments/assets/10de3939-0388-43ea-8ced-c7a47a840b20" />
