### PR TITLE
chore(mobile): version 0.1.1501

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -18,6 +18,10 @@ bin/
 build
 # TLSN submodule in tlsn-wasm
 packages/tlsn-wasm/tlsn/
+# Local WASM build output (populated by `npm run build:wasm`); matches the
+# `packages/*` workspace glob but has no lockfile entry, so including it
+# breaks `npm ci` on the EAS worker
+packages/tlsn-wasm-pkg/
 zip
 .vscode
 .claude/*

--- a/app/mobile/RELEASING.md
+++ b/app/mobile/RELEASING.md
@@ -41,6 +41,15 @@ Edit [app.json](app.json):
 
 Only edit the user-facing `version` string — iOS `buildNumber` and Android `versionCode` are auto-bumped by EAS via `autoIncrement` on the production profile (see [One-time setup](#one-time-setup)).
 
+**Also sync the native iOS project.** The build archive includes your local `ios/` directory (gitignored, but not excluded by `.easignore`), and when an `ios/` directory is present EAS builds it as a bare project and ignores `app.json`'s version. If you skip this, the build ships the previous version:
+
+```bash
+cd app/mobile
+plutil -replace CFBundleShortVersionString -string "0.1.XXXX" ios/TLSNotaryMobile/Info.plist
+```
+
+(or regenerate the native project with `npx expo prebuild --platform ios --no-install`). Android has no local `android/` directory, so it picks up `app.json` automatically.
+
 ### 2. Commit the version bump
 
 ```bash

--- a/app/mobile/app.json
+++ b/app/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "TLSNotary Mobile",
     "slug": "tlsn-mobile",
-    "version": "0.1.1500",
+    "version": "0.1.1501",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "tlsn-mobile",

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -45,6 +45,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6763331949"
+      }
+    }
   }
 }


### PR DESCRIPTION
Bumps the mobile app version to `0.1.1501` (alpha.15, mobile release 01) for the next TestFlight build.

iOS `buildNumber` / Android `versionCode` are auto-incremented by EAS (`autoIncrement` on the production profile), so only the user-facing version string changes.

Per [RELEASING.md](app/mobile/RELEASING.md).