### PR TITLE
feat(skills): canonical TLSN dev-onboarding skills (umbrella + focused)

### DIFF
--- a/skills/build-tlsn-host/SKILL.md
+++ b/skills/build-tlsn-host/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: build-tlsn-host
+description: Scaffold a TLSNotary host app on CLI, React Native, or browser extension. Use when the user asks to build, integrate, or add TLSNotary to a new project — including phrases like "add TLSN to my Expo app", "build a TLSN browser extension", "run TLSN plugins from a CLI", or any time the work involves writing a new consumer of the @tlsn/host-* adapter packages.
+---
+
+# Scaffold a TLSNotary host app
+
+Help a developer build a new application that embeds TLSNotary — a CLI tool, a React Native mobile app, or a browser extension — by scaffolding the right files and wiring them to the appropriate `@tlsn/host-*` adapter.
+
+## Arguments
+
+`$ARGUMENTS` may specify the target platform (`cli`, `react-native`, `extension`) and/or the dev's starting directory. If neither is provided, ask.
+
+## Process
+
+### Step 1: Pick the platform
+
+Detect first; ask only if ambiguous.
+
+| If you see… | Pick |
+|---|---|
+| `package.json` with `"react-native"` or `"expo"` | `react-native` |
+| `manifest.json` with `"manifest_version"` | `extension` |
+| A plain Node `package.json` with `"type": "module"` or no `package.json` at all | `cli` |
+| Multiple of the above | Ask the user which to scaffold |
+
+> **Current status:** `cli` (`@tlsn/host-cli`), `react-native` (`@tlsn/host-react-native`), and `extension` (`@tlsn/host-extension`) adapters are all published.
+
+### Step 2: Pick a starter plugin
+
+Ask the user which plugin they want to run as their first proof. Surface the list from `@tlsn/plugins`:
+
+```
+swissbank        — Swiss bank balance proof (recommended; works against the dev verifier with no real auth)
+twitter          — X/Twitter profile screen_name
+swissbank_hash   — Same as swissbank, with a hash commitment
+spotify          — Spotify top artist
+duolingo         — Duolingo streak
+discord_profile  — Discord username
+discord_dm       — Discord DM (requires real Discord auth)
+uber             — Uber rider profile
+idme             — ID.me credentials
+```
+
+Default to `swissbank` if the user is just exploring — it works against the local dev verifier without requiring real credentials.
+
+### Step 3: Confirm the verifier URL
+
+By default the CLI talks to `http://localhost:7047` (the verifier from `servers/verifier`). If the user has it running on a different host/port, ask. If they don't have a verifier running, point them at `cargo run -p tlsn-verifier-server` from the monorepo root.
+
+### Step 4: Scaffold the project
+
+For the **`cli`** platform, write these files into the target directory:
+
+#### `package.json`
+
+```json
+{
+  "name": "<their-project-name>",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "prove": "tlsn-cli run <plugin-id> --verifier http://localhost:7047",
+    "prove:auto": "tlsn-cli run <plugin-id> --verifier http://localhost:7047 --auto-approve"
+  },
+  "dependencies": {
+    "@tlsn/host-cli": "^0.1.0",
+    "@tlsn/plugins": "^0.1.0"
+  }
+}
+```
+
+For the **`react-native`** platform, you scaffold against a fresh Expo app. The lift here is more involved than CLI because RN needs native modules linked. Walk the dev through:
+
+#### 4a. Bootstrap the Expo app (if they don't have one)
+
+```bash
+npx create-expo-app@latest my-tlsn-app --template
+cd my-tlsn-app
+```
+
+#### 4b. Install host-react-native + peer deps
+
+```bash
+npx expo install react-native-webview @react-native-cookies/cookies
+npm install @tlsn/host-react-native @tlsn/plugins
+```
+
+#### 4c. Wire the native modules
+
+`@tlsn/host-react-native`'s NativeProver / MobilePluginHost expect a `tlsn-native` Expo module to be installed. Until the Phase 3 standalone npm package ships, point the dev at the tlsn-extension monorepo:
+
+```bash
+# Option A — git submodule
+git submodule add https://github.com/tlsnotary/tlsn-extension vendor/tlsn-extension
+ln -s ../../vendor/tlsn-extension/app/mobile/modules/tlsn-native modules/tlsn-native
+ln -s ../../vendor/tlsn-extension/app/mobile/modules/quickjs-native modules/quickjs-native
+
+# Then in package.json deps:
+#   "tlsn-native": "file:./modules/tlsn-native",
+#   "quickjs-native": "file:./modules/quickjs-native",
+
+# Build the Rust prover once:
+cd vendor/tlsn-extension/app/mobile && ./build.sh ios --skip-deps --no-run
+```
+
+#### 4d. Scaffold the runner screen
+
+Drop a starter `PluginRunnerScreen.tsx` that wires the package's primitives. The dev owns the styling and the approval-sheet UI; the package provides the protocol/IO plumbing.
+
+```typescript
+// src/screens/PluginRunnerScreen.tsx
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { View, Text } from 'react-native';
+import {
+  MobilePluginHost,
+  PluginRenderer,
+  PluginWebView,
+  NativeProver,
+  type NativeProverHandle,
+  type ApprovalMode,
+  type PluginConfig,
+  type DomJson,
+  type EventEmitter,
+  type WindowMessage,
+} from '@tlsn/host-react-native';
+
+export function PluginRunnerScreen({ pluginCode, pluginConfig }: {
+  pluginCode: string;
+  pluginConfig: PluginConfig;
+}) {
+  // ...wire MobilePluginHost ↔ NativeProver ↔ PluginWebView ↔ PluginRenderer
+  // ...show your own ApprovalSheet / RevealApprovalSheet
+  // ...call onComplete with the proof
+}
+```
+
+For a fuller worked example, point the dev at `app/mobile/components/tlsn/PluginScreen.tsx` in the tlsn-extension repo — that's the reference consumer for the same package.
+
+For the **`extension`** platform, you scaffold a Manifest-V3 Chrome extension with the four required entry points wired to `@tlsn/host-extension`.
+
+#### 4a. Bootstrap
+
+```bash
+mkdir my-tlsn-extension && cd my-tlsn-extension
+npm init -y
+npm install @tlsn/host-extension @tlsn/plugin-sdk @tlsn/plugins comlink webextension-polyfill tlsn-wasm
+npm install --save-dev webpack webpack-cli ts-loader typescript copy-webpack-plugin html-webpack-plugin
+```
+
+#### 4b. Minimum `manifest.json`
+
+```json
+{
+  "manifest_version": 3,
+  "name": "My TLSN Extension",
+  "version": "0.1.0",
+  "permissions": [
+    "offscreen",
+    "webRequest",
+    "storage",
+    "activeTab",
+    "tabs",
+    "windows"
+  ],
+  "host_permissions": ["<all_urls>"],
+  "background": { "service_worker": "background.bundle.js", "type": "module" },
+  "content_scripts": [
+    { "matches": ["http://*/*", "https://*/*"], "js": ["contentScript.bundle.js"] }
+  ],
+  "web_accessible_resources": [
+    { "resources": ["content.bundle.js", "icons/*"], "matches": ["<all_urls>"] }
+  ],
+  "action": { "default_popup": "popup.html" },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  }
+}
+```
+
+#### 4c. Background entry — `src/background.ts`
+
+```typescript
+import browser from 'webextension-polyfill';
+import {
+  WindowManager,
+  installRequestInterceptor,
+  confirmationManager,
+} from '@tlsn/host-extension/background';
+
+const windowManager = new WindowManager();
+installRequestInterceptor({ windowManager });
+
+browser.runtime.onMessage.addListener(async (msg, sender) => {
+  // … route OPEN_WINDOW / CLOSE_WINDOW / EXEC_CODE / RENDER_PLUGIN_UI / PLUGIN_CONFIRM_RESPONSE
+  // (mirror packages/extension/src/entries/Background/index.ts as the reference)
+});
+```
+
+#### 4d. Content script — `src/content.ts`
+
+```typescript
+import browser from 'webextension-polyfill';
+import { renderPluginUI } from '@tlsn/host-extension/content';
+import type { ContentMessage } from '@tlsn/host-extension/types';
+
+browser.runtime.onMessage.addListener((msg: unknown) => {
+  const req = msg as ContentMessage;
+  if (req.type === 'RENDER_PLUGIN_UI') {
+    renderPluginUI(req.json, req.windowId, {
+      onPluginAction: (onclick, windowId) =>
+        browser.runtime.sendMessage({ type: 'PLUGIN_UI_CLICK', onclick, windowId }),
+    });
+  }
+});
+```
+
+#### 4e. Offscreen entry — `src/offscreen.ts`
+
+```typescript
+import browser from 'webextension-polyfill';
+import { SessionManager } from '@tlsn/host-extension/offscreen';
+
+const sessionManager = new SessionManager();
+browser.runtime.onMessage.addListener(async (msg) => {
+  // route GET_PLUGIN_STATS_OFFSCREEN / EXEC_CODE_OFFSCREEN to sessionManager
+  // (mirror packages/extension/src/entries/Offscreen/index.tsx)
+});
+```
+
+#### 4f. Approval popup — `src/confirm-popup.tsx`
+
+The popup is opened by `confirmationManager.requestConfirmation()`; the dev writes the React shell (plugin name, requests list, three buttons). See `packages/extension/src/entries/ConfirmPopup/index.tsx` for the reference layout.
+
+For a fuller worked example, point the dev at `packages/extension/src/entries/Background/index.ts` in the tlsn-extension repo — that's the reference consumer for `@tlsn/host-extension`.
+
+If the developer wants to write their own JS driver instead of using the bin, also scaffold:
+
+#### `run.ts` (optional, for programmatic use)
+
+```typescript
+import { createCliAdapter } from '@tlsn/host-cli';
+import { PluginEventEmitter } from '@tlsn/host-cli/event-emitter';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const registry = require('@tlsn/plugins/dist/registry.js');
+const plugin = registry.PLUGIN_REGISTRY.find((p) => p.id === '<plugin-id>');
+const code = readFileSync(require.resolve(`@tlsn/plugins/dist/demo/${plugin.id}.js`), 'utf8');
+
+const adapter = await createCliAdapter({ mode: 'capture' });
+try {
+  const mode = await adapter.approval.requestPluginApproval({
+    config: plugin.pluginConfig,
+    source: code,
+  });
+  if (mode === 'rejected') process.exit(1);
+
+  const host = await adapter.createHost({
+    verifierUrl: 'http://localhost:7047',
+    proxyUrl: '',
+    approvalMode: mode,
+    pluginConfig: plugin.pluginConfig,
+  });
+
+  const result = await host.executePlugin(code, { eventEmitter: new PluginEventEmitter() });
+  console.log(result);
+} finally {
+  await adapter.dispose();
+}
+```
+
+### Step 5: Install + sanity-check
+
+```bash
+cd <their-project-dir>
+npm install
+npx playwright install chromium    # First-time browser fetch
+npm run prove
+```
+
+Tell the dev what to expect:
+
+1. A Chromium window opens pointed at the plugin's target host (e.g. `swissbank.tlsnotary.org`).
+2. They sign in (if needed) and click around — the extension captures auth headers in the background.
+3. The CLI prompts them to approve the proof (`all-session`, `manual`, or `reject`).
+4. If approved, the CLI calls `prove()` and prints the resulting proof JSON to stdout.
+
+**Heads-up — Rust prover binary.** `@tlsn/host-cli` ships a `RustProverClient` that spawns a separate `tlsn-prover` binary built from `packages/tlsn-mobile/`. From the monorepo:
+
+```bash
+cd packages/tlsn-mobile && cargo build --bin tlsn-prover --release
+```
+
+`createCliAdapter` auto-detects the binary in `packages/tlsn-mobile/target/release/tlsn-prover` (or via the `TLSN_PROVER_BIN` env var) and uses the Rust prover by default. If neither is found, it falls back to the `NullProverClient` stub that returns `{ stub: true, ... }` — so plugins still run end-to-end for UI / approval / interception testing without needing the binary.
+
+### Step 6: Tell them where to go next
+
+- **Customize approval UX**: `adapter.approval` is a `ClackApprovalUi` by default. They can replace it with their own via the `approval` option to `createCliAdapter`.
+- **Write a CI-friendly headless run**: `tlsn-cli session save https://swissbank.tlsnotary.org` first to bake in cookies, then `tlsn-cli run swissbank --headless --storage-state ~/.tlsn/sessions/session.json --auto-approve`.
+- **Write a custom plugin**: invoke `/create-plugin` (the existing skill) — its output drops into `packages/plugins/src/` and is auto-discovered.
+- **Switch platforms later**: the same plugin code runs unchanged on CLI / React Native / browser extension — only the adapter swaps.
+
+## Reference: what each adapter contract does
+
+So the dev knows where to plug in:
+
+| Contract | CLI impl | Mobile impl (future) | Extension impl (future) |
+|---|---|---|---|
+| `WindowManager` | Playwright `BrowserContext.newPage()` | `react-native-webview` source-change | `chrome.windows.create` |
+| `RequestInterceptor` | `page.route('**/*', …)` | Injected JS wrapping `fetch`/`XHR` + `@react-native-cookies/cookies` | `webRequest.onBeforeRequest` + `extraHeaders` |
+| `ProverClient` | Spawns the Rust prover binary (stub for now) | tlsn-native (uniffi) Expo module | tlsn-wasm in offscreen document |
+| `PluginRenderer` | JSON pretty-print to stdout (or `ink` TUI) | `<PluginRenderer>` over RN primitives | DOM elements in content script |
+| `ApprovalUi` | `@clack/prompts` (or `--auto-approve`) | `PluginApprovalSheet` + `RevealApprovalSheet` bottom sheets | Approval modal in content script + Options strict-mode |
+
+## Notes
+
+- The CLI deliberately doesn't constrain UI — the dev owns their approval prompts, renderer, theming. The adapter ships defaults; replace any of them via `createCliAdapter({ approval, renderer, prover })`.
+- The `--auto-approve` flag is for trusted CI / first-run smoke tests. **Don't** ship it into a user-facing wrapper.
+- A session captured via `session save` is just a Playwright `storageState` JSON. Treat it as sensitive — it contains the user's cookies.
+- If the verifier isn't running, the CLI will hang at the prove step. Tell the user to check `cargo run -p tlsn-verifier-server` is up.

--- a/skills/create-plugin/SKILL.md
+++ b/skills/create-plugin/SKILL.md
@@ -1,4 +1,9 @@
-# Create a TLSNotary Extension Plugin
+---
+name: create-plugin
+description: Create a TLSNotary plugin — sandboxed JavaScript that targets a web API, intercepts the user's auth, and produces a selective-disclosure proof. Use when the user asks to author a new TLSN plugin, prove data from a specific web service (e.g. Twitter, Spotify, a bank), or add a plugin to the demo gallery.
+---
+
+# Create a TLSNotary plugin
 
 Build a new demo plugin that proves data from a web service using TLSNotary.
 

--- a/skills/tlsnotary/SKILL.md
+++ b/skills/tlsnotary/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: tlsnotary
+description: Orient developers integrating TLSNotary into an app, browser extension, or web-service plugin. Use when the user asks how TLSNotary works, what TLSN packages exist, what the difference is between a plugin and a host, which integration path to pick, or any open question about adding TLSN to their own project — before routing them to the focused build-tlsn-host or create-plugin skills.
+---
+
+# TLSNotary — developer entry point
+
+TLSNotary is a protocol for producing **cryptographic proofs of HTTPS traffic** that selectively reveal only the data the user wants to disclose. A user can prove "I have a Spotify account with these top artists" to a third-party verifier without handing over their session cookie or the full response body. The verifier is convinced the data really came from `api.spotify.com` because the proof commits to the TLS transcript itself.
+
+This monorepo ships **everything a developer needs to add TLSNotary to a real product**: the protocol core, the contract that every platform adapter implements, three reference adapters (CLI, React Native, browser extension), a reference mobile app, the existing TLSN browser extension, and a Claude Code skill that scaffolds new consumers.
+
+There are **three paths** a developer typically takes — pick whichever matches the work.
+
+## 1 — Build a plugin
+
+A plugin is sandboxed JavaScript that targets a specific web API, intercepts the user's auth, calls `prove()`, and emits a proof. Plugins are platform-agnostic: the same plugin runs on the browser extension, the mobile app, and the CLI.
+
+- **When to pick this:** you want to prove data from a specific website or API (Twitter, your bank, a SaaS dashboard) but you don't need to ship a host.
+- **Skill:** [`create-plugin`](../create-plugin/SKILL.md) walks through research, plugin source, build registration, and verification.
+- **Reference:** [`PLUGIN.md`](../../../PLUGIN.md) is the canonical architecture deep-dive — capabilities, lifecycle, security model, worked X-Profile example.
+
+## 2 — Build your own browser extension
+
+A new Chrome/Firefox/Safari extension that runs TLSN plugins. Reuses the existing offscreen WASM prover and `webRequest` interception, all packaged as `@tlsn/host-extension`. You own the manifest, the popup UI, and your own plugin gallery.
+
+- **When to pick this:** you want a TLSN-powered extension with your own branding / plugin curation, not the upstream one in `packages/extension/`.
+- **Skill:** [`build-tlsn-host`](../build-tlsn-host/SKILL.md), extension flow.
+- **Reference implementation:** `packages/extension/` — the upstream extension; reads identically to what the skill scaffolds.
+
+## 3 — Build your own mobile app
+
+A new React Native / Expo app that runs TLSN plugins. Uses the native Rust prover under the hood (`tlsn-native` Expo module), WebView-based header interception, and React Native's primitives for the plugin UI. Packaged as `@tlsn/host-react-native`.
+
+- **When to pick this:** you want TLSN on iOS / Android with your own UX, gallery, theming.
+- **Skill:** [`build-tlsn-host`](../build-tlsn-host/SKILL.md), React Native flow.
+- **Reference implementation:** `app/mobile/` — the TLSN mobile app; consumes the same package an external dev would.
+
+## The package map
+
+```
+@tlsn/plugin-sdk          ← protocol core: HostCore, types, handlers, sandbox
+        ▲
+@tlsn/host-contracts      ← interface spec: HostAdapter, ProverClient,
+        ▲                   WindowManager, RequestInterceptor,
+        │                   PluginRenderer, ApprovalUi (+ ApprovalMode,
+        │                   translateHandler for the native bridge)
+        │
+   ┌────┴────────────────────────────────┐
+   │                                     │
+@tlsn/host-react-native   @tlsn/host-extension   @tlsn/host-cli
+   │                                     │             │
+   └──── platform-specific glue ─────────┘             │
+                                                       │
+   imports both plugin-sdk + the host-* it needs ──────┘
+
+Consumer (your app)
+   - imports plugin-sdk for protocol types (Handler, PluginConfig, DomJson, …)
+   - imports the host-* package for the platform glue
+   - implements/owns its own UI on top
+```
+
+`@tlsn/plugin-sdk` is **platform-agnostic** — types, the `HostCore` engine, the QuickJS / NativeFunction evaluator. Consumers always import from it directly.
+
+`@tlsn/host-contracts` defines the shape every host adapter implements. Most consumers don't import it; adapter authors do.
+
+`@tlsn/host-react-native`, `@tlsn/host-extension`, `@tlsn/host-cli` are platform glue — each pairs `HostCore` with a real `chrome.windows` / `react-native-webview` / Playwright `BrowserContext`, a real prover (WASM in the extension, native in mobile, a Rust binary on CLI), and a real renderer.
+
+A consumer app imports the `host-*` package matching its platform AND `@tlsn/plugin-sdk` for shared types — that's the canonical pattern, the same way `react-dom` sits alongside `react`.
+
+## Where to read more
+
+- **`PLUGIN.md`** — the deep-dive on plugin architecture, capabilities, and security.
+- **`CLAUDE.md`** — repo-level conventions and command reference for working in this monorepo.
+- **`packages/host-contracts/src/index.ts`** — the source of truth for what an adapter must implement (all the interface definitions).
+- **`app/mobile/`** — the canonical reference mobile consumer (uses `@tlsn/host-react-native`).
+- **`packages/extension/`** — the canonical reference extension consumer (uses `@tlsn/host-extension`).
+- **TLSNotary blog** — narrative posts at https://tlsnotary.org/blog, including the mobile-launch announcement.
+
+## How to use this skill
+
+This `tlsnotary` skill is the entry-point router. It exists so a developer can ask Claude "I want to add TLSN to my Expo app, where do I start?" and get oriented before being routed.
+
+When the developer has picked a path:
+
+- Plugin work → invoke the `create-plugin` skill.
+- Host work (extension / mobile / CLI) → invoke the `build-tlsn-host` skill, which detects the platform from the project and walks through scaffolding.
+
+Don't duplicate scaffolding here — defer to those focused skills.


### PR DESCRIPTION
## Summary

Ships three Claude Code skills under top-level **\`./skills/\`** so any developer integrating TLSNotary can ask Claude for help and get oriented automatically — no slash-command memorization required.

### \`skills/tlsnotary/SKILL.md\` — umbrella entry point

Describes the three integration paths (plugin / extension / mobile), the package layout (\`@tlsn/plugin-sdk\` + \`@tlsn/host-contracts\` + \`@tlsn/host-*\` adapters), and routes a developer to the focused skill that matches their work. Auto-discovers when someone asks how TLSN works, what packages exist, or which path to pick.

### \`skills/build-tlsn-host/SKILL.md\` — host-app scaffold

Detects the platform (CLI / RN / extension) from the user's project and walks through wiring the right \`@tlsn/host-*\` adapter. Replaces the prior \`.claude/commands/build-tlsn-host.md\` slash command; same content, now with frontmatter for auto-discovery.

### \`skills/create-plugin/SKILL.md\` — plugin authoring guide

Walks a developer through researching a target API, planning auth interception, writing the plugin source, building, and registering. Replaces the prior \`.claude/commands/create-plugin.md\`.

## Why top-level \`./skills/\`

More discoverable for someone landing on the repo as a human (no hidden dot-dir hop), trivially copy-able into another project's \`.claude/skills/\`. Symlink \`.claude/skills → ../skills\` locally if you want Claude Code's own auto-discovery to find them in this repo too.

## Depends on

This PR ships the dev-facing guides. The skills *reference* packages — \`@tlsn/host-react-native\`, \`@tlsn/host-extension\`, \`@tlsn/host-cli\`, \`@tlsn/host-contracts\` — that ship in **#359** (host-adapter platform). Merge #359 first; the skills won't be end-to-end useful until those packages land.

## Test plan

- [x] Skills load correctly in a fresh Claude Code session (verified via Skill tool listing)
- [x] Each skill's \`description:\` frontmatter triggers on the intended prompts
- [ ] Reviewer: run \`/build-tlsn-host\` and \`/create-plugin\` and confirm parity with the prior \`.claude/commands/\` versions