### PR TITLE
docs: document the mobile app alongside the extension

### DIFF
--- a/.claude/commands/create-plugin.md
+++ b/.claude/commands/create-plugin.md
@@ -15,18 +15,21 @@ Follow these steps in order. Ask the user for input when you need it.
 Before writing any code, you need to find a **JSON API endpoint** on the target service that returns the data to prove.
 
 **What to look for:**
+
 - A GET or POST endpoint that returns JSON (not HTML)
 - Small response size if possible (under 16KB ideal)
 - Contains the data the user wants to prove (username, score, badges, etc.)
 - Requires cookie-based or token-based auth (interceptable via browser)
 
 **Try to discover the API automatically first:**
+
 1. Search the web for the target service's known API endpoints, developer docs, or reverse-engineered APIs
 2. Fetch the target website's main page and look for API URLs in the JavaScript source, `__NEXT_DATA__`, or inline `window.*` variables
 3. Try common API patterns: `/api/v1/`, `/graphql`, `/gc-api/`, `/proxy/`
 4. Check if there's an existing old plugin in https://github.com/tlsnotary/tlsn-plugin-boilerplate that can provide clues
 
 **If automatic discovery fails, ask the user to help:**
+
 1. Ask them to open the target website with Chrome DevTools Network tab (filter XHR/Fetch)
 2. Ask them to copy the request as cURL (`Copy as cURL` from DevTools)
 3. From the cURL, identify:
@@ -35,21 +38,22 @@ Before writing any code, you need to find a **JSON API endpoint** on the target 
    - The response structure (JSON fields available)
 
 **If the user provides a cURL command**, test it with `curl` to verify it works and inspect the response:
+
 - Check the response is JSON
 - Check the response size (`wc -c`)
 - Identify which JSON fields to reveal in the proof
 
 **Examples from existing plugins:**
 
-| Service | API Endpoint | Method | Auth |
-|---------|-------------|--------|------|
-| Twitter/X | `api.x.com/1.1/account/settings.json` | GET | Cookie + Authorization + x-csrf-token |
-| Spotify | `api.spotify.com/v1/me/top/artists?time_range=medium_term&limit=1` | GET | Authorization (Bearer token) |
-| Uber | `riders.uber.com/graphql` | POST | Cookie + x-csrf-token |
-| Discord | `discord.com/api/v9/users/@me` | GET | Authorization (Bot/User token) |
-| Duolingo | `www.duolingo.com/2023-05-23/users/{id}?fields=longestStreak,username` | GET | Authorization |
-| Garmin | `connect.garmin.com/gc-api/badge-service/badge/earned` | GET | Cookie + connect-csrf-token |
-| Swiss Bank | `swissbank.tlsnotary.org/balances` | GET | Cookie |
+| Service    | API Endpoint                                                           | Method | Auth                                  |
+| ---------- | ---------------------------------------------------------------------- | ------ | ------------------------------------- |
+| Twitter/X  | `api.x.com/1.1/account/settings.json`                                  | GET    | Cookie + Authorization + x-csrf-token |
+| Spotify    | `api.spotify.com/v1/me/top/artists?time_range=medium_term&limit=1`     | GET    | Authorization (Bearer token)          |
+| Uber       | `riders.uber.com/graphql`                                              | POST   | Cookie + x-csrf-token                 |
+| Discord    | `discord.com/api/v9/users/@me`                                         | GET    | Authorization (Bot/User token)        |
+| Duolingo   | `www.duolingo.com/2023-05-23/users/{id}?fields=longestStreak,username` | GET    | Authorization                         |
+| Garmin     | `connect.garmin.com/gc-api/badge-service/badge/earned`                 | GET    | Cookie + connect-csrf-token           |
+| Swiss Bank | `swissbank.tlsnotary.org/balances`                                     | GET    | Cookie                                |
 
 ### Step 2: Plan the plugin
 
@@ -69,7 +73,9 @@ Based on the API research, determine:
 
 ### Step 3: Create the plugin file
 
-Create a TypeScript plugin file (e.g., `{name}.plugin.ts`):
+Create a TypeScript plugin file at `packages/plugins/src/{name}.plugin.ts`. Plugins live in
+the shared [`@tlsn/plugins`](../../packages/plugins) package so they run on **both** clients
+(the browser extension and the mobile app).
 
 Use this template, adapting it to the target service:
 
@@ -120,8 +126,8 @@ const onClick = async (): Promise<void> => {
     Host: api,
     Cookie: cachedCookie,
     // Add other required headers here
-    'Accept-Encoding': 'identity',  // REQUIRED: prevents compressed response
-    Connection: 'close',             // REQUIRED: clean TLS termination
+    'Accept-Encoding': 'identity', // REQUIRED: prevents compressed response
+    Connection: 'close', // REQUIRED: clean TLS termination
   };
 
   const resp = await prove(
@@ -134,8 +140,8 @@ const onClick = async (): Promise<void> => {
     {
       verifierUrl: __VERIFIER_URL__,
       proxyUrl: __PROXY_URL__ + api,
-      maxRecvData: {size},
-      maxSentData: {size},
+      maxRecvData: { size },
+      maxSentData: { size },
       handlers: [
         { type: 'SENT', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,
         { type: 'RECV', part: 'START_LINE', action: 'REVEAL' } satisfies Handler,
@@ -159,19 +165,50 @@ const onClick = async (): Promise<void> => {
   done(JSON.stringify(resp));
 };
 
-const expandUI = (): void => { setState('isMinimized', false); };
-const minimizeUI = (): void => { setState('isMinimized', true); };
+const expandUI = (): void => {
+  setState('isMinimized', false);
+};
+const minimizeUI = (): void => {
+  setState('isMinimized', true);
+};
 
 const proveProgressBar = (): DomJson[] => {
-  const progress = useState<{ step: string; progress: number; message: string } | null>('_proveProgress', null);
+  const progress = useState<{ step: string; progress: number; message: string } | null>(
+    '_proveProgress',
+    null,
+  );
   if (!progress) return [];
   const pct = `${Math.round(progress.progress * 100)}%`;
   return [
     div({ style: { marginTop: '12px' } }, [
-      div({ style: { height: '6px', backgroundColor: '#e5e7eb', borderRadius: '3px', overflow: 'hidden' } }, [
-        div({ style: { height: '100%', width: pct, background: 'linear-gradient(90deg, {COLOR1}, {COLOR2})', borderRadius: '3px', transition: 'width 0.4s ease' } }, []),
-      ]),
-      div({ style: { fontSize: '12px', color: '#6b7280', marginTop: '6px', textAlign: 'center' } }, [progress.message]),
+      div(
+        {
+          style: {
+            height: '6px',
+            backgroundColor: '#e5e7eb',
+            borderRadius: '3px',
+            overflow: 'hidden',
+          },
+        },
+        [
+          div(
+            {
+              style: {
+                height: '100%',
+                width: pct,
+                background: 'linear-gradient(90deg, {COLOR1}, {COLOR2})',
+                borderRadius: '3px',
+                transition: 'width 0.4s ease',
+              },
+            },
+            [],
+          ),
+        ],
+      ),
+      div(
+        { style: { fontSize: '12px', color: '#6b7280', marginTop: '6px', textAlign: 'center' } },
+        [progress.message],
+      ),
     ]),
   ];
 };
@@ -186,9 +223,7 @@ const main = (): DomJson => {
     const headers = useHeaders((h: InterceptedRequestHeader[]) =>
       h.filter((x) => x.url.startsWith(`https://${api}/`)),
     );
-    const cookie = headers
-      .flatMap((h) => h.requestHeaders)
-      .find((h) => h.name === 'Cookie')?.value;
+    const cookie = headers.flatMap((h) => h.requestHeaders).find((h) => h.name === 'Cookie')?.value;
     if (cookie) setState('cookie', cookie);
   }
 
@@ -199,45 +234,158 @@ const main = (): DomJson => {
   }, []);
 
   if (isMinimized) {
-    return div({
-      style: { position: 'fixed', bottom: '20px', right: '20px', width: '60px', height: '60px', borderRadius: '50%', backgroundColor: '{THEME_COLOR}', boxShadow: '0 4px 8px rgba(0,0,0,0.3)', zIndex: '999999', display: 'flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', transition: 'all 0.3s ease', fontSize: '24px', color: 'white' },
-      onclick: 'expandUI',
-    }, ['{EMOJI}']);
+    return div(
+      {
+        style: {
+          position: 'fixed',
+          bottom: '20px',
+          right: '20px',
+          width: '60px',
+          height: '60px',
+          borderRadius: '50%',
+          backgroundColor: '{THEME_COLOR}',
+          boxShadow: '0 4px 8px rgba(0,0,0,0.3)',
+          zIndex: '999999',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          cursor: 'pointer',
+          transition: 'all 0.3s ease',
+          fontSize: '24px',
+          color: 'white',
+        },
+        onclick: 'expandUI',
+      },
+      ['{EMOJI}'],
+    );
   }
 
-  return div({ style: { position: 'fixed', bottom: '0', right: '8px', width: '280px', borderRadius: '8px 8px 0 0', backgroundColor: 'white', boxShadow: '0 -2px 10px rgba(0,0,0,0.1)', zIndex: '999999', fontSize: '14px', fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif', overflow: 'hidden' } }, [
-    div({ style: { background: 'linear-gradient(135deg, {COLOR1} 0%, {COLOR2} 100%)', padding: '12px 16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', color: 'white' } }, [
-      div({ style: { fontWeight: '600', fontSize: '16px' } }, ['{Plugin Name}']),
-      button({ style: { background: 'transparent', border: 'none', color: 'white', fontSize: '20px', cursor: 'pointer', padding: '0', width: '24px', height: '24px', display: 'flex', alignItems: 'center', justifyContent: 'center' }, onclick: 'minimizeUI' }, ['\u2212']),
-    ]),
-    div({ style: { padding: '20px', backgroundColor: '#f8f9fa' } }, [
-      div({ style: { marginBottom: '16px', padding: '12px', borderRadius: '6px', backgroundColor: isConnected ? '#d4edda' : '#f8d7da', color: isConnected ? '#155724' : '#721c24', border: `1px solid ${isConnected ? '#c3e6cb' : '#f5c6cb'}`, fontWeight: '500' } }, [
-        isConnected ? '\u2713 Session detected' : '\u26A0 No session detected',
+  return div(
+    {
+      style: {
+        position: 'fixed',
+        bottom: '0',
+        right: '8px',
+        width: '280px',
+        borderRadius: '8px 8px 0 0',
+        backgroundColor: 'white',
+        boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
+        zIndex: '999999',
+        fontSize: '14px',
+        fontFamily:
+          '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+        overflow: 'hidden',
+      },
+    },
+    [
+      div(
+        {
+          style: {
+            background: 'linear-gradient(135deg, {COLOR1} 0%, {COLOR2} 100%)',
+            padding: '12px 16px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            color: 'white',
+          },
+        },
+        [
+          div({ style: { fontWeight: '600', fontSize: '16px' } }, ['{Plugin Name}']),
+          button(
+            {
+              style: {
+                background: 'transparent',
+                border: 'none',
+                color: 'white',
+                fontSize: '20px',
+                cursor: 'pointer',
+                padding: '0',
+                width: '24px',
+                height: '24px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              },
+              onclick: 'minimizeUI',
+            },
+            ['\u2212'],
+          ),
+        ],
+      ),
+      div({ style: { padding: '20px', backgroundColor: '#f8f9fa' } }, [
+        div(
+          {
+            style: {
+              marginBottom: '16px',
+              padding: '12px',
+              borderRadius: '6px',
+              backgroundColor: isConnected ? '#d4edda' : '#f8d7da',
+              color: isConnected ? '#155724' : '#721c24',
+              border: `1px solid ${isConnected ? '#c3e6cb' : '#f5c6cb'}`,
+              fontWeight: '500',
+            },
+          },
+          [isConnected ? '\u2713 Session detected' : '\u26A0 No session detected'],
+        ),
+        isConnected
+          ? button(
+              {
+                style: {
+                  width: '100%',
+                  padding: '12px 24px',
+                  borderRadius: '6px',
+                  border: 'none',
+                  background: 'linear-gradient(135deg, {COLOR1} 0%, {COLOR2} 100%)',
+                  color: 'white',
+                  fontWeight: '600',
+                  fontSize: '15px',
+                  transition: 'all 0.2s ease',
+                  boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+                  opacity: isRequestPending ? '0.5' : '1',
+                  cursor: isRequestPending ? 'not-allowed' : 'pointer',
+                },
+                onclick: 'onClick',
+              },
+              [isRequestPending ? 'Generating Proof...' : 'Generate Proof'],
+            )
+          : div(
+              {
+                style: {
+                  textAlign: 'center',
+                  color: '#666',
+                  padding: '12px',
+                  backgroundColor: '#fff3cd',
+                  borderRadius: '6px',
+                  border: '1px solid #ffeaa7',
+                },
+              },
+              ['Please login to {Service Name} to continue'],
+            ),
+        ...proveProgressBar(),
       ]),
-      isConnected
-        ? button({ style: { width: '100%', padding: '12px 24px', borderRadius: '6px', border: 'none', background: 'linear-gradient(135deg, {COLOR1} 0%, {COLOR2} 100%)', color: 'white', fontWeight: '600', fontSize: '15px', transition: 'all 0.2s ease', boxShadow: '0 2px 4px rgba(0,0,0,0.1)', opacity: isRequestPending ? '0.5' : '1', cursor: isRequestPending ? 'not-allowed' : 'pointer' }, onclick: 'onClick' }, [isRequestPending ? 'Generating Proof...' : 'Generate Proof'])
-        : div({ style: { textAlign: 'center', color: '#666', padding: '12px', backgroundColor: '#fff3cd', borderRadius: '6px', border: '1px solid #ffeaa7' } }, ['Please login to {Service Name} to continue']),
-      ...proveProgressBar(),
-    ]),
-  ]);
+    ],
+  );
 };
 
 export default { main, onClick, expandUI, minimizeUI, config };
 ```
 
-### Step 4: Build and verify
+### Step 4: Register the plugin
 
-Build the plugin with esbuild:
+Register it so both clients pick it up:
+
+1. Add an entry to `packages/plugins/src/registry.ts` (copy an existing entry's shape) and set `platforms` — `['demo', 'mobile']`, or a subset.
+2. Add the plugin id to the `plugins` array in `packages/plugins/build.js`.
+
+### Step 5: Build and verify
 
 ```bash
-npx esbuild {plugin_name}.plugin.ts --bundle --format=esm --outfile={plugin_name}.js \
-  --define:__VERIFIER_URL__='"http://localhost:7047"' \
-  --define:__PROXY_URL__='"ws://localhost:7047/proxy?token="'
+npm run build:plugins   # builds dist/demo + dist/mobile
 ```
 
-Test it in the extension's DevConsole (right-click → "Developer Console") by pasting the built JS.
+Then load the plugin in the demo (`npm run demo`). Keep plugin code browser-DOM-free so it also runs under React Native on mobile; `async`/`await` is fine (the mobile target is transpiled to `es2016`). See `PLUGIN.md` for details.
 
-### Step 5: Review for personal information
+### Step 6: Review for personal information
 
 Before committing, review ALL created/modified files to ensure no personal data (usernames, tokens, cookies, emails, IDs) leaked into the code.
 
@@ -245,18 +393,19 @@ Before committing, review ALL created/modified files to ensure no personal data 
 
 ### Auth interception strategies (by service type)
 
-| Auth Type | Example Plugins | Headers to Intercept | useHeaders Filter |
-|-----------|----------------|---------------------|-------------------|
-| Cookie only | Swiss Bank, Garmin | `Cookie` | Broad: any request to domain |
-| Bearer token | Spotify, Discord | `Authorization` | API requests to domain |
-| Cookie + CSRF | Uber, Garmin | `Cookie` + custom CSRF header | Broad for cookie, specific for CSRF |
-| Cookie + Bearer + CSRF | Twitter | `Cookie`, `authorization`, `x-csrf-token` | Specific API endpoint |
+| Auth Type              | Example Plugins    | Headers to Intercept                      | useHeaders Filter                   |
+| ---------------------- | ------------------ | ----------------------------------------- | ----------------------------------- |
+| Cookie only            | Swiss Bank, Garmin | `Cookie`                                  | Broad: any request to domain        |
+| Bearer token           | Spotify, Discord   | `Authorization`                           | API requests to domain              |
+| Cookie + CSRF          | Uber, Garmin       | `Cookie` + custom CSRF header             | Broad for cookie, specific for CSRF |
+| Cookie + Bearer + CSRF | Twitter            | `Cookie`, `authorization`, `x-csrf-token` | Specific API endpoint               |
 
 ### Race condition with header interception
 
 The `useHeaders()` hook only captures requests that happen AFTER the plugin's listener is active. If you open a page that loads all its data on initial render (SPA pattern), the API requests fire before interception is ready.
 
 **Solutions (from real plugins):**
+
 - **Garmin plugin**: Opens the home page (`connect.garmin.com/`) instead of the badges page, because the badges page fires its API call on load before interception is ready
 - **Garmin plugin**: Uses a broad URL filter (any request to domain) for cookies, and a separate specific filter for CSRF tokens that only appear on `/gc-api/` requests
 - **Spotify plugin**: Opens `developer.spotify.com` (not `api.spotify.com`) so the user's browsing generates API calls the plugin can intercept
@@ -285,7 +434,7 @@ const resp = await prove(
   {
     handlers: [
       { type: 'SENT', part: 'START_LINE', action: 'REVEAL' },
-      { type: 'SENT', part: 'BODY', action: 'REVEAL' },     // Reveals the GraphQL query
+      { type: 'SENT', part: 'BODY', action: 'REVEAL' }, // Reveals the GraphQL query
       { type: 'RECV', part: 'START_LINE', action: 'REVEAL' },
       { type: 'RECV', part: 'HEADERS', action: 'REVEAL', params: { key: 'date' } },
       { type: 'RECV', part: 'BODY', action: 'REVEAL', params: { type: 'json', path: 'data' } },
@@ -301,20 +450,16 @@ When different auth credentials appear on different types of requests, use separ
 ```typescript
 // Broad filter for cookies — catches page resource loads (JS, CSS, images)
 if (!cachedCookie) {
-  const headers = useHeaders((h) =>
-    h.filter((x) => x.url.startsWith(`https://${api}/`)),
-  );
-  const cookie = headers.flatMap((h) => h.requestHeaders)
-    .find((h) => h.name === 'Cookie')?.value;
+  const headers = useHeaders((h) => h.filter((x) => x.url.startsWith(`https://${api}/`)));
+  const cookie = headers.flatMap((h) => h.requestHeaders).find((h) => h.name === 'Cookie')?.value;
   if (cookie) setState('cookie', cookie);
 }
 
 // Specific filter for CSRF token — only sent with API calls
 if (!cachedCsrfToken) {
-  const apiHeaders = useHeaders((h) =>
-    h.filter((x) => x.url.startsWith(`https://${api}/gc-api/`)),
-  );
-  const csrfToken = apiHeaders.flatMap((h) => h.requestHeaders)
+  const apiHeaders = useHeaders((h) => h.filter((x) => x.url.startsWith(`https://${api}/gc-api/`)));
+  const csrfToken = apiHeaders
+    .flatMap((h) => h.requestHeaders)
     .find((h) => h.name === 'connect-csrf-token')?.value;
   if (csrfToken) setState('csrf-token', csrfToken);
 }
@@ -322,15 +467,15 @@ if (!cachedCsrfToken) {
 
 ### maxRecvData / maxSentData sizing guide
 
-| Plugin | Response Size | maxRecvData | maxSentData | Notes |
-|--------|-------------|-------------|-------------|-------|
-| Swiss Bank | ~200B | 460 | 180 | Tiny response, simple cookie |
-| Spotify | ~1.5KB | 2400 | 600 | Small JSON, Bearer token |
-| Discord Profile | ~1KB | 2500 | 1000 | Small JSON, Bearer token |
-| Twitter | ~3KB | 4000 | 2000 | Medium JSON, multiple auth headers |
-| Discord DM | ~5KB | 10000 | 2000 | Medium JSON, message content |
-| Uber | ~2KB | 16384 | 4096 | GraphQL POST, cookie auth |
-| Garmin | ~62KB | 70000 | 8192 | Large array, huge session cookie |
+| Plugin          | Response Size | maxRecvData | maxSentData | Notes                              |
+| --------------- | ------------- | ----------- | ----------- | ---------------------------------- |
+| Swiss Bank      | ~200B         | 460         | 180         | Tiny response, simple cookie       |
+| Spotify         | ~1.5KB        | 2400        | 600         | Small JSON, Bearer token           |
+| Discord Profile | ~1KB          | 2500        | 1000        | Small JSON, Bearer token           |
+| Twitter         | ~3KB          | 4000        | 2000        | Medium JSON, multiple auth headers |
+| Discord DM      | ~5KB          | 10000       | 2000        | Medium JSON, message content       |
+| Uber            | ~2KB          | 16384       | 4096        | GraphQL POST, cookie auth          |
+| Garmin          | ~62KB         | 70000       | 8192        | Large array, huge session cookie   |
 
 Large session cookies (e.g., Garmin's ~3KB `session` cookie) require higher `maxSentData`.
 
@@ -353,6 +498,6 @@ Connection: 'close',             // Clean TLS session termination
 ## Reference
 
 - Full plugin SDK docs: `PLUGIN.md` in repo root
-- Example plugins: `packages/demo/plugins/*.plugin.ts`
+- Example plugins: `packages/plugins/src/*.plugin.ts`
 - Plugin SDK types: `packages/plugin-sdk/src/types.ts`
 - Plugin SDK globals (available in sandbox): `packages/plugin-sdk/src/globals.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm install` - Install all dependencies for all packages and set up workspace links
 - `npm run dev` - Start extension development server on port 3000 (auto-builds dependencies)
 - `npm run build` - Build production extension (auto-builds dependencies first)
-- `npm run build:deps` - Build only dependencies (@tlsn/common and @tlsn/plugin-sdk)
+- `npm run build:deps` - Build only dependencies (@tlsn/common, @tlsn/plugin-sdk, @tlsn/plugins)
+- `npm run build:plugins` - Build only the shared plugins (@tlsn/plugins → dist/demo + dist/mobile)
 - `npm run build:extension` - Build only extension (assumes dependencies are built)
 - `npm run build:all` - Build all packages in monorepo
 - `npm run test` - Run tests for all packages
@@ -21,6 +22,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run tutorial` - Serve tutorial page on port 8080
 - `npm run docker:up` - Start demo Docker services (verifier + nginx)
 - `npm run docker:down` - Stop demo Docker services
+- `npm run mobile:ios` - Build deps + native libs and launch the mobile app on iOS
+- `npm run mobile:android` - Build deps + native libs and launch the mobile app on Android
 
 ### Extension Package Commands
 
@@ -48,6 +51,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run lint` - Run all linters (ESLint, Prettier, TypeScript)
 - `npm run lint:fix` - Auto-fix linting issues
 
+### Mobile App Commands (`app/mobile`)
+
+Run from `app/mobile/` (or use the `npm run mobile:*` root scripts):
+
+- `./build.sh ios` - Build JS deps + native libs and launch on iOS
+- `./build.sh android` - Build JS deps + native libs and launch on Android
+- `./build.sh --native` - Rebuild native libraries for both platforms
+- `./build.sh --help` - All options (`--no-run`, `--skip-deps`, `--rebuild-native`, `--clean`)
+- `npm run lint` / `npm run test` - Lint and test the mobile package
+
+The native prover lives in `packages/tlsn-mobile` (`build-ios.sh`, `build-android.sh`);
+`app/mobile/build.sh` invokes these automatically when artifacts are missing.
+
 ### Servers Workspace Commands (`servers/`)
 
 Cargo workspace containing all Rust deployables (verifier, swissbank). Run from
@@ -61,32 +77,43 @@ Cargo workspace containing all Rust deployables (verifier, swissbank). Run from
 
 ## Monorepo Architecture
 
-The project is organized as a monorepo with two top-level directories:
+The project ships **two TLSNotary clients** — the Chrome extension and the mobile
+app — that share one plugin system, one plugin registry (`@tlsn/plugins`), and the
+same verifier server. It is organized as a monorepo with three top-level workspaces:
 
 - **`packages/`** — npm workspaces (TypeScript projects):
-  - **`packages/common`**: Shared utilities (logging system) used by extension and plugin-sdk
-  - **`packages/extension`**: Chrome Extension (Manifest V3) for TLSNotary proof generation
-  - **`packages/plugin-sdk`**: SDK for developing and running TLSN plugins using QuickJS sandboxing
-  - **`packages/demo`**: Demo frontend with Docker setup and example plugins
+  - **`packages/common`**: Shared utilities (logging system) used across packages
+  - **`packages/extension`**: Chrome Extension (Manifest V3) — browser client
+  - **`packages/plugin-sdk`**: SDK for developing/running TLSN plugins using QuickJS sandboxing
+  - **`packages/plugins`**: Shared plugin sources + registry (`src/registry.ts`), built for demo (browser) and mobile (Hermes) targets
+  - **`packages/demo`**: Extension demo frontend with Docker setup
   - **`packages/tutorial`**: Tutorial examples for learning plugin development
+  - **`packages/eas-webhook`**: Demo service turning verifier webhooks into EAS attestations
+  - **`packages/tlsn-mobile`**: Native Rust prover for mobile (iOS `.xcframework` + Android `.so` via UniFFI)
+  - **`packages/tlsn-wasm`** / **`packages/tlsn-wasm-pkg`**: Local TLSN WebAssembly build helper + its (gitignored) output
+  - **`packages/ts-plugin-sample`**: Minimal TypeScript plugin sample
+- **`app/`** — npm workspaces (applications):
+  - **`app/mobile`**: React Native / Expo app (iOS + Android) — mobile client
 - **`servers/`** — Rust Cargo workspace (deployable servers):
   - **`servers/verifier`**: WebSocket server for TLSNotary verification (port 7047)
   - **`servers/swissbank`**: Fake Swiss bank with dashboard UI, used as a demo target (port 3000)
 
 **Build Dependencies:**
-The extension depends on `@tlsn/common` and `@tlsn/plugin-sdk`. These must be built before the extension:
+Both clients depend on `@tlsn/common`, `@tlsn/plugin-sdk`, and `@tlsn/plugins`. These must be built first:
 
 ```bash
 # From root - builds all dependencies automatically
-npm run dev
+npm run dev            # extension
+npm run mobile:ios     # mobile (also builds native libs)
 
 # Or manually build dependencies first
 cd packages/common && npm run build
 cd packages/plugin-sdk && npm run build
+cd packages/plugins && npm run build   # → dist/demo (browser) + dist/mobile (Hermes es2016)
 cd packages/extension && npm run dev
 ```
 
-**Important**: The extension must match the version of the notary server it connects to.
+**Important**: Each client must match the version of the notary/verifier server it connects to.
 
 ## Extension Architecture Overview
 
@@ -658,23 +685,34 @@ logger.setLevel(LogLevel.WARN);
 
 ## Creating New Plugins
 
-Use the Claude Code command `/create-plugin` to interactively build a new demo plugin. The command (defined in `.claude/commands/create-plugin.md`) guides you through:
+Use the Claude Code command `/create-plugin` to interactively build a new plugin. The command (defined in `.claude/commands/create-plugin.md`) guides you through:
 
 1. Researching the target API endpoint
 2. Planning auth interception strategy
-3. Creating the plugin source, build registration, and demo registry entry
+3. Creating the plugin source and registry entry
 4. Building and verifying the output
 
-For manual reference, see `PLUGIN.md` and the existing plugins in `packages/demo/plugins/`.
+For manual reference, see `PLUGIN.md` and the existing plugins in `packages/plugins/src/*.plugin.ts`.
 
-## Demo Package (`packages/demo`)
+## Shared Plugins Package (`packages/plugins`)
 
-Docker-based demo environment for testing plugins:
+Single source of truth for plugin code and metadata, consumed by **both** clients:
 
 **Files:**
 
-- `src/plugins/*.plugin.ts` - Plugin source files (TypeScript)
-- `public/plugins/*.js` - Built plugin files (generated by `build-plugins.js`)
+- `src/*.plugin.ts` - Plugin source files (TypeScript)
+- `src/registry.ts` - Shared registry; each entry declares `platforms: ('demo' | 'mobile')[]`
+- `build.js` - Builds two targets: `dist/demo/` (browser bundle for the extension) and `dist/mobile/` (Hermes-compatible `es2016`, no `async/await` in dynamically-evaluated code)
+
+Build with `npm run build:plugins` from the root.
+
+## Demo Package (`packages/demo`)
+
+Docker-based extension demo environment for testing plugins:
+
+**Files:**
+
+- Plugins come from `@tlsn/plugins` (`dist/demo/`) — not stored in this package
 - `docker-compose.yml` - Docker services configuration
 - `nginx.conf` - Reverse proxy configuration
 
@@ -701,6 +739,29 @@ npm run docker:up
 # Docker with custom verifier
 VITE_VERIFIER_HOST=verifier.example.com VITE_SSL=true docker compose up --build
 ```
+
+## Mobile App (`app/mobile`)
+
+React Native / Expo client (iOS + Android) with a native Rust prover. It runs the
+same `@tlsn/plugins` as the extension. See `app/mobile/README.md` for the full
+toolchain, build pipeline, and troubleshooting.
+
+**Plugin flow:**
+
+1. `PluginScreen` loads the plugin and starts `MobilePluginHost` (runs plugin JS)
+2. Plugin calls `openWindow()` → embedded `PluginWebView` opens the target site
+3. User logs in; plugin captures cookies/headers via `useHeaders()`
+4. Plugin calls `prove()` → `NativeProver` invokes the Rust prover via UniFFI (Swift on iOS, Kotlin on Android)
+5. Rust prover connects to the verifier over WebSocket and performs MPC-TLS
+
+**Key constraints:**
+
+- **Native modules** (`tlsn-native`, `quickjs-native`, cookies) mean Expo Go does not work — always use `expo run:ios` / `expo run:android` (via `build.sh`).
+- **Hermes** cannot parse `async/await` in dynamically-evaluated code (`new Function()`), so mobile plugins are compiled to `es2016` by `packages/plugins/build.js`. Rebuild with `npm run build:plugins` if you see "async functions are unsupported".
+- **Verifier URL**: the iOS simulator reaches `localhost:7047` directly; the Android emulator rewrites `localhost` to `10.0.2.2`. Point at a remote verifier by rebuilding plugins with `MOBILE_VERIFIER_URL`.
+- **Versioning**: mobile uses a 3-part `0.1.AABB` scheme (Apple rejects 4-part `CFBundleShortVersionString`); the extension stays 4-part `0.1.0.AABB`. See `app/mobile/RELEASING.md`.
+
+**Native prover (`packages/tlsn-mobile`):** Rust compiled to an iOS XCFramework and an Android `.so`, bridged via UniFFI. Rebuild only when changing the Rust code (`build-ios.sh` / `build-android.sh`, or `app/mobile/build.sh --native`).
 
 ## Important Implementation Notes
 

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -30,6 +30,24 @@ The TLSN Extension features a **secure plugin system** that allows developers to
 - ✅ **React-like Hooks** - Familiar patterns with `useEffect`, `useRequests`, `useHeaders`
 - ✅ **Type-Safe** - Full TypeScript support with declaration files
 
+### Cross-Platform: Extension and Mobile
+
+The same plugins run on **both** TLSNotary clients — the browser extension and the
+[mobile app](./app/mobile) (iOS + Android). Plugin sources and their shared registry live
+in [`packages/plugins`](./packages/plugins), which builds two targets:
+
+- **demo** (`dist/demo/`) — ESM bundles loaded by the extension, sandboxed in QuickJS WASM.
+- **mobile** (`dist/mobile/`) — bundles compiled to `es2016` and wrapped as a string the
+  mobile app evaluates with `new Function()` (sandboxed in native QuickJS).
+
+Write plugins normally in TypeScript; both targets are produced by `npm run build:plugins`.
+
+> **Mobile constraint (Hermes):** the mobile runtime evaluates plugin code dynamically, and
+> Hermes cannot parse `async`/`await` in dynamically-evaluated code. The mobile build
+> transpiles to `es2016` to handle this, so you can still author with `async`/`await` — just
+> rebuild with `npm run build:plugins` after changes. Avoid runtime-only APIs that assume a
+> browser DOM, since the same code must also run under React Native.
+
 ### Verifier Integration
 
 Plugins generate TLS proofs by communicating with a **verifier server** (see [VERIFIER.md](./VERIFIER.md) for implementation details). The verifier:

--- a/PLUGIN.md
+++ b/PLUGIN.md
@@ -38,7 +38,7 @@ in [`packages/plugins`](./packages/plugins), which builds two targets:
 
 - **demo** (`dist/demo/`) — ESM bundles loaded by the extension, sandboxed in QuickJS WASM.
 - **mobile** (`dist/mobile/`) — bundles compiled to `es2016` and wrapped as a string the
-  mobile app evaluates with `new Function()` (sandboxed in native QuickJS).
+  mobile app evaluates with `new Function()` under Hermes.
 
 Write plugins normally in TypeScript; both targets are produced by `npm run build:plugins`.
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,46 @@
 <img src="packages/extension/src/assets/img/icon-128.png" width="64"/>
 
-# TLSN Extension Monorepo
+# TLSNotary Apps & Plugin Tooling
 
-A Chrome Extension for TLSNotary with plugin SDK and verifier server.
+The TLSNotary clients — a **Chrome extension** and a native **mobile app** (iOS + Android) that generate cryptographic proofs of API responses — plus a plugin SDK, a shared plugin registry, and a verifier server.
+
+Built on the [TLSNotary protocol](https://github.com/tlsnotary/tlsn) (the core MPC-TLS Rust implementation lives in that repo; this repo consumes it via [`tlsn-wasm`](https://www.npmjs.com/package/tlsn-wasm) and the native mobile prover).
 
 > [!IMPORTANT]
-> When running the extension against a notary server, please ensure that the server's version is the same as the version of this extension.
+> When running a client against a notary/verifier server, ensure the server's version matches the version of the client.
 
 ## Table of Contents
 
+- [Clients](#clients)
 - [Demo](#demo)
 - [Tutorial](#tutorial)
 - [Monorepo Structure](#monorepo-structure)
 - [Architecture Overview](#architecture-overview)
 - [Getting Started](#getting-started)
 - [Development](#development)
-- [Production Build](#production-build)
+- [Production Build & Publishing](#production-build--publishing)
 - [End-to-End Testing](#end-to-end-testing)
 - [Websockify Integration](#websockify-integration)
-- [Publishing](#publishing)
+- [Building Plugins with Claude Code](#building-plugins-with-claude-code)
+- [Resources](#resources)
 - [License](#license)
+
+## Clients
+
+This monorepo ships **two TLSNotary clients** that share one plugin system, one plugin registry ([`@tlsn/plugins`](packages/plugins)), and the same verifier server:
+
+| Client                | Where                                      | Platforms               | Prover                                                                         |
+| --------------------- | ------------------------------------------ | ----------------------- | ------------------------------------------------------------------------------ |
+| **Browser extension** | [`packages/extension`](packages/extension) | Chrome / Chromium (MV3) | WASM (`tlsn-wasm`) in an offscreen document                                    |
+| **Mobile app**        | [`app/mobile`](app/mobile)                 | iOS + Android           | Native Rust prover ([`packages/tlsn-mobile`](packages/tlsn-mobile)) via UniFFI |
+
+Both run the same sandboxed JavaScript plugins (QuickJS on the extension, QuickJS/Hermes on mobile), capture auth from a logged-in session, and produce selectively-disclosed proofs against a [verifier server](servers/verifier).
 
 ## Demo
 
-Try TLSNotary live at **[demo.tlsnotary.org](https://demo.tlsnotary.org)**: just install the extension and run any of the bundled plugins against the hosted verifier.
+**Browser extension** — try TLSNotary live at **[demo.tlsnotary.org](https://demo.tlsnotary.org)**: install the extension and run any of the bundled plugins against the hosted verifier.
 
-To run the demo locally (verifier + demo site via Docker):
+To run the extension demo locally (verifier + demo site via Docker):
 
 ```bash
 npm run docker:up   # verifier on :7047, demo site on :80
@@ -38,9 +53,18 @@ Or serve just the demo site against your own verifier:
 npm run demo        # http://localhost:8080
 ```
 
+**Mobile app** — build and launch on a simulator/emulator or device:
+
+```bash
+npm run mobile:ios       # build deps + native libs + launch iOS
+npm run mobile:android   # build deps + native libs + launch Android
+```
+
+The mobile app presents a plugin gallery (Twitter, Swiss Bank, Spotify, Duolingo, Uber, Discord), lets the user log in via an embedded WebView, and generates proofs with the native prover. See [`app/mobile/README.md`](app/mobile/README.md) for the full toolchain and build pipeline.
+
 ### Environment Variables
 
-The demo uses `.env` files for configuration:
+The extension demo uses `.env` files for configuration:
 
 - `.env` - Local development defaults (`localhost:7047`)
 - `.env.production` - Production settings (`demo.tlsnotary.org`, SSL enabled)
@@ -55,6 +79,8 @@ npm run docker:up
 VITE_VERIFIER_HOST=verifier.example.com VITE_SSL=true docker compose up --build
 ```
 
+For the mobile app, point plugins at a remote verifier by rebuilding them with `MOBILE_VERIFIER_URL` (see [`app/mobile/README.md`](app/mobile/README.md#running-the-verifier)).
+
 ## Tutorial
 
 Want to write your own plugin? The [`tutorial`](packages/tutorial) package is an interactive 15-30 minute, hands-on walkthrough of building TLSNotary plugins — starting from a working Twitter plugin, then adapting it for a Swiss Bank balance proof (choosing what to reveal vs. redact). An optional "fool the verifier" challenge shows why careful server-side verification matters.
@@ -67,52 +93,33 @@ npm run tutorial
 
 ## Monorepo Structure
 
-This repository is organized as an npm workspaces monorepo with six main packages:
+This repository is an npm workspaces monorepo (`packages/*` and `app/*`) plus a Rust Cargo workspace (`servers/`):
 
 ```
 tlsn-extension/
-├── packages/
-│   ├── extension/           # Chrome Extension (Manifest V3)
-│   │   ├── src/
-│   │   │   ├── entries/
-│   │   │   │   ├── Background/     # Service worker for extension logic
-│   │   │   │   ├── Content/        # Content scripts injected into pages
-│   │   │   │   ├── Popup/          # Extension popup UI (optional)
-│   │   │   │   └── Offscreen/      # Offscreen document for DOM operations
-│   │   │   ├── manifest.json
-│   │   │   └── utils/
-│   │   ├── webpack.config.js
-│   │   └── package.json
-│   │
-│   ├── plugin-sdk/          # SDK for developing TLSN plugins
-│   │   ├── src/
-│   │   ├── examples/
-│   │   └── package.json
-│   │
+├── packages/                # npm workspaces (TypeScript)
+│   ├── extension/           # Chrome Extension (Manifest V3) — browser client
+│   ├── plugin-sdk/          # SDK for developing/running TLSN plugins (QuickJS sandbox)
+│   ├── plugins/             # Shared plugins + registry, built for demo (browser) and mobile (Hermes)
 │   ├── common/              # Shared utilities (logging system)
-│   │   ├── src/
-│   │   │   └── logger/           # Centralized logging with configurable levels
-│   │   └── package.json
-│   │
-│   ├── demo/                # Demo server with Docker setup
-│   │   ├── *.js                  # Example plugin files
-│   │   └── docker-compose.yml    # Docker services configuration
-│   │
-│   ├── tutorial/            # Tutorial examples
-│   │   └── *.js                  # Tutorial plugin files
-│   │
-│   └── tlsn-wasm/           # Local TLSN WebAssembly build (optional, gitignored)
-│       └── build.sh              # Builds `tlsn-wasm` into ../tlsn-wasm-pkg/
+│   ├── demo/                # Extension demo frontend + Docker setup
+│   ├── tutorial/            # Tutorial examples for plugin development
+│   ├── eas-webhook/         # Demo service: turns verifier webhooks into EAS attestations
+│   ├── tlsn-mobile/         # Native Rust prover for mobile (iOS .xcframework + Android .so via UniFFI)
+│   ├── tlsn-wasm/           # Local TLSN WebAssembly build helper (optional)
+│   ├── tlsn-wasm-pkg/       # Output of the local WASM build (gitignored)
+│   └── ts-plugin-sample/    # Minimal TypeScript plugin sample
+│
+├── app/                     # npm workspaces (applications)
+│   └── mobile/              # React Native / Expo app — iOS + Android client
+│       ├── app/             # Expo Router screens (plugin gallery + runner)
+│       ├── components/tlsn/ # WebView login, native prover bridge, plugin renderer
+│       ├── modules/         # Expo native modules: tlsn-native (prover), quickjs-native
+│       └── build.sh         # Unified build script (JS deps + native libs + run)
 │
 ├── servers/                 # Rust Cargo workspace (deployable servers)
-│   ├── Cargo.toml                # Workspace root
-│   ├── verifier/                 # WebSocket server for TLSNotary verification
-│   │   ├── src/main.rs           # Server setup, routing, and verification
-│   │   ├── config.yaml           # Webhook configuration
-│   │   └── Cargo.toml
-│   └── swissbank/                # Fake Swiss bank with dashboard UI (demo target)
-│       ├── src/
-│       └── Cargo.toml
+│   ├── verifier/            # WebSocket server for TLSNotary verification (:7047)
+│   └── swissbank/           # Fake Swiss bank with dashboard UI (demo target, :3000)
 │
 ├── package.json             # Root npm workspace configuration
 └── README.md
@@ -120,116 +127,121 @@ tlsn-extension/
 
 ### Package Details
 
-#### 1. **extension** - Chrome Extension (Manifest V3)
+#### `extension` — Chrome Extension (Manifest V3)
 
-A browser extension that enables TLSNotary functionality with the following key features:
+The browser client. Key features:
 
 - **Multi-Window Management**: Track multiple browser windows with request interception
 - **Request Interception**: Capture HTTP/HTTPS requests from managed windows
-- **Plugin Execution**: Run sandboxed JavaScript plugins using QuickJS
+- **Plugin Execution**: Run sandboxed JavaScript plugins using QuickJS (in an offscreen document)
 - **TLSN Overlay**: Visual display of intercepted requests
 
-**Key Entry Points:**
+Entry points: `Background` (service worker), `Content` (page injection + overlay), `Popup`, and `Offscreen` (DOM operations + WASM prover).
 
-- `Background`: Service worker for extension logic, window management, and message routing
-- `Content`: Scripts injected into pages for communication and overlay display
-- `Popup`: Optional extension popup UI
-- `Offscreen`: Background DOM operations for service worker limitations
+#### `app/mobile` — Mobile App (iOS + Android)
 
-#### 2. **plugin-sdk** - Plugin Development SDK
+React Native / Expo client with a native Rust prover. Key features:
 
-SDK for developing and running TLSN WebAssembly plugins with QuickJS sandboxing:
+- **Plugin gallery**: Select a plugin, log in via embedded WebView, generate a proof
+- **Native prover**: Rust ([`packages/tlsn-mobile`](packages/tlsn-mobile)) bridged via UniFFI — Swift/XCFramework on iOS, Kotlin/`.so` on Android
+- **Native QuickJS**: Vendored C sources in an Expo native module for plugin sandboxing
 
-- Secure JavaScript execution in isolated WebAssembly environment
+See [`app/mobile/README.md`](app/mobile/README.md) for prerequisites, the build pipeline, and architecture.
+
+#### `plugins` — Shared Plugins & Registry
+
+Single source of truth for plugin code and metadata, consumed by both clients:
+
+- Plugin sources in `src/*.plugin.ts` and a shared `src/registry.ts` (per-plugin `platforms: ('demo' | 'mobile')[]`)
+- `build.js` produces two targets: `dist/demo/` (browser bundle for the extension) and `dist/mobile/` (Hermes-compatible `es2016`, no `async/await` in dynamically-evaluated code)
+
+#### `plugin-sdk` — Plugin Development SDK
+
+SDK for developing and running TLSN plugins with QuickJS sandboxing:
+
+- Secure JavaScript execution in an isolated environment
 - Host capability system for controlled plugin access
 - React-like hooks: `useHeaders()`, `useRequests()`, `useEffect()`, `useState()`, `setState()`
-- Isomorphic package for Node.js and browser environments
-- TypeScript support with full type declarations
+- Isomorphic package for Node.js and browser environments, with full TypeScript declarations
 
-#### 3. **common** - Shared Utilities
+#### `common` — Shared Utilities
 
-Centralized logging system used across packages:
+Centralized logging system used across packages (`DEBUG`/`INFO`/`WARN`/`ERROR`, timestamped output, singleton).
 
-- Configurable log levels: `DEBUG`, `INFO`, `WARN`, `ERROR`
-- Timestamped output with level prefixes
-- Singleton pattern for consistent logging across modules
+#### `tlsn-mobile` — Native Mobile Prover
 
-#### 4. **verifier** - Verifier Server
+Rust prover compiled for mobile and bridged via UniFFI:
 
-Rust-based HTTP/WebSocket server for TLSNotary verification:
+- **iOS**: static library packaged as `TlsnMobile.xcframework` + Swift bindings (`build-ios.sh`)
+- **Android**: shared library `.so` + Kotlin bindings (`build-android.sh`)
 
-- Health check endpoint (`GET /health`)
-- Session creation endpoint (`WS /session`)
-- WebSocket verification endpoint (`WS /verifier?sessionId=<id>`)
-- WebSocket proxy endpoint (`WS /proxy?token=<host>`) - compatible with notary.pse.dev
-- Webhook API for POST notifications to external services
-- YAML configuration for webhook endpoints (`config.yaml`)
-- CORS enabled for cross-origin requests
+Built automatically by `app/mobile/build.sh`; only rebuild when changing the Rust code.
+
+#### `verifier` — Verifier Server (`servers/verifier`)
+
+Rust HTTP/WebSocket server for TLSNotary verification (shared by both clients):
+
+- `GET /health`, `WS /session`, `WS /verifier?sessionId=<id>`, `WS /proxy?token=<host>` (compatible with notary.pse.dev)
+- Webhook API for POST notifications, YAML config (`config.yaml`), CORS enabled
 - Runs on `localhost:7047` by default
 
-#### 5. **demo** - Demo Server
+#### `demo` — Extension Demo Frontend
 
-Docker-based demo environment with:
+React + Vite frontend (with Docker Compose: verifier + nginx) that drives the extension against the bundled plugins.
 
-- Pre-configured example plugins (Twitter, SwissBank)
-- React + Vite frontend with environment-based configuration
-- Docker Compose setup with verifier and nginx
-- Configurable verifier URLs via `.env` files or Docker build args
+#### `eas-webhook` — Demo Attestation Service
 
-#### 6. **tlsn-wasm** - TLSN WebAssembly (local build helper)
+Receives verifier webhooks and creates [EAS](https://attest.sh/) attestations on Sepolia testnet. Demo-only; see [`packages/eas-webhook/README.md`](packages/eas-webhook/README.md).
+
+#### `tlsn-wasm` — TLSN WebAssembly (local build helper)
 
 The extension depends on the published [`tlsn-wasm`](https://www.npmjs.com/package/tlsn-wasm) npm package by default. For local development against an unreleased `tlsn` revision, `packages/tlsn-wasm/build.sh` clones the `tlsn` repo and builds `packages/tlsn-wasm-pkg/` (gitignored). Run `npm link` from there and `npm link tlsn-wasm` inside `packages/extension` to override the published package.
 
 ## Architecture Overview
 
+Both clients run the same plugins and talk to the same verifier; they differ only in how the plugin sandbox and the prover are hosted.
+
 ### Extension Architecture
 
-The extension uses a message-passing architecture with five main entry points:
+The extension uses a message-passing architecture with five entry points:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     Browser Extension                         │
 │                                                               │
-│  ┌──────────────┐      ┌──────────────┐                      │
-│  │  Background  │◄────►│   Content    │◄──── Page Scripts    │
-│  │    (SW)      │      │   Script     │                      │
-│  └──────┬───────┘      └──────────────┘                      │
-│         │                                                     │
-│         ├─► Window Management (WindowManager)                │
-│         ├─► Request Interception (webRequest API)            │
-│         ├─► Session Management (SessionManager)              │
-│         └─► Message Routing                                  │
+│  ┌──────────────┐      ┌──────────────┐                       │
+│  │  Background  │◄────►│   Content    │◄──── Page Scripts      │
+│  │    (SW)      │      │   Script     │                        │
+│  └──────┬───────┘      └──────────────┘                       │
+│         │                                                      │
+│         ├─► Window Management (WindowManager)                  │
+│         ├─► Request Interception (webRequest API)             │
+│         ├─► Session Management (SessionManager)                │
+│         └─► Message Routing                                    │
 │                                                               │
-│  ┌──────────────┐                                            │
-│  │   Offscreen  │                                            │
-│  │  (Background)│                                            │
-│  └──────────────┘                                            │
+│  ┌──────────────┐                                             │
+│  │   Offscreen  │  ← QuickJS plugin sandbox + WASM prover      │
+│  └──────────────┘                                             │
 └─────────────────────────────────────────────────────────────┘
                           │
                           ▼
                    ┌──────────────┐
                    │   Verifier   │
-                   │    Server    │
                    │ (localhost:  │
                    │    7047)     │
                    └──────────────┘
 ```
 
-### Message Flow
-
-**Opening a Managed Window:**
+**Opening a managed window:**
 
 ```
 Page → window.tlsn.open(url)
   ↓ window.postMessage(TLSN_OPEN_WINDOW)
-Content Script → event listener
-  ↓ browser.runtime.sendMessage(OPEN_WINDOW)
-Background → WindowManager.registerWindow()
-  ↓ browser.windows.create()
-  ↓ Returns window info with UUID
+Content Script → browser.runtime.sendMessage(OPEN_WINDOW)
+Background → WindowManager.registerWindow() → browser.windows.create()
 ```
 
-**Request Interception:**
+**Request interception:**
 
 ```
 Browser → HTTP request in managed window
@@ -239,71 +251,78 @@ Background → WindowManager.addRequest()
 Content Script → Update TLSN overlay UI
 ```
 
+### Mobile Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                  Mobile App (Expo / RN, Hermes)               │
+│                                                                │
+│  PluginScreen ──► MobilePluginHost (runs plugin JS)           │
+│      │                  │                                       │
+│      │  openWindow()    │  prove()                             │
+│      ▼                  ▼                                       │
+│  PluginWebView      NativeProver ──► Rust prover (UniFFI)      │
+│  (login + cookie/   (Swift / Kotlin)   packages/tlsn-mobile   │
+│   header capture)                                              │
+└──────────────────────────────────────────────────────────────┘
+                          │ MPC-TLS over WebSocket
+                          ▼
+                   ┌──────────────┐
+                   │   Verifier   │  (localhost:7047;
+                   │              │   10.0.2.2 on Android emulator)
+                   └──────────────┘
+```
+
+See [`app/mobile/README.md`](app/mobile/README.md#architecture) for the full plugin flow and native-bridge details.
+
 ## Getting Started
 
-### Prerequisites
+### Common Prerequisites
 
 - **Node.js** >= 18
-- **Rust** (for verifier server) - Install from [rustup.rs](https://rustup.rs/)
+- **Rust** (for the verifier server and the native mobile prover) — install from [rustup.rs](https://rustup.rs/)
+
+### Extension Prerequisites
+
 - **Chrome/Chromium** browser
 
-### Installation
+### Mobile Prerequisites
 
-1. Clone the repository:
+- **iOS**: Xcode (+ iOS simulator), CocoaPods
+- **Android**: Android Studio (SDK, emulator, JDK) and the **Android NDK**
+- Expo / EAS tooling (used via `npx`)
+
+Rust cross-compilation targets, `cargo-ndk`, and the `tlsn` repo are auto-installed by `app/mobile/build.sh`. See [`app/mobile/README.md`](app/mobile/README.md#prerequisites) for the full tables and environment setup.
+
+### Installation
 
 ```bash
 git clone https://github.com/tlsnotary/tlsn-extension.git
 cd tlsn-extension
-```
-
-2. Install all dependencies:
-
-```bash
 npm install
 ```
 
-This installs dependencies for all packages in the monorepo and automatically sets up workspace links between packages.
+This installs dependencies for all workspaces and sets up package links.
 
 ## Development
 
-### Running the Extension in Development Mode
-
-1. Start the development server:
-
-```bash
-npm run dev
-```
-
-This automatically builds all dependencies (common, plugin-sdk) and then starts webpack-dev-server on port 3000 with hot module replacement. Files are written to `packages/extension/build/`.
-
-2. Load the extension in Chrome:
-   - Navigate to `chrome://extensions/`
-   - Enable "Developer mode" toggle (top right)
-   - Click "Load unpacked"
-   - Select the `packages/extension/build/` folder
-
-3. The extension will auto-reload on file changes (manual refresh needed for manifest changes).
-
 ### Running the Verifier Server
 
-The verifier server is required for E2E testing. Run it in a separate terminal:
+Both clients need a verifier. Run it in a separate terminal:
 
 ```bash
 cd servers
-cargo run -p tlsn-verifier-server
+cargo run -p tlsn-verifier-server   # http://localhost:7047
 ```
 
-The server will start on `http://localhost:7047`.
-
-**Verifier API Endpoints:**
+**Verifier API endpoints:**
 
 - `GET /health` - Health check
 - `WS /session` - Create new verification session
 - `WS /verifier?sessionId=<id>` - WebSocket verification endpoint
 - `WS /proxy?token=<host>` - WebSocket proxy for TLS connections (compatible with notary.pse.dev)
 
-**Webhook Configuration:**
-Configure `servers/verifier/config.yaml` to receive POST notifications after successful verifications:
+**Webhook configuration** — configure `servers/verifier/config.yaml` to receive POST notifications after successful verifications:
 
 ```yaml
 webhooks:
@@ -315,44 +334,61 @@ webhooks:
     url: 'https://your-backend.example.com/webhook/default'
 ```
 
-### Package-Specific Development
+### Extension Development
 
-**Extension:**
+```bash
+npm run dev   # builds deps, then webpack-dev-server on :3000 (HMR)
+```
+
+Then load it in Chrome:
+
+- Navigate to `chrome://extensions/`
+- Enable "Developer mode" (top right)
+- Click "Load unpacked" and select `packages/extension/build/`
+
+The extension auto-reloads on file changes (manual refresh needed for manifest changes).
+
+Package-specific scripts:
 
 ```bash
 cd packages/extension
-npm run dev              # Development mode
-npm run test             # Run tests
-npm run test:watch       # Watch mode
-npm run test:coverage    # Coverage report
-npm run lint             # Lint check
-npm run lint:fix         # Auto-fix linting issues
+npm run dev | test | test:watch | test:coverage | lint | lint:fix
 ```
 
-**Plugin SDK:**
+### Mobile Development
 
 ```bash
-cd packages/plugin-sdk
-npm run build            # Build SDK
-npm run test             # Run tests
-npm run lint             # Run all linters
-npm run lint:fix         # Auto-fix issues
+npm run mobile:ios       # build deps + native libs + launch iOS
+npm run mobile:android   # build deps + native libs + launch Android
 ```
 
-> **Note:** The plugin-SDK builds automatically when the extension is built, so manual building is usually not necessary.
-
-**Verifier:**
+Or run the full pipeline from `app/mobile/` with options (`--no-run`, `--skip-deps`, `--rebuild-native`, `--clean`):
 
 ```bash
-cd servers
-cargo run -p tlsn-verifier-server                # Development mode
-cargo build --release    # Production build
-cargo test               # Run tests
+cd app/mobile
+./build.sh ios
+./build.sh android
 ```
 
-## Production Build
+Notes:
 
-### Build Extension for Production
+- The verifier at `localhost:7047` is reachable as-is on the iOS simulator; on the Android emulator the app rewrites `localhost` to `10.0.2.2`.
+- The app uses native modules, so use `expo run:ios` / `expo run:android` (via `build.sh`) — **not** Expo Go.
+- Plugin code runs under Hermes, which can't parse `async/await` in dynamically-evaluated code; mobile plugins are compiled to `es2016`. If you see "async functions are unsupported", rebuild plugins: `npm run build:plugins`.
+
+See [`app/mobile/README.md`](app/mobile/README.md) for emulator clock sync, native logs, and troubleshooting.
+
+### Building Plugins
+
+Plugins live in [`packages/plugins`](packages/plugins) and are built for both clients:
+
+```bash
+npm run build:plugins   # writes dist/demo (browser) and dist/mobile (Hermes)
+```
+
+## Production Build & Publishing
+
+### Extension → Chrome Web Store
 
 From the repository root:
 
@@ -360,128 +396,76 @@ From the repository root:
 NODE_ENV=production npm run build
 ```
 
-This automatically:
+This builds dependencies, builds the extension with production optimizations, and creates `packages/extension/zip/extension-{version}.zip` (ready for the Chrome Web Store).
 
-1. Builds dependencies (`@tlsn/common` and `@tlsn/plugin-sdk`)
-2. Builds the extension with production optimizations
-3. Creates:
-   - Optimized build in `packages/extension/build/`
-   - Packaged extension in `packages/extension/zip/extension-{version}.zip`
+The easiest way to install the extension is from the [Chrome Web Store](https://chromewebstore.google.com/detail/tlsn-extension/gcfkkledipjbgdbimfpijgbkhajiaaph). For the full release process (versioning, CI, store upload), see [`RELEASING.md`](RELEASING.md).
 
-The zip file is ready for Chrome Web Store submission.
+### Mobile → App Store & Play Store
 
-**Alternative build commands:**
-
-- `npm run build:extension` - Build only the extension (assumes dependencies are built)
-- `npm run build:deps` - Build only the dependencies
-
-### Build All Packages
+Mobile builds and submissions run on **EAS** (Expo Application Services). In short:
 
 ```bash
-npm run build:all
+cd app/mobile
+npx eas-cli build  --profile production --platform all
+npx eas-cli submit --profile production --platform all
 ```
 
-This builds all packages in the monorepo (extension, plugin-sdk).
+For versioning (note the mobile-specific `0.1.AABB` scheme), credentials, and store promotion, see [`app/mobile/RELEASING.md`](app/mobile/RELEASING.md).
 
-### Build Verifier for Production
+### Build the Verifier for Production
 
 ```bash
 cd servers
-cargo build --release -p tlsn-verifier-server
+cargo build --release -p tlsn-verifier-server   # binary in servers/target/release/
 ```
-
-The binary will be in `servers/target/release/`.
 
 ## End-to-End Testing
 
-To test the complete TLSN workflow:
+To test the complete TLSN workflow with the **extension**:
 
-### 1. Start the Verifier Server
+1. **Start the verifier** and confirm it's up:
 
-In a terminal:
+   ```bash
+   cd servers && cargo run -p tlsn-verifier-server
+   curl http://localhost:7047/health   # → ok
+   ```
 
-```bash
-cd servers
-cargo run -p tlsn-verifier-server
-```
+2. **Start the extension** in dev mode (`npm run dev`) and load `packages/extension/build/` in Chrome.
 
-Verify it's running:
+3. **Run a test plugin** via the demo:
 
-```bash
-curl http://localhost:7047/health
-# Should return: ok
-```
+   ```bash
+   npm run demo   # http://localhost:8080
+   ```
 
-### 2. Start the Extension in Development Mode
+   Select a plugin; it opens a managed window to the target site, intercepts requests, connects to the verifier, shows a progress overlay, and runs the proof.
 
-In another terminal:
-
-```bash
-npm run dev
-```
-
-Load the extension in Chrome (see [Getting Started](#getting-started)).
-
-### 3. Run a Test Plugin
-
-Use the demo or tutorial packages to test plugins:
-
-```bash
-# Serve demo page
-npm run demo
-# Open http://localhost:8080 in your browser
-```
-
-1. Ensure the verifier is running on `localhost:7047`
-2. Select a plugin from the demo page
-3. The plugin will:
-   - Open a new window to the target site
-   - Intercept requests
-   - Create a prover connection to the verifier
-   - Display a UI overlay showing progress
-   - Execute the proof workflow
-
-### 4. Verify Request Interception
-
-When a managed window is opened:
-
-1. An overlay appears showing "TLSN Plugin In Progress"
-2. Intercepted requests are listed in real-time
-3. Request count updates as more requests are captured
+For the **mobile** end-to-end flow, start the verifier as above, then `npm run mobile:ios` / `npm run mobile:android` and run a plugin from the gallery.
 
 ### Testing Tips
 
-- **Monitor Background Service Worker**: Open Chrome DevTools for the background service worker via `chrome://extensions/` → Extension Details → "Inspect views: service worker"
-- **Check Console Logs**: Look for WindowManager logs, request interception logs, and message routing logs
-- **Test Multiple Windows**: Try opening multiple managed windows simultaneously (max 10)
-- **Verifier Connection**: Ensure verifier is accessible at `localhost:7047` before running proofs
+- **Background service worker logs**: `chrome://extensions/` → Extension Details → "Inspect views: service worker"
+- **Multiple windows**: the extension supports up to 10 concurrent managed windows
+- **Mobile native logs**: `xcrun simctl spawn booted log stream | grep -i tlsn` (iOS) or `adb logcat | grep -i tlsn` (Android)
+- **Verifier connection**: ensure the verifier is reachable before running proofs
 
 ## Websockify Integration
 
 For WebSocket proxying of TLS connections (optional):
 
-### Build Websockify Docker Image
-
 ```bash
 git clone https://github.com/novnc/websockify && cd websockify
 ./docker/build.sh
-```
 
-### Run Websockify
-
-```bash
 # For X.com
 docker run -it --rm -p 55688:80 novnc/websockify 80 api.x.com:443
-
-# For Twitter
-docker run -it --rm -p 55688:80 novnc/websockify 80 api.twitter.com:443
 ```
 
 This proxies HTTPS connections through WebSocket for browser-based TLS operations.
 
 ## Building Plugins with Claude Code
 
-This repo includes a [Claude Code](https://claude.ai/claude-code) slash command that scaffolds TLSNotary plugins interactively. It guides you through API discovery, auth interception strategy, and generates a complete plugin file.
+This repo includes a [Claude Code](https://claude.ai/claude-code) slash command that scaffolds TLSNotary plugins interactively — API discovery, auth interception strategy, and a complete plugin file added to [`packages/plugins`](packages/plugins) (usable by both clients).
 
 ### Install
 
@@ -501,40 +485,14 @@ This repo includes a [Claude Code](https://claude.ai/claude-code) slash command 
 /create-plugin GitHub contribution count
 ```
 
-The command will:
-
-1. Research the target service's API endpoints
-2. Plan the auth interception strategy
-3. Generate a complete plugin `.ts` file with UI, proof handlers, and progress bar
-4. Show you how to build and test it
-
-## Publishing
-
-### Chrome Web Store
-
-1. Create a production build:
-
-```bash
-NODE_ENV=production npm run build
-```
-
-2. Test the extension thoroughly
-
-3. Upload `packages/extension/zip/extension-{version}.zip` to [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
-
-4. Follow the [Chrome Web Store publishing guide](https://developer.chrome.com/webstore/publish)
-
-### Pre-built Extension
-
-The easiest way to install the TLSN browser extension is from the [Chrome Web Store](https://chromewebstore.google.com/detail/tlsn-extension/gcfkkledipjbgdbimfpijgbkhajiaaph).
+See [`PLUGIN.md`](PLUGIN.md) for the plugin architecture, capabilities, and authoring guide.
 
 ## Resources
 
 - [TLSNotary Documentation](https://docs.tlsnotary.org/)
-- [Webpack Documentation](https://webpack.js.org/concepts/)
-- [Chrome Extension Documentation](https://developer.chrome.com/docs/extensions/)
-- [Manifest V3 Migration Guide](https://developer.chrome.com/docs/extensions/mv3/intro/)
-- [webextension-polyfill](https://github.com/mozilla/webextension-polyfill)
+- [Chrome Extension Documentation](https://developer.chrome.com/docs/extensions/) · [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/) · [webextension-polyfill](https://github.com/mozilla/webextension-polyfill)
+- [Expo Documentation](https://docs.expo.dev/) · [React Native](https://reactnative.dev/) · [EAS Build](https://docs.expo.dev/build/introduction/)
+- [App Store Connect](https://appstoreconnect.apple.com/) · [Google Play Console](https://play.google.com/console)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This monorepo ships **two TLSNotary clients** that share one plugin system, one 
 | **Browser extension** | [`packages/extension`](packages/extension) | Chrome / Chromium (MV3) | WASM (`tlsn-wasm`) in an offscreen document                                    |
 | **Mobile app**        | [`app/mobile`](app/mobile)                 | iOS + Android           | Native Rust prover ([`packages/tlsn-mobile`](packages/tlsn-mobile)) via UniFFI |
 
-Both run the same sandboxed JavaScript plugins (QuickJS on the extension, QuickJS/Hermes on mobile), capture auth from a logged-in session, and produce selectively-disclosed proofs against a [verifier server](servers/verifier).
+Both run the same JavaScript plugins (sandboxed in QuickJS WASM on the extension; evaluated with `new Function()` under Hermes on mobile), capture auth from a logged-in session, and produce selectively-disclosed proofs against a [verifier server](servers/verifier).
 
 ## Demo
 
@@ -60,7 +60,7 @@ npm run mobile:ios       # build deps + native libs + launch iOS
 npm run mobile:android   # build deps + native libs + launch Android
 ```
 
-The mobile app presents a plugin gallery (Twitter, Swiss Bank, Spotify, Duolingo, Uber, Discord), lets the user log in via an embedded WebView, and generates proofs with the native prover. See [`app/mobile/README.md`](app/mobile/README.md) for the full toolchain and build pipeline.
+The mobile app presents a plugin gallery (Swiss Bank, Spotify, Duolingo, Discord — work-in-progress plugins appear behind the Debug toggle), lets the user log in via an embedded WebView, and generates proofs with the native prover. See [`app/mobile/README.md`](app/mobile/README.md) for the full toolchain and build pipeline.
 
 ### Environment Variables
 
@@ -144,7 +144,7 @@ React Native / Expo client with a native Rust prover. Key features:
 
 - **Plugin gallery**: Select a plugin, log in via embedded WebView, generate a proof
 - **Native prover**: Rust ([`packages/tlsn-mobile`](packages/tlsn-mobile)) bridged via UniFFI — Swift/XCFramework on iOS, Kotlin/`.so` on Android
-- **Native QuickJS**: Vendored C sources in an Expo native module for plugin sandboxing
+- **Plugin execution**: Plugin JS is evaluated with `new Function()` under Hermes via the plugin SDK's `NativeFunctionEvaluator` (a vendored native QuickJS module exists in `modules/quickjs-native` but is not currently in the plugin execution path)
 
 See [`app/mobile/README.md`](app/mobile/README.md) for prerequisites, the build pipeline, and architecture.
 
@@ -206,23 +206,23 @@ Both clients run the same plugins and talk to the same verifier; they differ onl
 The extension uses a message-passing architecture with five entry points:
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                     Browser Extension                         │
+┌───────────────────────────────────────────────────────────────┐
+│                       Browser Extension                       │
 │                                                               │
 │  ┌──────────────┐      ┌──────────────┐                       │
-│  │  Background  │◄────►│   Content    │◄──── Page Scripts      │
-│  │    (SW)      │      │   Script     │                        │
+│  │  Background  │◄────►│   Content    │◄──── Page Scripts     │
+│  │    (SW)      │      │   Script     │                       │
 │  └──────┬───────┘      └──────────────┘                       │
-│         │                                                      │
-│         ├─► Window Management (WindowManager)                  │
+│         │                                                     │
+│         ├─► Window Management (WindowManager)                 │
 │         ├─► Request Interception (webRequest API)             │
-│         ├─► Session Management (SessionManager)                │
-│         └─► Message Routing                                    │
+│         ├─► Session Management (SessionManager)               │
+│         └─► Message Routing                                   │
 │                                                               │
 │  ┌──────────────┐                                             │
-│  │   Offscreen  │  ← QuickJS plugin sandbox + WASM prover      │
+│  │   Offscreen  │  ← QuickJS plugin sandbox + WASM prover     │
 │  └──────────────┘                                             │
-└─────────────────────────────────────────────────────────────┘
+└───────────────────────────────────────────────────────────────┘
                           │
                           ▼
                    ┌──────────────┐
@@ -255,15 +255,15 @@ Content Script → Update TLSN overlay UI
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│                  Mobile App (Expo / RN, Hermes)               │
-│                                                                │
-│  PluginScreen ──► MobilePluginHost (runs plugin JS)           │
-│      │                  │                                       │
-│      │  openWindow()    │  prove()                             │
-│      ▼                  ▼                                       │
-│  PluginWebView      NativeProver ──► Rust prover (UniFFI)      │
-│  (login + cookie/   (Swift / Kotlin)   packages/tlsn-mobile   │
-│   header capture)                                              │
+│                Mobile App (Expo / RN, Hermes)                │
+│                                                              │
+│  PluginScreen ──► MobilePluginHost (runs plugin JS)          │
+│      │                  │                                    │
+│      │  openWindow()    │  prove()                           │
+│      ▼                  ▼                                    │
+│  PluginWebView      NativeProver ──► Rust prover (UniFFI)    │
+│  (login + cookie/   (Swift / Kotlin)   packages/tlsn-mobile  │
+│   header capture)                                            │
 └──────────────────────────────────────────────────────────────┘
                           │ MPC-TLS over WebSocket
                           ▼

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,12 @@
-# Releasing tlsn-extension
+# Releasing the browser extension
+
+This guide covers releasing the **Chrome extension** to the Chrome Web Store. For releasing
+the **mobile app** to the App Store and Play Store (EAS builds, the `0.1.AABB` version
+scheme, store submission), see [`app/mobile/RELEASING.md`](app/mobile/RELEASING.md).
 
 ## Version Scheme
 
-`0.1.0.AABB` — `AA` is the TLSNotary alpha version, `BB` is the extension release within that alpha (e.g., `0.1.0.1402` = alpha.14, release 02).
+`0.1.0.AABB` — `AA` is the TLSNotary alpha version, `BB` is the extension release within that alpha (e.g., `0.1.0.1402` = alpha.14, release 02). (The mobile app uses a separate 3-part `0.1.AABB` scheme because iOS rejects 4-part versions.)
 
 ## Prerequisites
 

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -2,7 +2,7 @@
 
 React Native/Expo mobile app for iOS and Android with native TLSNotary proof generation.
 
-The app features a plugin gallery where users can select from available plugins (Twitter, Swiss Bank, Spotify, Duolingo, Uber, Discord), log in via an embedded WebView, and generate cryptographic proofs of API responses using MPC-TLS.
+The app features a plugin gallery where users can select from available plugins (Swiss Bank, Spotify, Duolingo, Discord — work-in-progress plugins appear behind the Debug toggle), log in via an embedded WebView, and generate cryptographic proofs of API responses using MPC-TLS.
 
 ## Prerequisites
 

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -1,6 +1,11 @@
-This folder contains a basic demo for running TLSNotary plugins.
-The demo needs the TLSNotary extension to run the plugins in your browser.
+This folder contains a basic demo for running TLSNotary plugins **in the browser**.
+It needs the TLSNotary browser extension to run the plugins. (For the mobile
+equivalent, see the [mobile app](../../app/mobile/README.md), which has its own
+built-in plugin gallery and native prover.)
+
 In this demo, the plugins prove data from a server (e.g. Twitter). Of course you will also need the verifier counterpart. In this demo we will use the verifier server from the `servers/verifier` folder.
+
+The plugins themselves come from the shared [`@tlsn/plugins`](../plugins) package (the demo loads its `dist/demo/` build); they are not stored in this folder.
 
 Prerequisites:
 
@@ -16,9 +21,9 @@ To run this demo:
 
 ## 1. Install the browser extension
 
-### Install from the Google Web Store
+### Install from the Chrome Web Store
 
-TODO
+Install the published extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/tlsn-extension/gcfkkledipjbgdbimfpijgbkhajiaaph).
 
 ### Build from source
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -1,0 +1,70 @@
+# @tlsn/plugins
+
+Shared TLSNotary plugins and their registry — the **single source of truth** consumed
+by both clients: the browser extension (via [`packages/demo`](../demo)) and the
+[mobile app](../../app/mobile).
+
+A plugin logs the user into a service, captures auth (cookies/headers), calls an API
+endpoint through the TLS prover, and produces a selectively-disclosed proof of the
+response. See [`PLUGIN.md`](../../PLUGIN.md) for the authoring guide and capabilities.
+
+## Layout
+
+```
+packages/plugins/
+├── src/
+│   ├── *.plugin.ts     # Plugin sources (twitter, swissbank, spotify, duolingo, uber, discord, ...)
+│   └── registry.ts     # Shared metadata; each entry declares platforms: ('demo' | 'mobile')[]
+├── build.js            # esbuild bundler → dist/demo + dist/mobile
+└── dist/
+    ├── registry.js     # Compiled registry (tsc)
+    ├── demo/*.js       # ESM bundles for the browser extension
+    └── mobile/*.js     # Hermes-compatible string modules for the mobile app
+```
+
+The `registry.ts` `platforms` field controls where each plugin appears, and `debug: true`
+hides a work-in-progress plugin behind the mobile app's Debug mode (and adds a "WIP"
+badge on the demo).
+
+## Build
+
+```bash
+npm run build            # both targets (from this package) — runs build.js + tsc registry
+npm run build:demo       # demo target only
+npm run build:mobile     # mobile target only
+
+# From the repo root:
+npm run build:plugins
+```
+
+### Targets
+
+- **demo** (`dist/demo/*.js`): standard ESM bundles loaded by the extension demo. The
+  verifier/proxy URLs are baked in from `VITE_VERIFIER_HOST` / `VITE_SSL`.
+- **mobile** (`dist/mobile/*.js`): bundled with esbuild `target: 'es2016'` (Hermes cannot
+  parse `async/await` in dynamically-evaluated code), then wrapped as an exported string
+  constant (`<NAME>_PLUGIN_CODE`). The mobile app evaluates this string via `new Function()`
+  in `MobilePluginHost`. The verifier URL is baked in from `MOBILE_VERIFIER_URL`.
+
+### Environment variables
+
+| Variable              | Target | Default                 | Description                            |
+| --------------------- | ------ | ----------------------- | -------------------------------------- |
+| `VITE_VERIFIER_HOST`  | demo   | `localhost:7047`        | Verifier host                          |
+| `VITE_SSL`            | demo   | `false`                 | Use `https`/`wss`                      |
+| `MOBILE_VERIFIER_URL` | mobile | `http://localhost:7047` | Verifier URL baked into mobile plugins |
+
+```bash
+# Point mobile plugins at the public demo verifier
+MOBILE_VERIFIER_URL=https://demo.tlsnotary.org npm run build:plugins
+```
+
+## Adding a plugin
+
+Use the Claude Code command `/create-plugin` (see [`.claude/commands/create-plugin.md`](../../.claude/commands/create-plugin.md)),
+or manually:
+
+1. Add `src/<name>.plugin.ts`.
+2. Add an entry to `src/registry.ts` with the right `platforms`.
+3. Add the plugin id to the `plugins` array in `build.js`.
+4. `npm run build:plugins`.

--- a/packages/tlsn-mobile/README.md
+++ b/packages/tlsn-mobile/README.md
@@ -1,46 +1,64 @@
 # tlsn-mobile
 
-Native iOS library for TLSNotary proof generation using UniFFI bindings.
+Native library for TLSNotary proof generation on **iOS and Android**, exposed to the
+mobile app through UniFFI bindings (Swift on iOS, Kotlin on Android).
+
+> In normal development you do not run these scripts directly — `app/mobile/build.sh`
+> builds the native library automatically when the artifacts are missing (and
+> `app/mobile/build.sh --native` forces a rebuild). Use the scripts below only when
+> iterating on the Rust code in this package.
 
 ## Prerequisites
 
-- Rust with iOS targets:
+- Rust with the mobile targets:
   ```bash
-  rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+  rustup target add aarch64-apple-ios aarch64-apple-ios-sim   # iOS
+  rustup target add aarch64-linux-android                     # Android
   ```
-- Xcode with iOS SDK
+- **iOS**: Xcode with the iOS SDK
+- **Android**: Android NDK and `cargo-ndk` (`cargo install cargo-ndk`)
+
+Cross targets and `cargo-ndk` are installed automatically by `app/mobile/build.sh`.
 
 ## Building
+
+### iOS
 
 ```bash
 ./build-ios.sh
 ```
 
-This will:
-1. Build the Rust library for iOS device (`aarch64-apple-ios`)
-2. Build for iOS simulator (`aarch64-apple-ios-sim`)
-3. Generate Swift bindings via UniFFI
-4. Create an XCFramework combining both architectures
+This builds for device (`aarch64-apple-ios`) and simulator (`aarch64-apple-ios-sim`),
+generates Swift bindings via UniFFI, assembles `TlsnMobile.xcframework`, and copies the
+outputs into the Expo native module (`app/mobile/modules/tlsn-native/ios/`).
 
-Output files:
-- `target/TlsnMobile.xcframework` - Universal iOS framework
-- `target/swift/tlsn_mobile.swift` - Swift bindings
+Outputs:
 
-## Integration with Expo Module
+- `target/TlsnMobile.xcframework` — universal iOS framework
+- `target/swift/tlsn_mobile.swift` — Swift bindings
 
-After building, copy the outputs to the Expo native module:
+### Android
 
 ```bash
-cp target/swift/tlsn_mobile.swift ../mobile/modules/tlsn-native/ios/
-cp -r target/TlsnMobile.xcframework ../mobile/modules/tlsn-native/ios/
+./build-android.sh
 ```
 
-Then rebuild the iOS app:
+This builds the `arm64-v8a` shared library (`aarch64-linux-android`) with `cargo-ndk`,
+generates Kotlin bindings via UniFFI, strips the `.so`, and copies the outputs into the
+Expo native module (`app/mobile/modules/tlsn-native/android/`).
+
+Outputs:
+
+- `target/aarch64-linux-android/release/libtlsn_mobile.so` — shared library
+- `target/kotlin/uniffi/tlsn_mobile/tlsn_mobile.kt` — Kotlin bindings
+
+Both scripts copy their outputs directly into `app/mobile/modules/tlsn-native/`, so no
+manual copy step is needed. After a native rebuild, rebuild the app:
 
 ```bash
-cd ../mobile
+cd ../../app/mobile
 npx expo prebuild --clean
-npx expo run:ios
+npx expo run:ios      # or: npx expo run:android
 ```
 
 ## API
@@ -53,9 +71,11 @@ Call once at app startup:
 try initialize()
 ```
 
+(Kotlin: `initialize()`.)
+
 ### Prove
 
-Generate a TLS proof:
+Generate a TLS proof (Swift shown; the Kotlin API mirrors it):
 
 ```swift
 let request = HttpRequest(
@@ -79,23 +99,28 @@ let options = ProverOptions(
 let result = try prove(request: request, options: options)
 ```
 
+> On Android, the Expo Kotlin bridge cannot auto-convert nested JS objects, so the app
+> JSON-serializes these parameters on the JS side and parses them with `JSONObject` on
+> the Kotlin side. See `app/mobile/components/tlsn/NativeProver.tsx`.
+
 ### Selective Disclosure with Handlers
 
 Handlers control what data is revealed in the MPC proof:
 
-| Handler Type | Part | Description |
-|-------------|------|-------------|
-| `.sent` | `.startLine` | HTTP request line (method, path, version) |
-| `.sent` | `.headers` | Request headers (includes auth tokens!) |
-| `.sent` | `.body` | Request body |
-| `.recv` | `.startLine` | HTTP response status line |
-| `.recv` | `.headers` | Response headers |
-| `.recv` | `.body` | Response body |
-| `*` | `.all` | Entire message |
+| Handler Type | Part         | Description                               |
+| ------------ | ------------ | ----------------------------------------- |
+| `.sent`      | `.startLine` | HTTP request line (method, path, version) |
+| `.sent`      | `.headers`   | Request headers (includes auth tokens!)   |
+| `.sent`      | `.body`      | Request body                              |
+| `.recv`      | `.startLine` | HTTP response status line                 |
+| `.recv`      | `.headers`   | Response headers                          |
+| `.recv`      | `.body`      | Response body                             |
+| `*`          | `.all`       | Entire message                            |
 
-**Important**: If you don't specify any SENT handlers, the entire request (including authorization headers) will be redacted in the proof.
+**Important**: If you don't specify any SENT handlers, the entire request (including
+authorization headers) will be redacted in the proof.
 
-Example - reveal only response, redact request:
+Example — reveal only the response, redact the request:
 
 ```swift
 let handlers = [


### PR DESCRIPTION
The repo now ships **two TLSNotary clients** — the Chrome extension and a native iOS/Android app — but the docs described only the extension. This documents the mobile platform and fixes drift from the move to the shared `@tlsn/plugins` package.

## Changes

- **README** — retitled to **TLSNotary Apps & Plugin Tooling** (the MPC-TLS protocol lives in the separate [`tlsn`](https://github.com/tlsnotary/tlsn) repo, so "TLSNotary Monorepo" overclaimed). Full multi-platform rewrite: mobile demo/dev/build/publish sections, refreshed structure tree (now includes `app/mobile`, `packages/plugins`, `tlsn-mobile`, `eas-webhook`, …), and a mobile architecture diagram.
- **CLAUDE.md** — added mobile commands and a mobile architecture section; fixed the package list and the plugin source location (now `@tlsn/plugins`, not `packages/demo`).
- **PLUGIN.md** — plugins run on both clients; documented the Hermes/`es2016` mobile constraint.
- **.claude/commands/create-plugin.md** — scaffold into `packages/plugins/src` + `registry.ts`, build via `npm run build:plugins` (was a stale one-off esbuild path).
- **packages/plugins/README.md** — new; documents the dual `dist/demo` + `dist/mobile` build.
- **packages/tlsn-mobile/README.md** — documents the Android build (was iOS-only).
- **packages/demo/README.md** — scoped to the extension, links the mobile app, fixed store link + plugin source.
- **RELEASING.md** — cross-links the mobile release guide (`app/mobile/RELEASING.md`).

## Notes

- The GitHub repo **description and topics** were also updated (live) to reflect extension + mobile.
- The large line count on `create-plugin.md` is mostly the Prettier hook reflowing existing embedded code examples — no content lost; the actual edit is small.
- Docs-only; Prettier-clean; all relative links verified.