### PR TITLE
feat: flag experimental plugins (hidden on mobile, WIP badge on demo + mobile)

### DIFF
--- a/app/mobile/app/(tabs)/index.tsx
+++ b/app/mobile/app/(tabs)/index.tsx
@@ -29,7 +29,14 @@ export default function PluginGalleryScreen() {
         >
           <Text style={styles.logo}>{plugin.logo}</Text>
           <View style={styles.cardBody}>
-            <Text style={styles.name}>{plugin.name}</Text>
+            <View style={styles.nameRow}>
+              <Text style={styles.name}>{plugin.name}</Text>
+              {plugin.debug && (
+                <View style={styles.wipBadge}>
+                  <Text style={styles.wipText}>WIP</Text>
+                </View>
+              )}
+            </View>
             <Text style={styles.description}>{plugin.description}</Text>
           </View>
         </TouchableOpacity>
@@ -72,7 +79,24 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '700',
     color: '#243f5f',
+    flexShrink: 1,
+  },
+  nameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
     marginBottom: 4,
+  },
+  wipBadge: {
+    backgroundColor: '#fef3c7',
+    borderRadius: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+  },
+  wipText: {
+    color: '#92400e',
+    fontSize: 11,
+    fontWeight: '700',
   },
   description: {
     fontSize: 14,

--- a/app/mobile/app/(tabs)/index.tsx
+++ b/app/mobile/app/(tabs)/index.tsx
@@ -1,13 +1,22 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, StyleSheet } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import { getPluginRegistry } from '../../assets/plugins/registry';
-import { useVerifierUrl } from '@/lib/useVerifierUrl';
+import { useVerifierUrl, getDebugEnabled } from '@/lib/useVerifierUrl';
 
 export default function PluginGalleryScreen() {
   const router = useRouter();
   const { url: verifierUrl } = useVerifierUrl();
-  const plugins = getPluginRegistry(verifierUrl);
+  const [debugEnabled, setDebugEnabled] = useState(false);
+
+  // Re-read on focus so toggling Debug in Settings updates the list immediately.
+  useFocusEffect(
+    useCallback(() => {
+      getDebugEnabled().then(setDebugEnabled);
+    }, []),
+  );
+
+  const plugins = getPluginRegistry(verifierUrl).filter((p) => debugEnabled || !p.debug);
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>

--- a/app/mobile/assets/plugins/registry.ts
+++ b/app/mobile/assets/plugins/registry.ts
@@ -10,6 +10,8 @@ export interface PluginEntry {
   resultLabel: string;
   /** Accent colour for the result header gradient */
   accentColor: string;
+  /** Only listed while the app's Debug mode is enabled. */
+  debug: boolean;
   pluginConfig: PluginConfig;
   getPluginCode: () => string;
   /** GitHub URL pointing at the plugin's source on `main`. */
@@ -44,6 +46,7 @@ function toPluginEntry(meta: PluginMetadata, verifierUrl: string): PluginEntry {
     logo: meta.logo,
     resultLabel: meta.resultLabel,
     accentColor: meta.accentColor,
+    debug: meta.debug ?? false,
     pluginConfig: {
       name: meta.pluginConfig.name,
       description: meta.pluginConfig.description,

--- a/packages/demo/src/App.css
+++ b/packages/demo/src/App.css
@@ -1007,6 +1007,11 @@ body {
   color: #991b1b;
 }
 
+.plugin-badge.plugin-badge--wip {
+  background: #fef3c7;
+  color: #92400e;
+}
+
 .plugin-result--error .plugin-result-title {
   color: #991b1b;
 }

--- a/packages/demo/src/components/PluginButtons.tsx
+++ b/packages/demo/src/components/PluginButtons.tsx
@@ -57,6 +57,14 @@ export function PluginButtons({
               <div className="plugin-info">
                 <h3 className="plugin-name">
                   {plugin.name}
+                  {plugin.debug && (
+                    <span
+                      className="plugin-badge plugin-badge--wip"
+                      title="Work in progress — experimental plugin"
+                    >
+                      WIP
+                    </span>
+                  )}
                   {hasResult && !result.isError && <span className="plugin-badge">✓ Verified</span>}
                   {result?.isError && (
                     <span className="plugin-badge plugin-badge--error">&#x2717; Failed</span>

--- a/packages/demo/src/plugins.ts
+++ b/packages/demo/src/plugins.ts
@@ -10,6 +10,7 @@ export const plugins: Record<string, Plugin> = Object.fromEntries(
       logo: p.logo,
       file: `/plugins/${p.id}.js`,
       parseResult: (json) => json.results[json.results.length - 1].value,
+      debug: p.debug ?? false,
     } satisfies Plugin,
   ]),
 );

--- a/packages/demo/src/types.ts
+++ b/packages/demo/src/types.ts
@@ -4,6 +4,8 @@ export interface Plugin {
   logo: string;
   file: string;
   parseResult: (json: PluginResult) => string;
+  /** Work-in-progress / experimental plugin — shown with a "WIP" badge. */
+  debug?: boolean;
 }
 
 export interface PluginResult {

--- a/packages/plugins/src/registry.ts
+++ b/packages/plugins/src/registry.ts
@@ -19,6 +19,11 @@ export interface PluginMetadata {
   accentColor: string;
   /** Which platforms include this plugin */
   platforms: ('demo' | 'mobile')[];
+  /**
+   * When true, the plugin is only listed on mobile while the app's Debug mode
+   * is enabled. Use for work-in-progress / experimental plugins.
+   */
+  debug?: boolean;
   /** Plugin config (mirrors the plugin's internal `config` object) */
   pluginConfig: {
     name: string;
@@ -77,7 +82,7 @@ export const PLUGIN_REGISTRY: PluginMetadata[] = [
       urls: ['https://swissbank.tlsnotary.org/*'],
     },
   },
-   {
+  {
     id: 'swissbank_hash',
     name: 'Swiss Bank (Hashed)',
     description:
@@ -88,7 +93,8 @@ export const PLUGIN_REGISTRY: PluginMetadata[] = [
     platforms: ['demo', 'mobile'],
     pluginConfig: {
       name: 'Swiss Bank Prover (Hashed)',
-      description: 'This plugin will prove a blinded hash of an account balance on a (dummy) Swiss bank.',
+      description:
+        'This plugin will prove a blinded hash of an account balance on a (dummy) Swiss bank.',
       requests: [
         {
           method: 'GET',
@@ -150,6 +156,7 @@ export const PLUGIN_REGISTRY: PluginMetadata[] = [
     resultLabel: 'Profile',
     accentColor: '#000000',
     platforms: ['demo', 'mobile'],
+    debug: true,
     pluginConfig: {
       name: 'Uber Profile Prover',
       description: 'This plugin will prove your Uber rider profile via GraphQL.',
@@ -171,6 +178,7 @@ export const PLUGIN_REGISTRY: PluginMetadata[] = [
     resultLabel: 'Message',
     accentColor: '#5865F2',
     platforms: ['demo', 'mobile'],
+    debug: true,
     pluginConfig: {
       name: 'Discord DM Plugin',
       description: 'This plugin will prove your Discord direct messages.',

--- a/packages/plugins/src/registry.ts
+++ b/packages/plugins/src/registry.ts
@@ -20,8 +20,9 @@ export interface PluginMetadata {
   /** Which platforms include this plugin */
   platforms: ('demo' | 'mobile')[];
   /**
-   * When true, the plugin is only listed on mobile while the app's Debug mode
-   * is enabled. Use for work-in-progress / experimental plugins.
+   * Marks a work-in-progress / experimental plugin. On mobile it is only listed
+   * while the app's Debug mode is enabled; on the demo it is shown with a "WIP"
+   * badge.
    */
   debug?: boolean;
   /** Plugin config (mirrors the plugin's internal `config` object) */


### PR DESCRIPTION
## What

Adds an optional `debug` flag to the shared plugin registry to mark **work-in-progress / experimental** plugins, with a treatment appropriate to each platform:

- **Mobile** — flagged plugins are **hidden** from the home gallery unless the app's **Debug** mode (Settings) is enabled. When Debug is on and they appear, they carry a **"WIP"** badge.
- **Demo** — flagged plugins are always shown but carry a **"WIP"** badge (hiding them on a public demo would be confusing).

**Uber** and **Discord DM** are flagged.

## Why

The mobile app recently gained a Debug mode; this piggybacks on it to keep half-baked plugins out of the default mobile gallery while still letting us dogfood them. On the public demo, the same plugins stay visible but are clearly labeled experimental.

## How

- `packages/plugins/src/registry.ts` — add `debug?: boolean` to `PluginMetadata`; set `debug: true` on `uber` and `discord_dm`.

**Mobile:**
- `app/mobile/assets/plugins/registry.ts` — carry the flag onto the mobile `PluginEntry`.
- `app/mobile/app/(tabs)/index.tsx` — filter the gallery to `debugEnabled || !p.debug`, re-reading `getDebugEnabled()` on screen focus so toggling Debug in Settings updates the list without an app restart; render a "WIP" badge on flagged cards.

**Demo:**
- `packages/demo/src/types.ts` + `plugins.ts` — carry the flag onto the demo `Plugin`.
- `packages/demo/src/components/PluginButtons.tsx` — render a "WIP" badge on flagged plugin cards.
- `packages/demo/src/App.css` — `.plugin-badge--wip` style (amber).

Adding/removing a plugin from the experimental set is a one-line `debug: true` in the shared registry.

## Scope

- The extension is unaffected — it doesn't consult the flag.
- Mobile `getPluginById` is left unfiltered, so a debug plugin still runs if navigated to directly.

## Verification

- Rebuilt `@tlsn/plugins` (both mobile and demo consume its built `dist/`) — all plugins built OK.
- `tsc --noEmit` on the mobile app and the demo — no new errors in touched files.
- ESLint + Prettier clean on the changed files.
