### PR TITLE
feat(mobile): Debug toggle + resizable in-proof log drawer

### DIFF
--- a/app/mobile/app/(tabs)/settings.tsx
+++ b/app/mobile/app/(tabs)/settings.tsx
@@ -15,6 +15,8 @@ import {
   setVerifierUrl,
   getProxyMode,
   setProxyMode,
+  getDebugEnabled,
+  setDebugEnabled,
   getLogLevel,
   setLogLevelPref,
   DEFAULT_VERIFIER_URL,
@@ -28,6 +30,7 @@ export default function SettingsScreen() {
   const [url, setUrl] = useState('');
   const [saved, setSaved] = useState(false);
   const [proxyMode, setProxyModeState] = useState(false);
+  const [debugEnabled, setDebugEnabledState] = useState(false);
   const [logLevel, setLogLevelState] = useState<TlsnLogLevel>(DEFAULT_LOG_LEVEL);
   // Don't let the async initial read clobber a tap that lands before it resolves.
   const logLevelTouched = useRef(false);
@@ -35,6 +38,7 @@ export default function SettingsScreen() {
   useEffect(() => {
     getVerifierUrl().then(setUrl);
     getProxyMode().then(setProxyModeState);
+    getDebugEnabled().then(setDebugEnabledState);
     getLogLevel().then((level) => {
       if (!logLevelTouched.current) setLogLevelState(level);
     });
@@ -43,6 +47,11 @@ export default function SettingsScreen() {
   const handleToggleProxyMode = async (value: boolean) => {
     setProxyModeState(value);
     await setProxyMode(value);
+  };
+
+  const handleToggleDebug = async (value: boolean) => {
+    setDebugEnabledState(value);
+    await setDebugEnabled(value);
   };
 
   const handleSelectLogLevel = async (level: TlsnLogLevel) => {
@@ -111,29 +120,47 @@ export default function SettingsScreen() {
       </View>
 
       <View style={[styles.card, styles.cardSpacing]}>
-        <Text style={styles.label}>Prover verbosity</Text>
-        <Text style={styles.description}>
-          How much the tlsn prover logs — captures this level and finer detail (not a display
-          filter). Use Debug or Trace to diagnose proving failures; applies on the next run.
-        </Text>
-        <View style={styles.segment}>
-          {LOG_LEVELS.map((level) => {
-            const active = logLevel === level;
-            return (
-              <TouchableOpacity
-                key={level}
-                style={[styles.segmentButton, active && styles.segmentButtonActive]}
-                onPress={() => handleSelectLogLevel(level)}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
-                  {level.charAt(0).toUpperCase() + level.slice(1)}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
+        <View style={styles.toggleRow}>
+          <View style={styles.toggleLabelGroup}>
+            <Text style={styles.label}>Debug</Text>
+            <Text style={styles.linkDescription}>
+              Show prover log detail and a live log drawer while running a plugin.
+            </Text>
+          </View>
+          <Switch
+            value={debugEnabled}
+            onValueChange={handleToggleDebug}
+            trackColor={{ false: '#ddd', true: '#243f5f' }}
+          />
         </View>
       </View>
+
+      {debugEnabled && (
+        <View style={[styles.card, styles.cardSpacing]}>
+          <Text style={styles.label}>Prover verbosity</Text>
+          <Text style={styles.description}>
+            How much the tlsn prover logs — captures this level and finer detail (not a display
+            filter). Use Debug or Trace to diagnose proving failures; applies on the next run.
+          </Text>
+          <View style={styles.segment}>
+            {LOG_LEVELS.map((level) => {
+              const active = logLevel === level;
+              return (
+                <TouchableOpacity
+                  key={level}
+                  style={[styles.segmentButton, active && styles.segmentButtonActive]}
+                  onPress={() => handleSelectLogLevel(level)}
+                  activeOpacity={0.7}
+                >
+                  <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
+                    {level.charAt(0).toUpperCase() + level.slice(1)}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        </View>
+      )}
 
       <TouchableOpacity
         style={[styles.card, styles.cardSpacing, styles.linkRow]}

--- a/app/mobile/app/logs.tsx
+++ b/app/mobile/app/logs.tsx
@@ -1,75 +1,10 @@
-import React, { useMemo, useState, useSyncExternalStore } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, FlatList, Share, Platform } from 'react-native';
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
 import { Stack } from 'expo-router';
 
-import {
-  subscribe,
-  getLogs,
-  clearLogs,
-  formatLogs,
-  type LogEntry,
-  type LogLevel,
-} from '@/lib/logStore';
-
-type Filter = 'all' | LogLevel;
-
-const FILTERS: { key: Filter; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'debug', label: 'Debug' },
-  { key: 'info', label: 'Info' },
-  { key: 'warn', label: 'Warn' },
-  { key: 'error', label: 'Error' },
-];
-
-const LEVEL_COLOR: Record<LogLevel, string> = {
-  debug: '#8a8f98',
-  info: '#2563eb',
-  warn: '#b45309',
-  error: '#dc2626',
-};
-
-const MONO = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
-
-function LogRow({ entry }: { entry: LogEntry }) {
-  const color = LEVEL_COLOR[entry.level];
-  return (
-    <View style={[styles.row, { borderLeftColor: color }]}>
-      <View style={styles.rowHeader}>
-        <Text style={[styles.level, { color }]}>{entry.level.toUpperCase()}</Text>
-        {entry.source === 'native' && <Text style={styles.nativeBadge}>native</Text>}
-        {entry.tag ? <Text style={styles.tag}>{entry.tag}</Text> : null}
-      </View>
-      <Text style={styles.message} selectable>
-        {entry.text}
-      </Text>
-    </View>
-  );
-}
+import { LogList } from '@/components/LogList';
 
 export default function LogsScreen() {
-  // Third arg (getServerSnapshot) is required for web static rendering
-  // (expo.web.output: "static"); getLogs returns a stable, env-agnostic snapshot.
-  const logs = useSyncExternalStore(subscribe, getLogs, getLogs);
-  const [filter, setFilter] = useState<Filter>('all');
-
-  const filtered = useMemo(
-    () => (filter === 'all' ? logs : logs.filter((l) => l.level === filter)),
-    [logs, filter],
-  );
-
-  // The list is inverted (newest at the bottom, auto-pinned, scroll up for
-  // history), so the data is newest-first. This avoids any scrollToEnd loop.
-  const inverted = useMemo(() => filtered.slice().reverse(), [filtered]);
-
-  const handleShare = async () => {
-    if (filtered.length === 0) return;
-    try {
-      await Share.share({ message: formatLogs(filtered) });
-    } catch {
-      // user dismissed share sheet — nothing to do
-    }
-  };
-
   return (
     <View style={styles.container}>
       <Stack.Screen
@@ -83,52 +18,7 @@ export default function LogsScreen() {
           headerTitleStyle: { fontWeight: 'bold' },
         }}
       />
-
-      <View style={styles.toolbar}>
-        <View style={styles.filterRow}>
-          {FILTERS.map((f) => {
-            const active = filter === f.key;
-            return (
-              <TouchableOpacity
-                key={f.key}
-                style={[styles.chip, active && styles.chipActive]}
-                onPress={() => setFilter(f.key)}
-                activeOpacity={0.7}
-              >
-                <Text style={[styles.chipText, active && styles.chipTextActive]}>{f.label}</Text>
-              </TouchableOpacity>
-            );
-          })}
-        </View>
-        <View style={styles.actionRow}>
-          <Text style={styles.count}>{filtered.length} entries</Text>
-          <View style={styles.actionButtons}>
-            <TouchableOpacity style={styles.actionButton} onPress={handleShare} activeOpacity={0.7}>
-              <Text style={styles.actionText}>Share</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.actionButton} onPress={clearLogs} activeOpacity={0.7}>
-              <Text style={styles.actionText}>Clear</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </View>
-
-      {filtered.length === 0 ? (
-        <View style={styles.empty}>
-          <Text style={styles.emptyText}>No logs yet.</Text>
-          <Text style={styles.emptyHint}>Run a plugin to capture proving logs here.</Text>
-        </View>
-      ) : (
-        <FlatList
-          inverted
-          data={inverted}
-          keyExtractor={(e) => String(e.id)}
-          renderItem={({ item }) => <LogRow entry={item} />}
-          contentContainerStyle={styles.listContent}
-          initialNumToRender={30}
-          windowSize={11}
-        />
-      )}
+      <LogList style={styles.list} />
     </View>
   );
 }
@@ -138,119 +28,7 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#0f1115',
   },
-  toolbar: {
-    backgroundColor: '#1b1f27',
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#2c313c',
-  },
-  filterRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 6,
-  },
-  chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 5,
-    borderRadius: 14,
-    backgroundColor: '#2c313c',
-  },
-  chipActive: {
-    backgroundColor: '#3b82f6',
-  },
-  chipText: {
-    fontSize: 12,
-    color: '#c9ced8',
-    fontWeight: '600',
-  },
-  chipTextActive: {
-    color: '#fff',
-  },
-  actionRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginTop: 10,
-  },
-  count: {
-    fontSize: 12,
-    color: '#8a8f98',
-  },
-  actionButtons: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  actionButton: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 8,
-    backgroundColor: '#2c313c',
-  },
-  actionText: {
-    fontSize: 13,
-    color: '#c9ced8',
-    fontWeight: '600',
-  },
-  listContent: {
-    paddingVertical: 6,
-  },
-  row: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderLeftWidth: 3,
-    marginHorizontal: 8,
-    marginVertical: 2,
-    backgroundColor: '#161a21',
-    borderRadius: 4,
-  },
-  rowHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    marginBottom: 2,
-  },
-  level: {
-    fontSize: 10,
-    fontWeight: '800',
-    letterSpacing: 0.5,
-  },
-  nativeBadge: {
-    fontSize: 9,
-    fontWeight: '700',
-    color: '#0f1115',
-    backgroundColor: '#a3e635',
-    paddingHorizontal: 5,
-    paddingVertical: 1,
-    borderRadius: 4,
-    overflow: 'hidden',
-  },
-  tag: {
-    fontSize: 11,
-    color: '#9aa3b2',
-    fontFamily: MONO,
-  },
-  message: {
-    fontSize: 12,
-    color: '#e6e9ef',
-    fontFamily: MONO,
-    lineHeight: 16,
-  },
-  empty: {
+  list: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24,
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#c9ced8',
-    fontWeight: '600',
-    marginBottom: 6,
-  },
-  emptyHint: {
-    fontSize: 13,
-    color: '#6b7280',
-    textAlign: 'center',
   },
 });

--- a/app/mobile/app/plugin/[id].tsx
+++ b/app/mobile/app/plugin/[id].tsx
@@ -1,9 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet, Alert, ScrollView, TouchableOpacity } from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import { PluginScreen } from '@/components/tlsn/PluginScreen';
+import { LogDrawer } from '@/components/LogDrawer';
 import { getPluginById } from '../../assets/plugins/registry';
-import { useVerifierUrl, useProxyMode } from '@/lib/useVerifierUrl';
+import { useVerifierUrl, useProxyMode, getDebugEnabled } from '@/lib/useVerifierUrl';
 
 /**
  * Extract all handler result values from the proof result string.
@@ -68,6 +70,12 @@ export default function PluginRunnerScreen() {
   const [result, setResult] = useState<string | null>(null);
   const [provenExpanded, setProvenExpanded] = useState(false);
   const [rawExpanded, setRawExpanded] = useState(false);
+  const [debugEnabled, setDebugEnabled] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(false);
+
+  useEffect(() => {
+    getDebugEnabled().then(setDebugEnabled);
+  }, []);
 
   const results = useMemo(() => (result ? parseResults(result) : []), [result]);
   const keyValue = results.length > 0 ? results[results.length - 1].value : null;
@@ -93,6 +101,18 @@ export default function PluginRunnerScreen() {
           headerStyle: { backgroundColor: '#243f5f' },
           headerTintColor: '#fff',
           headerTitleStyle: { fontWeight: 'bold' },
+          // When Debug is enabled (Settings), expose a live log drawer toggle.
+          headerRight: debugEnabled
+            ? () => (
+                <TouchableOpacity
+                  onPress={() => setLogsOpen((v) => !v)}
+                  hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                  activeOpacity={0.7}
+                >
+                  <FontAwesome name="terminal" size={20} color="#fff" />
+                </TouchableOpacity>
+              )
+            : undefined,
         }}
       />
       {result ? (
@@ -188,6 +208,8 @@ export default function PluginRunnerScreen() {
           }}
         />
       )}
+
+      <LogDrawer visible={logsOpen} onClose={() => setLogsOpen(false)} />
     </View>
   );
 }

--- a/app/mobile/components/LogDrawer.tsx
+++ b/app/mobile/components/LogDrawer.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Animated,
+  PanResponder,
+  Dimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { LogList } from '@/components/LogList';
+
+const SCREEN_H = Dimensions.get('window').height;
+const MIN_H = 200;
+const MAX_H = Math.round(SCREEN_H * 0.8);
+const DEFAULT_H = Math.round(SCREEN_H * 0.42);
+
+const clamp = (h: number) => Math.min(MAX_H, Math.max(MIN_H, h));
+
+/**
+ * A resizable bottom-sheet log drawer that floats over the current screen
+ * (it does not resize the underlying content — important on the proof screen,
+ * whose WebView shouldn't reflow mid-proof). Drag the grab handle to resize.
+ */
+export function LogDrawer({ visible, onClose }: { visible: boolean; onClose: () => void }) {
+  const insets = useSafeAreaInsets();
+  // `committed` is the height between drags (updated on release); `height` is the
+  // live Animated value driven during a drag (so dragging doesn't re-render).
+  const [committed, setCommitted] = useState(DEFAULT_H);
+  const height = useMemo(() => new Animated.Value(DEFAULT_H), []);
+
+  // Only the grab handle drives resize, so the list inside still scrolls freely.
+  const pan = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 2,
+        onPanResponderMove: (_, g) => height.setValue(clamp(committed - g.dy)),
+        // Commit on both release and terminate so committed/height never desync
+        // (a terminated drag would otherwise leave them mismatched → next-drag jump).
+        onPanResponderRelease: (_, g) => setCommitted(clamp(committed - g.dy)),
+        onPanResponderTerminate: (_, g) => setCommitted(clamp(committed - g.dy)),
+      }),
+    [committed, height],
+  );
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.drawer, { height }]}>
+      <View style={styles.handleArea} {...pan.panHandlers}>
+        <View style={styles.grabber} />
+      </View>
+      <View style={styles.header}>
+        <Text style={styles.title}>Logs</Text>
+        <TouchableOpacity
+          onPress={onClose}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.close}>Close</Text>
+        </TouchableOpacity>
+      </View>
+      <LogList style={styles.list} />
+      {insets.bottom > 0 ? (
+        <View style={{ height: insets.bottom, backgroundColor: '#0f1115' }} />
+      ) : null}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  drawer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: '#0f1115',
+    borderTopLeftRadius: 14,
+    borderTopRightRadius: 14,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 12,
+  },
+  handleArea: {
+    paddingVertical: 8,
+    alignItems: 'center',
+    backgroundColor: '#1b1f27',
+  },
+  grabber: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#4b5563',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+    backgroundColor: '#1b1f27',
+  },
+  title: {
+    color: '#e6e9ef',
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  close: {
+    color: '#3b82f6',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  list: {
+    flex: 1,
+  },
+});

--- a/app/mobile/components/LogList.tsx
+++ b/app/mobile/components/LogList.tsx
@@ -1,0 +1,262 @@
+import React, { useMemo, useState, useSyncExternalStore } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  FlatList,
+  ScrollView,
+  Share,
+  Platform,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+
+import {
+  subscribe,
+  getLogs,
+  clearLogs,
+  formatLogs,
+  type LogEntry,
+  type LogLevel,
+} from '@/lib/logStore';
+
+type Filter = 'all' | LogLevel;
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'debug', label: 'Debug' },
+  { key: 'info', label: 'Info' },
+  { key: 'warn', label: 'Warn' },
+  { key: 'error', label: 'Error' },
+];
+
+const LEVEL_COLOR: Record<LogLevel, string> = {
+  debug: '#8a8f98',
+  info: '#2563eb',
+  warn: '#b45309',
+  error: '#dc2626',
+};
+
+const MONO = Platform.OS === 'ios' ? 'Menlo' : 'monospace';
+
+function LogRow({ entry }: { entry: LogEntry }) {
+  const color = LEVEL_COLOR[entry.level];
+  return (
+    <View style={[styles.row, { borderLeftColor: color }]}>
+      <View style={styles.rowHeader}>
+        <Text style={[styles.level, { color }]}>{entry.level.toUpperCase()}</Text>
+        {entry.source === 'native' && <Text style={styles.nativeBadge}>native</Text>}
+        {entry.tag ? <Text style={styles.tag}>{entry.tag}</Text> : null}
+      </View>
+      <Text style={styles.message} selectable>
+        {entry.text}
+      </Text>
+    </View>
+  );
+}
+
+/**
+ * Reusable log viewer backed by `logStore`: level-filter chips, Share, Clear,
+ * and an inverted (newest-at-bottom) list. Used by both the full Logs screen
+ * and the in-proof log drawer.
+ */
+export function LogList({ style }: { style?: StyleProp<ViewStyle> }) {
+  // Third arg (getServerSnapshot) is required for web static rendering
+  // (expo.web.output: "static"); getLogs returns a stable, env-agnostic snapshot.
+  const logs = useSyncExternalStore(subscribe, getLogs, getLogs);
+  const [filter, setFilter] = useState<Filter>('all');
+
+  const filtered = useMemo(
+    () => (filter === 'all' ? logs : logs.filter((l) => l.level === filter)),
+    [logs, filter],
+  );
+
+  // Inverted list (newest at the bottom, auto-pinned, scroll up for history), so
+  // the data is newest-first. This avoids any scrollToEnd loop.
+  const inverted = useMemo(() => filtered.slice().reverse(), [filtered]);
+
+  const handleShare = async () => {
+    if (filtered.length === 0) return;
+    try {
+      await Share.share({ message: formatLogs(filtered) });
+    } catch {
+      // user dismissed share sheet — nothing to do
+    }
+  };
+
+  return (
+    <View style={[styles.container, style]}>
+      <View style={styles.toolbar}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.filterScroll}
+          contentContainerStyle={styles.filterRow}
+        >
+          {FILTERS.map((f) => {
+            const active = filter === f.key;
+            return (
+              <TouchableOpacity
+                key={f.key}
+                style={[styles.chip, active && styles.chipActive]}
+                onPress={() => setFilter(f.key)}
+                activeOpacity={0.7}
+              >
+                <Text style={[styles.chipText, active && styles.chipTextActive]}>{f.label}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </ScrollView>
+        <View style={styles.actionButtons}>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={handleShare}
+            activeOpacity={0.7}
+            accessibilityLabel="Share logs"
+          >
+            <FontAwesome name="share-square-o" size={18} color="#c9ced8" />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.iconButton}
+            onPress={clearLogs}
+            activeOpacity={0.7}
+            accessibilityLabel="Clear logs"
+          >
+            <FontAwesome name="trash-o" size={18} color="#c9ced8" />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {filtered.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No logs yet.</Text>
+          <Text style={styles.emptyHint}>Run a plugin to capture proving logs here.</Text>
+        </View>
+      ) : (
+        <FlatList
+          inverted
+          data={inverted}
+          keyExtractor={(e) => String(e.id)}
+          renderItem={({ item }) => <LogRow entry={item} />}
+          contentContainerStyle={styles.listContent}
+          initialNumToRender={30}
+          windowSize={11}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#0f1115',
+  },
+  toolbar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#1b1f27',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#2c313c',
+  },
+  filterScroll: {
+    flex: 1,
+  },
+  filterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingRight: 8,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 5,
+    borderRadius: 14,
+    backgroundColor: '#2c313c',
+  },
+  chipActive: {
+    backgroundColor: '#3b82f6',
+  },
+  chipText: {
+    fontSize: 12,
+    color: '#c9ced8',
+    fontWeight: '600',
+  },
+  chipTextActive: {
+    color: '#fff',
+  },
+  actionButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingLeft: 4,
+  },
+  iconButton: {
+    padding: 6,
+  },
+  listContent: {
+    paddingVertical: 6,
+  },
+  row: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderLeftWidth: 3,
+    marginHorizontal: 8,
+    marginVertical: 2,
+    backgroundColor: '#161a21',
+    borderRadius: 4,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 2,
+  },
+  level: {
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 0.5,
+  },
+  nativeBadge: {
+    fontSize: 9,
+    fontWeight: '700',
+    color: '#0f1115',
+    backgroundColor: '#a3e635',
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  tag: {
+    fontSize: 11,
+    color: '#9aa3b2',
+    fontFamily: MONO,
+  },
+  message: {
+    fontSize: 12,
+    color: '#e6e9ef',
+    fontFamily: MONO,
+    lineHeight: 16,
+  },
+  empty: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#c9ced8',
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  emptyHint: {
+    fontSize: 13,
+    color: '#6b7280',
+    textAlign: 'center',
+  },
+});

--- a/app/mobile/components/tlsn/NativeProver.tsx
+++ b/app/mobile/components/tlsn/NativeProver.tsx
@@ -25,7 +25,7 @@ import type {
   RevealRangeDescriptor,
 } from '../../modules/tlsn-native/src';
 import { addLog, type LogLevel } from '@/lib/logStore';
-import { getLogLevel } from '@/lib/useVerifierUrl';
+import { getEffectiveLogLevel } from '@/lib/useVerifierUrl';
 
 export type {
   HandlerType,
@@ -150,9 +150,9 @@ function NativeProverComponent(
         setIsReady(true);
         onReady?.();
 
-        // Apply the persisted native log level so the Logs screen shows the
-        // verbosity the user selected in Settings.
-        getLogLevel()
+        // Apply the effective native log level (the selected verbosity only when
+        // Debug is enabled in Settings, otherwise the quiet default).
+        getEffectiveLogLevel()
           .then((level) => module.setLogLevel(level))
           .catch(() => {});
       } catch (e) {

--- a/app/mobile/lib/useVerifierUrl.ts
+++ b/app/mobile/lib/useVerifierUrl.ts
@@ -5,15 +5,23 @@ import type { TlsnLogLevel } from '../modules/tlsn-native/src';
 const configFile = new File(Paths.document, 'verifier-config.json');
 const DEFAULT_VERIFIER_URL = 'https://demo.tlsnotary.org';
 const DEFAULT_PROXY_MODE = false;
+const DEFAULT_DEBUG_ENABLED = false;
 const DEFAULT_LOG_LEVEL: TlsnLogLevel = 'info';
 const LOG_LEVELS: TlsnLogLevel[] = ['info', 'debug', 'trace'];
 
-export { DEFAULT_VERIFIER_URL, DEFAULT_PROXY_MODE, DEFAULT_LOG_LEVEL, LOG_LEVELS };
+export {
+  DEFAULT_VERIFIER_URL,
+  DEFAULT_PROXY_MODE,
+  DEFAULT_DEBUG_ENABLED,
+  DEFAULT_LOG_LEVEL,
+  LOG_LEVELS,
+};
 export type { TlsnLogLevel };
 
 interface Config {
   verifierUrl?: string;
   proxyMode?: boolean;
+  debugEnabled?: boolean;
   logLevel?: TlsnLogLevel;
 }
 
@@ -64,6 +72,16 @@ export async function setProxyMode(value: boolean): Promise<void> {
   await patchConfig({ proxyMode: value });
 }
 
+export async function getDebugEnabled(): Promise<boolean> {
+  const config = await loadConfig();
+  return config.debugEnabled ?? DEFAULT_DEBUG_ENABLED;
+}
+
+export async function setDebugEnabled(value: boolean): Promise<void> {
+  console.log('[useVerifierUrl] setDebugEnabled called with:', value);
+  await patchConfig({ debugEnabled: value });
+}
+
 export async function getLogLevel(): Promise<TlsnLogLevel> {
   const config = await loadConfig();
   return config.logLevel ?? DEFAULT_LOG_LEVEL;
@@ -72,6 +90,16 @@ export async function getLogLevel(): Promise<TlsnLogLevel> {
 export async function setLogLevelPref(level: TlsnLogLevel): Promise<void> {
   console.log('[useVerifierUrl] setLogLevelPref called with:', level);
   await patchConfig({ logLevel: level });
+}
+
+/**
+ * The native log level to actually apply: only honour the chosen verbosity when
+ * Debug is enabled, otherwise stay at the quiet default.
+ */
+export async function getEffectiveLogLevel(): Promise<TlsnLogLevel> {
+  const config = await loadConfig();
+  if (!(config.debugEnabled ?? DEFAULT_DEBUG_ENABLED)) return DEFAULT_LOG_LEVEL;
+  return config.logLevel ?? DEFAULT_LOG_LEVEL;
 }
 
 export function useVerifierUrl(): { url: string; loading: boolean } {


### PR DESCRIPTION
Stacked on #352 (base = `feat/mobile-console-view`). Retarget to `main` once #352 merges.

## What

A **Debug** switch in Settings that gates the advanced logging UI, plus a live, resizable log drawer on the proof screen — so you can watch the prover's logs *while a proof runs* instead of navigating away.

- **Settings → Debug** (off by default). When on, it reveals the **Prover verbosity** control. The effective native level is the quiet default (`info`) whenever Debug is off, via `getEffectiveLogLevel()`.
- **In-proof log drawer**: when Debug is on, the proof screen shows a terminal-icon header button that toggles a **resizable bottom sheet** (drag the handle). It's an absolute overlay — it does **not** resize/reflow the proof WebView.
- **Shared `<LogList>`**: extracted from the Logs screen so the full screen and the drawer share one implementation. Its toolbar is now a single row (filter chips + Share/Clear icons; dropped the entry count).

## Implementation notes

- Drawer uses RN-core `Animated` + `PanResponder` (no new deps). Committed height in `useState`, live height in a memoized `Animated.Value` (so dragging doesn't re-render); reworked to satisfy the repo's React-Compiler ESLint rules (no ref reads during render). Commits on both release and terminate so the size can't desync.
- Pure JS — no `npm run build:native` needed for this PR.

## Testing

- ESLint clean on all changed files; `vitest` 33/33.
- Adversarial review pass; the one finding (drag-terminate desync) is fixed via `onPanResponderTerminate`.
- Needs on-device verification of the drawer gesture (can't run the RN app in CI here).

<img width="1320" height="2868" alt="simulator_screenshot_AF941EFA-B897-4FB5-8359-486595A2EE35" src="https://github.com/user-attachments/assets/ae66a9c0-bbee-4724-90d0-750de8a4f5e1" />
<img width="1320" height="2868" alt="simulator_screenshot_599E1B50-6899-45D6-BABA-7E844EF486F9" src="https://github.com/user-attachments/assets/8007ff3c-d426-4c82-8e39-8b8c7381c8db" />
<img width="1320" height="2868" alt="simulator_screenshot_A114267F-242E-4213-ACEB-56707E8E5319" src="https://github.com/user-attachments/assets/16f8c5be-52a9-4c95-acf8-8eb11bda352e" />
