### PR TITLE
fix(mobile): drop unused default Android permissions

### DIFF
--- a/app/mobile/app.json
+++ b/app/mobile/app.json
@@ -26,7 +26,14 @@
         "backgroundColor": "#243F5F"
       },
       "edgeToEdgeEnabled": true,
-      "package": "org.tlsnotary.mobile"
+      "package": "org.tlsnotary.mobile",
+      "permissions": [],
+      "blockedPermissions": [
+        "android.permission.READ_EXTERNAL_STORAGE",
+        "android.permission.WRITE_EXTERNAL_STORAGE",
+        "android.permission.SYSTEM_ALERT_WINDOW",
+        "android.permission.VIBRATE"
+      ]
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
## What

Trim the Android permission set the mobile app requests down to only what it actually uses, via `android.blockedPermissions` in `app.json`.

Before this change the merged Android manifest requested five permissions; four were never used by the app:

| Permission | Injected by | Used by app? |
|---|---|---|
| `INTERNET` | Expo template + `expo-file-system` + RN core | ✅ Yes — kept |
| `READ_EXTERNAL_STORAGE` | `expo-file-system` | ❌ No |
| `WRITE_EXTERNAL_STORAGE` | `expo-file-system` | ❌ No |
| `SYSTEM_ALERT_WINDOW` | React Native core (dev-menu only) | ❌ No |
| `VIBRATE` | Expo prebuild template default | ❌ No |

## Why

These come from Expo's default prebuild template and from dependency manifests (autolinking) — not from anything the app declares deliberately. Verified against the code:

- **Storage**: the only filesystem usage is `lib/useVerifierUrl.ts`, which reads/writes `Paths.document` (the app's private, scoped document directory). Scoped storage needs no external-storage permission.
- **Vibration**: no `Vibration`/haptics usage anywhere.
- **Draw over other apps**: every "overlay" in the code is an in-app React Native `<View>`; `SYSTEM_ALERT_WINDOW` is only needed by the RN dev-menu, which lives in the debug source set and is excluded from release.

An allow-list (`"permissions": []`) alone cannot remove library-injected permissions, so `blockedPermissions` is used — it emits `tools:node="remove"` and rejects the library declarations during manifest merge.

## Verification

Ran `expo prebuild --clean` + Gradle `assembleDebug` and inspected the generated **merged manifest**:

- `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`, `VIBRATE` → **removed**.
- `INTERNET` → kept.
- `SYSTEM_ALERT_WINDOW` → present only in the **debug** merged manifest (re-added by the debug source set for the dev menu); absent from release.

Net result: the released app requests only **`INTERNET`** (plus the AndroidX-internal, app-private `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`, which is not user-facing).

## iOS

No change needed. iOS only prompts when a gated API is called and requires a matching `NS…UsageDescription`; the generated `Info.plist` contains zero such keys and the entitlements file is empty. The iOS build already requests no permissions or capabilities.

## Notes

- `android/` and `ios/` are generated by `expo prebuild` (gitignored), so the only source change is `app/mobile/app.json`.