### PR TITLE
feat: peer-to-peer web proofs (in-browser verifier, MPC + Proxy)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23242,6 +23242,7 @@
       "name": "@tlsnotary/demo",
       "version": "0.1.0",
       "dependencies": {
+        "@tlsn/common": "*",
         "@tlsn/plugins": "*",
         "comlink": "^4.4.2",
         "happy-dom": "^20.8.9",
@@ -23621,7 +23622,6 @@
         "comlink": "^4.4.2",
         "events": "^3.3.0",
         "path-browserify": "^1.0.1",
-        "peerjs": "^1.5.5",
         "process": "^0.11.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,6 +5335,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -7985,6 +7994,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "dev": true,
@@ -10502,6 +10521,8 @@
     },
     "node_modules/comlink": {
       "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
       "license": "Apache-2.0"
     },
     "node_modules/command-exists": {
@@ -11151,6 +11172,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -12084,7 +12111,6 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/events": {
@@ -17468,6 +17494,38 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/peerjs": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+      "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@msgpack/msgpack": "^2.8.0",
+        "eventemitter3": "^4.0.7",
+        "peerjs-js-binarypack": "^2.1.0",
+        "webrtc-adapter": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
+    "node_modules/peerjs-js-binarypack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+      "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/peer"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
@@ -18672,10 +18730,192 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.11.0",
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -19395,6 +19635,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/requireg": {
       "version": "0.2.2",
       "dependencies": {
@@ -19820,6 +20066,12 @@
       "version": "3.0.1",
       "license": "MIT"
     },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
     "node_modules/secp256k1": {
       "version": "4.0.4",
       "hasInstallScript": true,
@@ -20116,6 +20368,12 @@
     "node_modules/server-only": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -21146,6 +21404,10 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tlsn-wasm": {
+      "resolved": "packages/tlsn-wasm-pkg",
+      "link": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -22422,6 +22684,19 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "dev": true,
@@ -22576,6 +22851,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
@@ -22962,11 +23243,16 @@
       "version": "0.1.0",
       "dependencies": {
         "@tlsn/plugins": "*",
+        "comlink": "^4.4.2",
         "happy-dom": "^20.8.9",
+        "peerjs": "^1.5.5",
+        "qrcode": "^1.5.4",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "tlsn-wasm": "0.1.0-alpha.15"
       },
       "devDependencies": {
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
@@ -22996,6 +23282,12 @@
     "packages/demo/node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
+    },
+    "packages/demo/node_modules/tlsn-wasm": {
+      "version": "0.1.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/tlsn-wasm/-/tlsn-wasm-0.1.0-alpha.15.tgz",
+      "integrity": "sha512-6NwgWlc56UADOOt5+zwbb+XaSVSS8nz01H5lnG2sAvSUjapNM4mTWHedeHQn1eWJHoIQD3iVt1o7lPhk1fXMoA==",
+      "license": "MIT OR Apache-2.0"
     },
     "packages/eas-webhook": {
       "name": "@tlsn/eas-webhook",
@@ -23329,6 +23621,7 @@
         "comlink": "^4.4.2",
         "events": "^3.3.0",
         "path-browserify": "^1.0.1",
+        "peerjs": "^1.5.5",
         "process": "^0.11.10",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -23981,6 +24274,11 @@
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
       }
+    },
+    "packages/tlsn-wasm-pkg": {
+      "name": "tlsn-wasm",
+      "version": "0.1.0-alpha.16-pre",
+      "license": "MIT OR Apache-2.0"
     },
     "packages/ts-plugin-sample": {
       "name": "@tlsn/ts-plugin-sample",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23610,7 +23610,7 @@
       }
     },
     "packages/extension": {
-      "version": "0.1.0.1500",
+      "version": "0.1.0.1501",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.4.2",

--- a/packages/common/src/bytes.test.ts
+++ b/packages/common/src/bytes.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { bytesToBase64, base64ToBytes, toUint8Array } from './bytes.js';
+
+/**
+ * Tests for the byte-bridge helpers. These carry the prover's MPC stream over
+ * text-only channels, so the round-trip must be byte-exact: a single dropped or
+ * transposed byte corrupts the MPC silently. The cases below cover the edges
+ * (empty, every byte value, and a payload larger than one MPC frame).
+ */
+
+describe('bytesToBase64 / base64ToBytes round-trip', () => {
+  const roundTrip = (bytes: Uint8Array) => base64ToBytes(bytesToBase64(bytes));
+
+  it('round-trips an empty buffer', () => {
+    expect(bytesToBase64(new Uint8Array(0))).toBe('');
+    expect(base64ToBytes('')).toEqual(new Uint8Array(0));
+  });
+
+  it('round-trips a short ASCII-ish payload', () => {
+    const bytes = new Uint8Array([0x47, 0x45, 0x54, 0x20, 0x2f]); // "GET /"
+    expect(roundTrip(bytes)).toEqual(bytes);
+  });
+
+  it('round-trips every possible byte value (0..255)', () => {
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    expect(roundTrip(bytes)).toEqual(bytes);
+  });
+
+  it('round-trips NUL bytes without truncating', () => {
+    const bytes = new Uint8Array([0x00, 0x41, 0x00, 0x00, 0x42]);
+    expect(roundTrip(bytes)).toEqual(bytes);
+  });
+
+  it('round-trips a payload larger than a single MPC frame', () => {
+    const bytes = new Uint8Array(70_000); // > the largest plugin maxRecvData (65536)
+    for (let i = 0; i < bytes.length; i++) bytes[i] = (i * 31 + 7) & 0xff;
+    expect(roundTrip(bytes)).toEqual(bytes);
+  });
+
+  it('produces a base64 string that decodes to the original length', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const b64 = bytesToBase64(bytes);
+    expect(b64).toBe('AQID');
+    expect(base64ToBytes(b64)).toEqual(bytes);
+  });
+});
+
+describe('toUint8Array', () => {
+  it('returns a Uint8Array unchanged', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(toUint8Array(bytes)).toBe(bytes);
+  });
+
+  it('wraps an ArrayBuffer into a Uint8Array view', () => {
+    const buf = new Uint8Array([4, 5, 6]).buffer;
+    expect(toUint8Array(buf)).toEqual(new Uint8Array([4, 5, 6]));
+  });
+});

--- a/packages/common/src/bytes.ts
+++ b/packages/common/src/bytes.ts
@@ -1,0 +1,48 @@
+/**
+ * Byte helpers for relaying binary MPC frames over text-only channels.
+ *
+ * The extension bridges the prover's MPC byte stream through chrome message
+ * passing (JSON only), and the demo relays it over a PeerJS data channel, so
+ * binary frames are base64-encoded in transit. These helpers are the single
+ * source of truth for that encoding on both sides — a mismatch would corrupt
+ * the MPC stream silently.
+ */
+
+/**
+ * Encodes raw bytes as a base64 string.
+ *
+ * Built one char at a time rather than `String.fromCharCode(...bytes)` so large
+ * MPC frames don't blow the argument-count limit of a spread call.
+ *
+ * @param bytes The bytes to encode.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+/**
+ * Decodes a base64 string produced by {@link bytesToBase64} back to bytes.
+ *
+ * @param b64 The base64 string to decode.
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64);
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Normalizes a data-channel payload to a `Uint8Array`.
+ *
+ * PeerJS hands binary frames over as either a `Uint8Array` or a raw
+ * `ArrayBuffer` depending on the channel; callers want a `Uint8Array`.
+ *
+ * @param data The payload received from the transport.
+ */
+export function toUint8Array(data: unknown): Uint8Array {
+  if (data instanceof Uint8Array) return data;
+  return new Uint8Array(data as ArrayBufferLike);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -11,3 +11,6 @@ export {
 
 // IoChannel exports
 export { type IoChannel, fromWebSocket, fromOpenWebSocket } from './io-channel.js';
+
+// Byte helpers (relaying binary MPC frames over text-only channels)
+export { bytesToBase64, base64ToBytes, toUint8Array } from './bytes.js';

--- a/packages/demo/.gitignore
+++ b/packages/demo/.gitignore
@@ -1,4 +1,5 @@
 *.wasm
 dist/
 public/plugins/
+public/tlsn-wasm/
 generated/

--- a/packages/demo/copy-wasm.js
+++ b/packages/demo/copy-wasm.js
@@ -1,0 +1,17 @@
+// Copy the tlsn-wasm package into public/ so it is served as static files with
+// its `snippets/` layout intact. The WASM glue and its rayon thread-spawner use
+// `new URL('./spawn.js', import.meta.url)` and `import('../../../tlsn_wasm.js')`
+// internally; bundling them breaks those relative paths, so we load the package
+// from a static URL instead (see src/peer/wasm.worker.ts).
+import { cpSync, rmSync } from 'fs';
+import { createRequire } from 'module';
+import { dirname, resolve } from 'path';
+
+const require = createRequire(import.meta.url);
+const src = dirname(require.resolve('tlsn-wasm/package.json'));
+const dest = resolve(import.meta.dirname, 'public', 'tlsn-wasm');
+
+rmSync(dest, { recursive: true, force: true });
+cpSync(src, dest, { recursive: true });
+
+console.log(`[copy-wasm] ${src} → ${dest}`);

--- a/packages/demo/nginx.conf
+++ b/packages/demo/nginx.conf
@@ -1,3 +1,20 @@
+# Cross-origin isolation for the peer-to-peer verifier (mirror of the
+# crossOriginIsolatePeer() plugin in vite.config.ts, which only runs under
+# `vite dev`/`vite preview`). The in-browser WASM verifier needs
+# SharedArrayBuffer, which requires COOP+COEP on its document. The verifier is
+# the `?j=<peerId>` document; isolate ONLY that one. The prover document
+# (/peer.html with no query) must NOT get COEP, or the extension's injected
+# window.tlsn would be blocked. nginx omits an add_header whose value is empty,
+# so these map to "" for the prover document.
+map $arg_j $peer_coep {
+    default      "";
+    "~.+"        "require-corp";
+}
+map $arg_j $peer_coop {
+    default      "";
+    "~.+"        "same-origin";
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -59,10 +76,35 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
     }
 
-    # Default: proxy to static demo server
+    # Verifier document (/peer.html?j=<peerId>): isolate only when the `j` query
+    # arg is present. CORP is always set so this document is embeddable; COEP/COOP
+    # come from the maps above (empty — and thus omitted — for the prover document).
+    location = /peer.html {
+        proxy_pass http://demo-static:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header Cross-Origin-Resource-Policy cross-origin always;
+        add_header Cross-Origin-Embedder-Policy $peer_coep always;
+        add_header Cross-Origin-Opener-Policy $peer_coop always;
+    }
+
+    # Hashed JS/CSS/WASM/worker assets must be embeddable inside the isolated
+    # verifier (COEP require-corp + CORP cross-origin). Anchored at the path
+    # start, so /tutorial/assets/* is unaffected.
+    location ~ ^/(assets/|tlsn-wasm/) {
+        proxy_pass http://demo-static:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        add_header Cross-Origin-Embedder-Policy require-corp always;
+        add_header Cross-Origin-Resource-Policy cross-origin always;
+    }
+
+    # Default: proxy to static demo server. CORP cross-origin so root assets
+    # (e.g. favicon) are still embeddable inside the isolated verifier document.
     location / {
         proxy_pass http://demo-static:80;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        add_header Cross-Origin-Resource-Policy cross-origin always;
     }
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "npm run build:plugins && vite",
-    "build": "npm run build:plugins && vite build",
+    "dev": "npm run build:plugins && npm run copy:wasm && vite",
+    "build": "npm run build:plugins && npm run copy:wasm && vite build",
     "build:plugins": "node build-plugins.js",
+    "copy:wasm": "node copy-wasm.js",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
     "typecheck:plugins": "tsc --noEmit -p ../plugins/src/tsconfig.json",
@@ -15,11 +16,16 @@
   },
   "dependencies": {
     "@tlsn/plugins": "*",
+    "comlink": "^4.4.2",
     "happy-dom": "^20.8.9",
+    "peerjs": "^1.5.5",
+    "qrcode": "^1.5.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tlsn-wasm": "0.1.0-alpha.15"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@tlsn/common": "*",
     "@tlsn/plugins": "*",
     "comlink": "^4.4.2",
     "happy-dom": "^20.8.9",

--- a/packages/demo/peer.html
+++ b/packages/demo/peer.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TLSNotary — Peer-to-peer</title>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/peer/main-peer.tsx"></script>
+  </body>
+</html>

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -446,9 +446,11 @@ export function App() {
           <a href="#build-your-own" className="hero-cta hero-cta-secondary">
             Build your own →
           </a>
-          <a href="/peer.html" className="hero-cta hero-cta-secondary">
+          {/* Re-enable once the relay-capable extension (>= 0.1.0.1501) is
+              live on the Chrome Web Store; until then peer.html can't work. */}
+          {/* <a href="/peer.html" className="hero-cta hero-cta-secondary">
             Peer-to-peer (preview) →
-          </a>
+          </a> */}
         </div>
       </div>
 

--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -446,6 +446,9 @@ export function App() {
           <a href="#build-your-own" className="hero-cta hero-cta-secondary">
             Build your own →
           </a>
+          <a href="/peer.html" className="hero-cta hero-cta-secondary">
+            Peer-to-peer (preview) →
+          </a>
         </div>
       </div>
 

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useRef, useState, type ReactNode } from 'react';
 import QRCode from 'qrcode';
 import type { DataConnection } from 'peerjs';
 import { bytesToBase64, base64ToBytes, toUint8Array } from '@tlsn/common';
@@ -114,6 +114,26 @@ function Channel({ proving, mode }: { proving: boolean; mode: Mode }) {
   );
 }
 
+// Render a hostname with a <wbr> break opportunity after each dot, so a long
+// host wraps at label boundaries ("swissbank." / "tlsnotary.org") instead of
+// mid-word.
+function HostName({ host }: { host: string }) {
+  return (
+    <>
+      {host.split('.').map((label, i) => (
+        <Fragment key={i}>
+          {i > 0 && (
+            <>
+              .<wbr />
+            </>
+          )}
+          {label}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
 // The target server, shown as a card alongside the prover/verifier panes.
 function ServerNode({ mode, host }: { mode: Mode; host: string }) {
   const side = mode === 'Proxy' ? 'verifier' : 'prover';
@@ -123,7 +143,7 @@ function ServerNode({ mode, host }: { mode: Mode; host: string }) {
         <span className="peer-pane-role">Server</span>
         <span className="peer-pane-badge">🌐 HTTPS</span>
       </div>
-      <div className="peer-node-host">{host || 'the target site'}</div>
+      <div className="peer-node-host">{host ? <HostName host={host} /> : 'the target site'}</div>
       <div className="peer-node-n">
         {side} connects · {mode === 'Proxy' ? 'Proxy' : 'MPC'}
       </div>
@@ -250,7 +270,9 @@ function ProverView() {
   // Host immediately so the join QR appears right away — no extra click.
   const host = usePeerHost(true);
 
-  const [selected, setSelected] = useState<string>(PLUGIN_ENTRIES[0]?.[0] ?? '');
+  const [selected, setSelected] = useState<string>(
+    plugins.spotify ? 'spotify' : (PLUGIN_ENTRIES[0]?.[0] ?? ''),
+  );
   const [mode, setMode] = useState<Mode>('Mpc');
   const [showProtocolInfo, setShowProtocolInfo] = useState(false);
   const [proving, setProving] = useState(false);
@@ -261,6 +283,11 @@ function ProverView() {
   const [qr, setQr] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [verifier, setVerifier] = useState<RemoteVerifier>({ state: 'idle' });
+  // Tears down the current relay wiring. Kept in a ref (not unwired when
+  // execCode resolves) because in relay mode the prover finishes before the
+  // verifier does, and we must keep listening for its terminal {t:'vs'} frame.
+  const unwireRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => unwireRef.current?.(), []);
 
   const plugin = plugins[selected];
   const serverHost = plugin?.host ?? '';
@@ -395,7 +422,12 @@ function ProverView() {
       return;
     }
     const requestId = `p2p_prove_${Date.now()}`;
-    const unwire = wireRelay(host.conn, requestId);
+    // Tear down any prior wiring, then wire this proof. Do NOT unwire when
+    // execCode resolves: the verifier sends its terminal {t:'vs'} frame after
+    // the prover finishes, so the listener must outlive this call. It is torn
+    // down by the next proof or on unmount.
+    unwireRef.current?.();
+    unwireRef.current = wireRelay(host.conn, requestId);
     setProving(true);
     setProveError(null);
     setProveDone(false);
@@ -413,7 +445,6 @@ function ProverView() {
       setProveError(e instanceof Error ? e.message : String(e));
     } finally {
       setProving(false);
-      unwire();
     }
   };
 
@@ -427,9 +458,9 @@ function ProverView() {
       </div>
 
       <ol className="peer-steps">
-        <li>Pair a verifier (scan the code on the right)</li>
-        <li>Select what you want to prove (plugin)</li>
-        <li>Click Prove to the verifier, then follow the steps in the extension popup</li>
+        <li>Pair a verifier (scan QR code)</li>
+        <li>Select what you want to prove</li>
+        <li>Click "Prove to the verifier" and follow the steps in the extension popup</li>
       </ol>
 
       {hasExtension === false && (
@@ -522,7 +553,13 @@ function ProverView() {
       )}
       {proveError && <div className="peer-error">❌ {proveError}</div>}
       {proveDone && !proveError && (
-        <div className="peer-proof-sent">✓ Proof complete — verified on the other device.</div>
+        <div className="peer-proof-sent">
+          {verifier.state === 'verified'
+            ? '✓ Proof complete — verified on the other device.'
+            : verifier.state === 'error'
+              ? '✓ Proof sent — but verification failed on the other device.'
+              : '✓ Proof sent — waiting for the other device to verify…'}
+        </div>
       )}
 
       {showProtocolInfo && (
@@ -534,8 +571,17 @@ function ProverView() {
           </p>
           <p>
             <strong>Proxy</strong> — faster. The verifier relays your encrypted connection to the
-            server, so it sits in the data path (it still can&apos;t read the TLS traffic). Best
-            when the verifier is an independent party.
+            server, so it sits in the data path (it still can&apos;t read the TLS traffic). Its
+            integrity then depends on the verifier&apos;s network path to the server being
+            trustworthy — and in this demo that hop runs through a shared TCP proxy, which becomes
+            part of that trust. MPC mode avoids this.{' '}
+            <a
+              href="https://tlsnotary.org/blog/2026/04/22/proxy-mode/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more →
+            </a>
           </p>
         </InfoModal>
       )}
@@ -846,7 +892,7 @@ function VerifierView({ joinId }: { joinId: string }) {
           </div>
           <div className="peer-fields-title">Request sent</div>
           <pre className="peer-selftest-pre">{result.sent}</pre>
-          <div className="peer-fields-title">Response received (authenticated)</div>
+          <div className="peer-fields-title">Response received</div>
           <pre className="peer-selftest-pre">{result.recv}</pre>
         </>
       )}

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -1,0 +1,436 @@
+import { useEffect, useRef, useState } from 'react';
+import QRCode from 'qrcode';
+import type { DataConnection } from 'peerjs';
+import { plugins } from '../plugins';
+import { usePeerDialer, usePeerHost } from './usePeerConnection';
+import {
+  initWasmRuntime,
+  runVerifierSession,
+  SelfTestResult,
+  WasmRuntimeStatus,
+} from './wasmRuntime';
+import '../App.css';
+import './peer.css';
+
+const PLUGIN_ENTRIES = Object.entries(plugins);
+// TCP proxy for the prover→server hop (the verifier is the peer; only this hop
+// needs a reachable relay). Overrides the plugin's build-time localhost proxy.
+const PROXY_BASE = 'wss://demo.tlsnotary.org';
+
+interface PeerLimits {
+  maxSentData: number;
+  maxRecvData: number;
+}
+
+// Base64 (de)serialization for relayed MPC bytes (the extension↔page bridge
+// carries strings). Loop-based to handle large payloads without spread.
+function bytesToB64(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function b64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64);
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  return bytes;
+}
+function toU8(d: unknown): Uint8Array {
+  if (d instanceof Uint8Array) return d;
+  return new Uint8Array(d as ArrayBufferLike);
+}
+
+function parseJoinId(): string | null {
+  return new URLSearchParams(window.location.search).get('j');
+}
+
+// Role is decided by the URL: `?j=<peerId>` opens the verifier (it dials the
+// prover that is hosting that peer); no query opens the prover.
+export function PeerToPeerPage() {
+  const [joinId] = useState(parseJoinId);
+
+  return (
+    <div className="app-container">
+      <div className="peer-topbar">
+        <a href="/" className="peer-back-link">
+          ← Back to demo
+        </a>
+        <span className="peer-tag">Preview</span>
+      </div>
+
+      <div className="hero-section peer-hero">
+        <h1 className="hero-title">Peer-to-peer web proofs</h1>
+        <p className="hero-subtitle">
+          Prove a fact from any site with your extension, and let another device verify it directly
+          over a PeerJS data channel — the MPC-TLS session runs between two browsers, with no hosted
+          verifier.
+        </p>
+      </div>
+
+      {joinId ? <VerifierView joinId={joinId} /> : <ProverView />}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Prover (this device has the extension). The PAGE hosts the PeerJS connection
+// (QR + pairing) and relays the MPC byte stream to/from the extension, which
+// does the actual proving. No PeerJS in the extension.
+// ---------------------------------------------------------------------------
+
+function ProverView() {
+  const [connectStarted, setConnectStarted] = useState(false);
+  const host = usePeerHost(connectStarted);
+
+  const [selected, setSelected] = useState<string>(PLUGIN_ENTRIES[0]?.[0] ?? '');
+  const [proving, setProving] = useState(false);
+  const [proveProgress, setProveProgress] = useState('');
+  const [proveDone, setProveDone] = useState(false);
+  const [proveError, setProveError] = useState<string | null>(null);
+  const [hasExtension, setHasExtension] = useState<boolean | null>(null);
+  const [qr, setQr] = useState<string | null>(null);
+
+  // The content script injects window.tlsn shortly after load.
+  useEffect(() => {
+    const id = setTimeout(() => setHasExtension(!!window.tlsn?.execCode), 800);
+    return () => clearTimeout(id);
+  }, []);
+
+  const joinUrl = host.peerId ? `${window.location.origin}/peer.html?j=${host.peerId}` : null;
+
+  useEffect(() => {
+    if (!joinUrl) {
+      setQr(null);
+      return;
+    }
+    let cancelled = false;
+    QRCode.toDataURL(joinUrl, { width: 200, margin: 1 })
+      .then((u) => {
+        if (!cancelled) setQr(u);
+      })
+      .catch(() => {
+        if (!cancelled) setQr(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [joinUrl]);
+
+  const connected = host.status === 'connected' && !!host.conn;
+
+  // Bridge the extension's MPC byte stream over the page's data channel:
+  //  - extension → page (TLSN_PEER_DATA_OUT) → conn.send → verifier
+  //  - verifier → conn.on('data') → page → extension (TLSN_PEER_DATA_IN)
+  const wireRelay = (conn: DataConnection, requestId: string): (() => void) => {
+    const onWindow = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const d = event.data;
+      if (!d || d.requestId !== requestId) return;
+      if (d.type === 'TLSN_PEER_DATA_OUT') {
+        try {
+          conn.send(b64ToBytes(d.data));
+        } catch {
+          /* channel closed */
+        }
+      } else if (d.type === 'TLSN_PROVE_PROGRESS') {
+        // Forward the prover's limits to the verifier as a string frame (the
+        // data channel otherwise carries raw MPC bytes), then show progress.
+        if (d.step === 'PEER_LIMITS') {
+          try {
+            conn.send(d.message);
+          } catch {
+            /* channel closed */
+          }
+        } else {
+          setProveProgress(d.message ?? d.step ?? '');
+        }
+      }
+    };
+    const onData = (raw: unknown) => {
+      window.postMessage(
+        { type: 'TLSN_PEER_DATA_IN', requestId, data: bytesToB64(toU8(raw)) },
+        window.location.origin,
+      );
+    };
+    const onClose = () => {
+      window.postMessage({ type: 'TLSN_PEER_DATA_CLOSED', requestId }, window.location.origin);
+    };
+    window.addEventListener('message', onWindow);
+    conn.on('data', onData);
+    conn.on('close', onClose);
+    return () => {
+      window.removeEventListener('message', onWindow);
+      conn.off('data', onData);
+      conn.off('close', onClose);
+    };
+  };
+
+  const handleProve = async () => {
+    const plugin = plugins[selected];
+    if (!plugin || proving || !host.conn) return;
+    if (!window.tlsn?.execCode) {
+      setProveError('TLSNotary extension not detected on this page.');
+      return;
+    }
+    const requestId = `p2p_prove_${Date.now()}`;
+    const unwire = wireRelay(host.conn, requestId);
+    setProving(true);
+    setProveError(null);
+    setProveDone(false);
+    setProveProgress('Starting…');
+    try {
+      const code = await fetch(plugin.file).then((r) => r.text());
+      await window.tlsn.execCode(code, {
+        requestId,
+        // proxyBase: relay the prover↔server TCP through a reachable proxy
+        // (overrides the plugin's build-time ws://localhost:7047 origin).
+        sessionData: { peerRelay: '1', mode: 'Mpc', proxyBase: PROXY_BASE },
+      });
+      setProveDone(true);
+    } catch (e: unknown) {
+      setProveError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setProving(false);
+      unwire();
+    }
+  };
+
+  return (
+    <div className="peer-split peer-split--single">
+      <section className="peer-pane peer-pane--prover">
+        <div className="peer-pane-head">
+          <span className="peer-pane-role">Prover (this device)</span>
+          <span className="peer-pane-badge">extension · MPC</span>
+        </div>
+        <p className="peer-pane-sub">
+          First connect a verifying device, then prove with your TLSNotary extension. PeerJS runs
+          here in the page; the extension only relays its proof bytes.
+        </p>
+
+        {hasExtension === false && (
+          <div className="peer-check-warn">
+            ⚠️ TLSNotary extension not detected — you can still pair, but proving needs the
+            extension.
+          </div>
+        )}
+
+        {/* Step 1: connect */}
+        {!connected && (
+          <>
+            <button
+              className="plugin-run-btn"
+              onClick={() => setConnectStarted(true)}
+              disabled={connectStarted}
+            >
+              {connectStarted ? (
+                <>
+                  <span className="spinner" /> Waiting for verifier…
+                </>
+              ) : (
+                '▶ Connect a verifier'
+              )}
+            </button>
+            {host.error && <div className="peer-error">❌ {host.error}</div>}
+            {connectStarted && joinUrl && (
+              <div className="peer-qr-block">
+                <div className="peer-fields-title">Scan with the verifying device</div>
+                {qr && <img className="peer-qr" src={qr} alt="Verifier join QR code" />}
+                <div className="peer-link-row">
+                  <input className="peer-link-input" readOnly value={joinUrl} />
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Step 2: prove (only after the verifier is connected) */}
+        {connected && (
+          <>
+            <div className="peer-proof-sent">✓ Verifier connected — ready to prove.</div>
+
+            <label className="peer-field-label" htmlFor="peer-plugin-select">
+              Plugin
+            </label>
+            <select
+              id="peer-plugin-select"
+              className="peer-select"
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              disabled={proving}
+            >
+              {PLUGIN_ENTRIES.map(([key, p]) => (
+                <option key={key} value={key}>
+                  {p.logo} {p.name}
+                </option>
+              ))}
+            </select>
+
+            <button
+              className="plugin-run-btn"
+              onClick={handleProve}
+              disabled={proving || hasExtension === false}
+            >
+              {proving ? (
+                <>
+                  <span className="spinner" /> Proving…
+                </>
+              ) : (
+                '▶ Prove to the verifier'
+              )}
+            </button>
+
+            {proving && proveProgress && !proveDone && (
+              <div className="peer-selftest-progress">
+                <span className="spinner spinner--dark" /> {proveProgress}
+              </div>
+            )}
+            {proveError && <div className="peer-error">❌ {proveError}</div>}
+            {proveDone && !proveError && (
+              <div className="peer-proof-sent">
+                ✓ Proof complete — verified on the other device.
+              </div>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Verifier (other device, e.g. a phone). Runs the WASM verifier in-browser.
+// ---------------------------------------------------------------------------
+
+function VerifierView({ joinId }: { joinId: string }) {
+  const [wasm, setWasm] = useState<WasmRuntimeStatus>(() => {
+    const isolated = window.crossOriginIsolated === true;
+    return isolated
+      ? { state: 'initializing', isolated }
+      : {
+          state: 'error',
+          isolated: false,
+          error: 'Page is not cross-origin isolated, so SharedArrayBuffer is unavailable.',
+        };
+  });
+  const [progress, setProgress] = useState('');
+  const [result, setResult] = useState<SelfTestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const started = useRef(false);
+
+  // Boot the WASM runtime (needs cross-origin isolation — provided for ?j= pages).
+  useEffect(() => {
+    if (wasm.state !== 'initializing') return;
+    let cancelled = false;
+    initWasmRuntime({ loggingLevel: 'Info' })
+      .then((threads) => {
+        if (!cancelled) setWasm({ state: 'ready', isolated: true, threads });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setWasm({
+            state: 'error',
+            isolated: true,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Only dial the prover once the WASM is ready, so the verifier is wired to
+  // consume the MPC stream the instant the channel opens.
+  const dialer = usePeerDialer(wasm.state === 'ready' ? joinId : null);
+
+  // The prover sends its limits as the first (string) frame; adopt them — same
+  // model as the verifier server, which takes the prover's register limits.
+  // Subsequent frames are raw MPC bytes handled inside runVerifierSession.
+  useEffect(() => {
+    if (!dialer.conn || wasm.state !== 'ready' || started.current) return;
+    const conn = dialer.conn;
+    const onFirst = (d: unknown) => {
+      if (typeof d !== 'string' || started.current) return;
+      let limits: PeerLimits;
+      try {
+        limits = JSON.parse(d) as PeerLimits;
+      } catch {
+        return;
+      }
+      started.current = true;
+      conn.off('data', onFirst);
+      setProgress('Starting verifier…');
+      runVerifierSession(limits, conn, setProgress)
+        .then(setResult)
+        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+    };
+    conn.on('data', onFirst);
+    return () => {
+      conn.off('data', onFirst);
+    };
+  }, [dialer.conn, wasm.state]);
+
+  const connecting = wasm.state === 'ready' && !result && !error && dialer.status !== 'error';
+
+  return (
+    <div className="peer-split peer-split--single">
+      <div className={`peer-wasm-banner peer-wasm-banner--${wasm.state}`}>
+        {wasm.state === 'ready' && (
+          <span>
+            🦀 In-browser verifier ready — WASM running with {wasm.threads} thread
+            {wasm.threads === 1 ? '' : 's'}
+          </span>
+        )}
+        {(wasm.state === 'initializing' || wasm.state === 'idle') && (
+          <span>
+            <span className="spinner spinner--dark" /> Loading in-browser TLSNotary verifier…
+          </span>
+        )}
+        {wasm.state === 'error' && <span>⚠️ In-browser verifier unavailable: {wasm.error}</span>}
+      </div>
+
+      <section className="peer-pane peer-pane--verifier">
+        <div className="peer-pane-head">
+          <span className="peer-pane-role">Verifier (this device)</span>
+          <span
+            className={`peer-status-pill peer-status-pill--${result ? 'verified' : error ? 'error' : 'connected'}`}
+          >
+            {result ? 'Verified' : error ? 'Error' : 'Verifying'}
+          </span>
+        </div>
+        <p className="peer-pane-sub">
+          Runs the MPC-TLS verifier in this browser and confirms what the prover proved.
+        </p>
+
+        {connecting && (
+          <div className="peer-verifier-progress">
+            <span className="spinner spinner--dark" />
+            <div>
+              <div className="peer-verifier-progress-title">
+                {dialer.status === 'connected' ? 'Verifying…' : 'Connecting to prover…'}
+              </div>
+              <div className="peer-verifier-progress-msg">{progress}</div>
+            </div>
+          </div>
+        )}
+
+        {dialer.error && !result && <div className="peer-error">❌ {dialer.error}</div>}
+        {error && <div className="peer-error">❌ {error}</div>}
+
+        {result && (
+          <>
+            <div className="peer-verdict">
+              ✓ Verified in-browser — TLS session to {result.serverName ?? 'server'} authenticated (
+              {result.threads} threads, {(result.ms / 1000).toFixed(1)}s)
+            </div>
+            <div className="peer-fields-title">Received (verifier's authenticated view)</div>
+            <pre className="peer-selftest-pre">{result.recv}</pre>
+            <div className="peer-fields-title">Sent</div>
+            <pre className="peer-selftest-pre">{result.sent}</pre>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import QRCode from 'qrcode';
 import type { DataConnection } from 'peerjs';
+import { bytesToBase64, base64ToBytes, toUint8Array } from '@tlsn/common';
 import { plugins } from '../plugins';
 import { usePeerDialer, usePeerHost } from './usePeerConnection';
 import {
@@ -51,24 +52,6 @@ interface RemoteVerifier {
 interface RemoteProver {
   state: 'idle' | 'connected' | 'proving' | 'done' | 'error';
   message?: string;
-}
-
-// Base64 (de)serialization for relayed MPC bytes (the extension↔page bridge
-// carries strings). Loop-based to handle large payloads without spread.
-function bytesToB64(bytes: Uint8Array): string {
-  let s = '';
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-  return btoa(s);
-}
-function b64ToBytes(b64: string): Uint8Array {
-  const s = atob(b64);
-  const bytes = new Uint8Array(s.length);
-  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
-  return bytes;
-}
-function toU8(d: unknown): Uint8Array {
-  if (d instanceof Uint8Array) return d;
-  return new Uint8Array(d as ArrayBufferLike);
 }
 
 function parseJoinId(): string | null {
@@ -345,7 +328,7 @@ function ProverView() {
       if (!d || d.requestId !== requestId) return;
       if (d.type === 'TLSN_RELAY_OUT') {
         try {
-          conn.send(b64ToBytes(d.data));
+          conn.send(base64ToBytes(d.data));
         } catch {
           /* channel closed */
         }
@@ -388,7 +371,7 @@ function ProverView() {
         return;
       }
       window.postMessage(
-        { type: 'TLSN_RELAY_IN', requestId, data: bytesToB64(toU8(raw)) },
+        { type: 'TLSN_RELAY_IN', requestId, data: bytesToBase64(toUint8Array(raw)) },
         window.location.origin,
       );
     };

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -6,7 +6,7 @@ import { usePeerDialer, usePeerHost } from './usePeerConnection';
 import {
   initWasmRuntime,
   runVerifierSession,
-  SelfTestResult,
+  VerifierResult,
   WasmRuntimeStatus,
 } from './wasmRuntime';
 import '../App.css';
@@ -313,7 +313,7 @@ function VerifierView({ joinId }: { joinId: string }) {
         };
   });
   const [progress, setProgress] = useState('');
-  const [result, setResult] = useState<SelfTestResult | null>(null);
+  const [result, setResult] = useState<VerifierResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const started = useRef(false);
 

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import QRCode from 'qrcode';
 import type { DataConnection } from 'peerjs';
 import { plugins } from '../plugins';
@@ -13,13 +13,44 @@ import '../App.css';
 import './peer.css';
 
 const PLUGIN_ENTRIES = Object.entries(plugins);
-// TCP proxy for the prover→server hop (the verifier is the peer; only this hop
-// needs a reachable relay). Overrides the plugin's build-time localhost proxy.
+// TCP proxy for the server hop (browsers can't open raw TCP). In MPC mode the
+// prover (extension) uses it; in Proxy mode the verifier (this page) does.
 const PROXY_BASE = 'wss://demo.tlsnotary.org';
+const CHROME_STORE_URL =
+  'https://chromewebstore.google.com/detail/tlsnotary/gnoglgpcamodhflknhmafmjdahcejcgg';
 
-interface PeerLimits {
+type Mode = 'Mpc' | 'Proxy';
+
+// ---- Control frames sent over the data channel (strings; MPC frames are bytes).
+interface LimitsFrame {
+  t: 'limits';
   maxSentData: number;
   maxRecvData: number;
+  mode?: Mode;
+  server?: string;
+}
+interface ProverStatusFrame {
+  t: 'ps';
+  step?: string;
+  message?: string;
+}
+interface VerifierStatusFrame {
+  t: 'vs';
+  state: 'connected' | 'verifying' | 'verified' | 'error';
+  message?: string;
+  threads?: number;
+  serverName?: string;
+}
+type CtrlFrame = LimitsFrame | ProverStatusFrame | VerifierStatusFrame;
+
+interface RemoteVerifier {
+  state: 'idle' | 'connected' | 'verifying' | 'verified' | 'error';
+  message?: string;
+  threads?: number;
+}
+interface RemoteProver {
+  state: 'idle' | 'connected' | 'proving' | 'done' | 'error';
+  message?: string;
 }
 
 // Base64 (de)serialization for relayed MPC bytes (the extension↔page bridge
@@ -44,6 +75,157 @@ function parseJoinId(): string | null {
   return new URLSearchParams(window.location.search).get('j');
 }
 
+function pillClass(state: string): string {
+  // Success states (paired / finished) are green; in-progress is blue.
+  if (state === 'verified' || state === 'done' || state === 'connected') return 'connected';
+  if (state === 'error') return 'error';
+  if (state === 'idle') return 'idle';
+  return 'progress';
+}
+
+// ---------------------------------------------------------------------------
+// Shared presentational pieces
+// ---------------------------------------------------------------------------
+
+// Lightweight click-to-open explainer modal (closes on overlay click or ×).
+function InfoModal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="peer-modal-overlay" onClick={onClose}>
+      <div className="peer-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="peer-modal-head">
+          <span className="peer-modal-title">{title}</span>
+          <button type="button" className="peer-modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="peer-modal-body">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+function Channel({ proving, mode }: { proving: boolean; mode: Mode }) {
+  return (
+    <div className="peer-topo-channel">
+      <div className={`peer-track ${proving ? 'peer-track--proving' : ''}`}>
+        <div className="peer-rail" />
+        {[0, 0.25, 0.5, 0.75].map((d) => (
+          <span
+            key={`f${d}`}
+            className="peer-packet peer-packet--fwd"
+            style={{ animationDelay: `${d}s` }}
+          />
+        ))}
+        <span className="peer-packet peer-packet--rev" style={{ animationDelay: '0.4s' }} />
+      </div>
+      <div className="peer-clabel">P2P · {mode === 'Proxy' ? 'Proxy' : 'MPC'}</div>
+    </div>
+  );
+}
+
+// The target server, shown as a card alongside the prover/verifier panes.
+function ServerNode({ mode, host }: { mode: Mode; host: string }) {
+  const side = mode === 'Proxy' ? 'verifier' : 'prover';
+  return (
+    <div className="peer-topo-node peer-topo-node--server">
+      <div className="peer-pane-head">
+        <span className="peer-pane-role">Server</span>
+        <span className="peer-pane-badge">🌐 HTTPS</span>
+      </div>
+      <div className="peer-node-host">{host || 'the target site'}</div>
+      <div className="peer-node-n">
+        {side} connects · {mode === 'Proxy' ? 'Proxy' : 'MPC'}
+      </div>
+    </div>
+  );
+}
+
+// The server↔browser hop: a connector line with an ⓘ that explains the TCP
+// proxy (browsers can't open raw TCP). Clicking ⓘ opens the shared InfoModal.
+function ProxyLink({ proving }: { proving: boolean }) {
+  const [info, setInfo] = useState(false);
+  return (
+    <div className="peer-link">
+      <div className={`peer-link-rail ${proving ? 'peer-link-rail--flow' : ''}`} />
+      <button
+        type="button"
+        className="peer-idot"
+        onClick={() => setInfo(true)}
+        title="Why a TCP proxy?"
+        aria-label="Why a TCP proxy?"
+      >
+        i
+      </button>
+      <span className="peer-link-cap">TCP proxy</span>
+      {info && (
+        <InfoModal title="Why a TCP proxy?" onClose={() => setInfo(false)}>
+          <p>
+            Browsers can&apos;t open raw TCP sockets, so the TLS connection to the server is relayed
+            through a WebSocket-to-TCP proxy ({new URL(PROXY_BASE).host}). It only forwards the
+            already-encrypted bytes — it can&apos;t read or change the traffic, and it is not the
+            verifier.
+          </p>
+        </InfoModal>
+      )}
+    </div>
+  );
+}
+
+// Linear topology row: the Server sits beside whichever browser opens the
+// connection — left of the prover in MPC, right of the verifier in Proxy.
+function Topo({
+  mode,
+  proving,
+  host,
+  proverLocal,
+  proverPane,
+  verifierPane,
+}: {
+  mode: Mode;
+  proving: boolean;
+  host: string;
+  proverLocal: boolean;
+  proverPane: ReactNode;
+  verifierPane: ReactNode;
+}) {
+  const serverSide = (
+    <>
+      <ServerNode mode={mode} host={host} />
+      <ProxyLink proving={proving} />
+    </>
+  );
+  return (
+    <div className="peer-topo">
+      {mode === 'Mpc' && serverSide}
+      <div
+        className={`peer-topo-pane peer-topo-pane--prover ${proverLocal ? 'peer-topo-pane--local' : 'peer-topo-pane--remote'}`}
+      >
+        {proverPane}
+      </div>
+      <Channel proving={proving} mode={mode} />
+      <div
+        className={`peer-topo-pane peer-topo-pane--verifier ${proverLocal ? 'peer-topo-pane--remote' : 'peer-topo-pane--local'}`}
+      >
+        {verifierPane}
+      </div>
+      {mode === 'Proxy' && (
+        <>
+          <ProxyLink proving={proving} />
+          <ServerNode mode={mode} host={host} />
+        </>
+      )}
+    </div>
+  );
+}
+
 // Role is decided by the URL: `?j=<peerId>` opens the verifier (it dials the
 // prover that is hosting that peer); no query opens the prover.
 export function PeerToPeerPage() {
@@ -61,9 +243,12 @@ export function PeerToPeerPage() {
       <div className="hero-section peer-hero">
         <h1 className="hero-title">Peer-to-peer web proofs</h1>
         <p className="hero-subtitle">
-          Prove a fact from any site with your extension, and let another device verify it directly
-          over a PeerJS data channel — the MPC-TLS session runs between two browsers, with no hosted
+          Use the TLSNotary extension to prove from this browser to another browser, on any machine
+          you like. The TLSNotary session runs peer-to-peer: no server in the middle, no hosted
           verifier.
+        </p>
+        <p className="peer-newcomer">
+          New to TLSNotary? <a href="/">Start with the main demo →</a>
         </p>
       </div>
 
@@ -79,21 +264,46 @@ export function PeerToPeerPage() {
 // ---------------------------------------------------------------------------
 
 function ProverView() {
-  const [connectStarted, setConnectStarted] = useState(false);
-  const host = usePeerHost(connectStarted);
+  // Host immediately so the join QR appears right away — no extra click.
+  const host = usePeerHost(true);
 
   const [selected, setSelected] = useState<string>(PLUGIN_ENTRIES[0]?.[0] ?? '');
+  const [mode, setMode] = useState<Mode>('Mpc');
+  const [showProtocolInfo, setShowProtocolInfo] = useState(false);
   const [proving, setProving] = useState(false);
   const [proveProgress, setProveProgress] = useState('');
   const [proveDone, setProveDone] = useState(false);
   const [proveError, setProveError] = useState<string | null>(null);
   const [hasExtension, setHasExtension] = useState<boolean | null>(null);
   const [qr, setQr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [verifier, setVerifier] = useState<RemoteVerifier>({ state: 'idle' });
 
-  // The content script injects window.tlsn shortly after load.
+  const plugin = plugins[selected];
+  const serverHost = plugin?.host ?? '';
+
+  // Detect the extension's injected window.tlsn. The content script injects it
+  // shortly after load; poll and also listen for the `tlsn_loaded` event so a
+  // late install is picked up automatically (once the page has the content
+  // script — a fresh install still needs a reload, offered in the warning).
   useEffect(() => {
-    const id = setTimeout(() => setHasExtension(!!window.tlsn?.execCode), 800);
-    return () => clearTimeout(id);
+    const check = () => {
+      if (window.tlsn?.execCode) {
+        setHasExtension(true);
+        clearInterval(interval);
+      } else {
+        setHasExtension((v) => (v === null ? false : v));
+      }
+    };
+    const initial = setTimeout(check, 800);
+    const interval = setInterval(check, 1500);
+    const onLoaded = () => check();
+    window.addEventListener('tlsn_loaded', onLoaded);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(interval);
+      window.removeEventListener('tlsn_loaded', onLoaded);
+    };
   }, []);
 
   const joinUrl = host.peerId ? `${window.location.origin}/peer.html?j=${host.peerId}` : null;
@@ -118,9 +328,16 @@ function ProverView() {
 
   const connected = host.status === 'connected' && !!host.conn;
 
-  // Bridge the extension's MPC byte stream over the page's data channel:
+  // Reflect verifier connection state in the remote pane as soon as paired.
+  useEffect(() => {
+    setVerifier((v) => (connected && v.state === 'idle' ? { state: 'connected' } : v));
+  }, [connected]);
+
+  // Bridge the extension's MPC byte stream over the page's data channel, and
+  // relay status both ways so each pane mirrors the other device:
   //  - extension → page (TLSN_PEER_DATA_OUT) → conn.send → verifier
-  //  - verifier → conn.on('data') → page → extension (TLSN_PEER_DATA_IN)
+  //  - extension progress → conn.send({t:'ps'}) → verifier's prover pane
+  //  - verifier → conn.on('data'): bytes → extension; {t:'vs'} → verifier pane
   const wireRelay = (conn: DataConnection, requestId: string): (() => void) => {
     const onWindow = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
@@ -133,20 +350,43 @@ function ProverView() {
           /* channel closed */
         }
       } else if (d.type === 'TLSN_PROVE_PROGRESS') {
-        // Forward the prover's limits to the verifier as a string frame (the
-        // data channel otherwise carries raw MPC bytes), then show progress.
         if (d.step === 'PEER_LIMITS') {
+          // First control frame: limits + mode + server name for the verifier.
+          // Stamp mode/server from this page's own state (authoritative) so the
+          // verifier always reflects the selected mode and target.
           try {
-            conn.send(d.message);
+            const limits = JSON.parse(d.message) as Omit<LimitsFrame, 't' | 'server'>;
+            conn.send(JSON.stringify({ t: 'limits', ...limits, mode, server: serverHost }));
           } catch {
             /* channel closed */
           }
         } else {
           setProveProgress(d.message ?? d.step ?? '');
+          try {
+            conn.send(JSON.stringify({ t: 'ps', step: d.step, message: d.message }));
+          } catch {
+            /* channel closed */
+          }
         }
       }
     };
     const onData = (raw: unknown) => {
+      if (typeof raw === 'string') {
+        // Status from the verifier — update its pane; don't relay as MPC bytes.
+        try {
+          const frame = JSON.parse(raw) as CtrlFrame;
+          if (frame.t === 'vs') {
+            setVerifier({
+              state: frame.state,
+              message: frame.message,
+              threads: frame.threads,
+            });
+          }
+        } catch {
+          /* ignore malformed control frame */
+        }
+        return;
+      }
       window.postMessage(
         { type: 'TLSN_PEER_DATA_IN', requestId, data: bytesToB64(toU8(raw)) },
         window.location.origin,
@@ -166,7 +406,6 @@ function ProverView() {
   };
 
   const handleProve = async () => {
-    const plugin = plugins[selected];
     if (!plugin || proving || !host.conn) return;
     if (!window.tlsn?.execCode) {
       setProveError('TLSNotary extension not detected on this page.');
@@ -178,13 +417,13 @@ function ProverView() {
     setProveError(null);
     setProveDone(false);
     setProveProgress('Starting…');
+    setVerifier({ state: 'verifying', message: 'Verifying…' });
     try {
       const code = await fetch(plugin.file).then((r) => r.text());
       await window.tlsn.execCode(code, {
         requestId,
-        // proxyBase: relay the prover↔server TCP through a reachable proxy
-        // (overrides the plugin's build-time ws://localhost:7047 origin).
-        sessionData: { peerRelay: '1', mode: 'Mpc', proxyBase: PROXY_BASE },
+        // proxyBase: where the server hop is tunnelled. mode: MPC or Proxy.
+        sessionData: { peerRelay: '1', mode, proxyBase: PROXY_BASE },
       });
       setProveDone(true);
     } catch (e: unknown) {
@@ -195,105 +434,220 @@ function ProverView() {
     }
   };
 
-  return (
-    <div className="peer-split peer-split--single">
-      <section className="peer-pane peer-pane--prover">
-        <div className="peer-pane-head">
-          <span className="peer-pane-role">Prover (this device)</span>
-          <span className="peer-pane-badge">extension · MPC</span>
+  const proverPane = (
+    <>
+      <div className="peer-pane-head">
+        <span className="peer-pane-role">
+          Prover <span className="peer-you">you</span>
+        </span>
+        <span className="peer-pane-badge">extension · {mode === 'Proxy' ? 'Proxy' : 'MPC'}</span>
+      </div>
+
+      <ol className="peer-steps">
+        <li>Pair a verifier (scan the code on the right)</li>
+        <li>Select what you want to prove (plugin)</li>
+        <li>Click Prove to the verifier, then follow the steps in the extension popup</li>
+      </ol>
+
+      {hasExtension === false && (
+        <div className="peer-check-warn">
+          ⚠️ TLSNotary extension not detected.{' '}
+          <a href={CHROME_STORE_URL} target="_blank" rel="noopener noreferrer">
+            Install from the Chrome Web Store
+          </a>
+          , then{' '}
+          <button type="button" className="peer-link-btn" onClick={() => window.location.reload()}>
+            recheck
+          </button>
+          .
         </div>
-        <p className="peer-pane-sub">
-          First connect a verifying device, then prove with your TLSNotary extension. PeerJS runs
-          here in the page; the extension only relays its proof bytes.
-        </p>
+      )}
 
-        {hasExtension === false && (
-          <div className="peer-check-warn">
-            ⚠️ TLSNotary extension not detected — you can still pair, but proving needs the
-            extension.
-          </div>
-        )}
+      <label className="peer-field-label" htmlFor="peer-plugin-select">
+        What do you want to prove?
+      </label>
+      <select
+        id="peer-plugin-select"
+        className="peer-select"
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+        disabled={proving}
+      >
+        {PLUGIN_ENTRIES.map(([key, p]) => (
+          <option key={key} value={key}>
+            {p.logo} {p.name}
+          </option>
+        ))}
+      </select>
+      {plugin?.description && <p className="peer-claim">{plugin.description}</p>}
 
-        {/* Step 1: connect */}
-        {!connected && (
+      <div className="peer-mode-row">
+        <span className="peer-field-label peer-field-label--inline">
+          Protocol{' '}
+          <button
+            type="button"
+            className="peer-info-btn"
+            onClick={() => setShowProtocolInfo(true)}
+            aria-label="About protocol modes"
+            title="MPC vs Proxy"
+          >
+            ⓘ
+          </button>
+        </span>
+        <div className="peer-seg" role="group" aria-label="Protocol mode">
+          <button
+            type="button"
+            className={`peer-seg-btn ${mode === 'Mpc' ? 'peer-seg-btn--active' : ''}`}
+            onClick={() => setMode('Mpc')}
+            disabled={proving}
+          >
+            MPC
+          </button>
+          <button
+            type="button"
+            className={`peer-seg-btn ${mode === 'Proxy' ? 'peer-seg-btn--active' : ''}`}
+            onClick={() => setMode('Proxy')}
+            disabled={proving}
+          >
+            Proxy
+          </button>
+        </div>
+      </div>
+
+      <button
+        className="plugin-run-btn"
+        onClick={handleProve}
+        disabled={!connected || proving || hasExtension === false}
+      >
+        {proving ? (
           <>
-            <button
-              className="plugin-run-btn"
-              onClick={() => setConnectStarted(true)}
-              disabled={connectStarted}
-            >
-              {connectStarted ? (
-                <>
-                  <span className="spinner" /> Waiting for verifier…
-                </>
-              ) : (
-                '▶ Connect a verifier'
-              )}
-            </button>
-            {host.error && <div className="peer-error">❌ {host.error}</div>}
-            {connectStarted && joinUrl && (
-              <div className="peer-qr-block">
-                <div className="peer-fields-title">Scan with the verifying device</div>
-                {qr && <img className="peer-qr" src={qr} alt="Verifier join QR code" />}
-                <div className="peer-link-row">
-                  <input className="peer-link-input" readOnly value={joinUrl} />
-                </div>
-              </div>
-            )}
+            <span className="spinner" /> Proving…
           </>
+        ) : !connected ? (
+          'Waiting for verifier…'
+        ) : proveDone ? (
+          '▶ Prove again'
+        ) : (
+          '▶ Prove to the verifier'
         )}
+      </button>
 
-        {/* Step 2: prove (only after the verifier is connected) */}
-        {connected && (
-          <>
-            <div className="peer-proof-sent">✓ Verifier connected — ready to prove.</div>
+      {proving && proveProgress && !proveDone && (
+        <div className="peer-selftest-progress">
+          <span className="spinner spinner--dark" /> {proveProgress}
+        </div>
+      )}
+      {proveError && <div className="peer-error">❌ {proveError}</div>}
+      {proveDone && !proveError && (
+        <div className="peer-proof-sent">✓ Proof complete — verified on the other device.</div>
+      )}
 
-            <label className="peer-field-label" htmlFor="peer-plugin-select">
-              Plugin
-            </label>
-            <select
-              id="peer-plugin-select"
-              className="peer-select"
-              value={selected}
-              onChange={(e) => setSelected(e.target.value)}
-              disabled={proving}
-            >
-              {PLUGIN_ENTRIES.map(([key, p]) => (
-                <option key={key} value={key}>
-                  {p.logo} {p.name}
-                </option>
-              ))}
-            </select>
+      {showProtocolInfo && (
+        <InfoModal title="Protocol: MPC vs Proxy" onClose={() => setShowProtocolInfo(false)}>
+          <p>
+            <strong>MPC</strong> — strongest. The verifier helps run the TLS session with you via
+            secure multi-party computation, so it can vouch for the data while never seeing your
+            connection or login.
+          </p>
+          <p>
+            <strong>Proxy</strong> — faster. The verifier relays your encrypted connection to the
+            server, so it sits in the data path (it still can&apos;t read the TLS traffic). Best
+            when the verifier is an independent party.
+          </p>
+        </InfoModal>
+      )}
+    </>
+  );
 
-            <button
-              className="plugin-run-btn"
-              onClick={handleProve}
-              disabled={proving || hasExtension === false}
-            >
-              {proving ? (
-                <>
-                  <span className="spinner" /> Proving…
-                </>
-              ) : (
-                '▶ Prove to the verifier'
-              )}
-            </button>
+  const verifierPane = (
+    <>
+      <div className="peer-pane-head">
+        <span className="peer-pane-role">Verifier</span>
+        <span className="peer-pane-badge">📱 other device</span>
+      </div>
+      {!connected ? (
+        <>
+          <span className="peer-status-pill peer-status-pill--idle">Waiting</span>
+          <p className="peer-pane-msg">
+            Scan with the device that will verify, or open the link in another browser.
+          </p>
+          {host.error && <div className="peer-error">❌ {host.error}</div>}
+          {qr && <img className="peer-qr" src={qr} alt="Verifier join QR code" />}
+          {joinUrl && (
+            <div className="peer-link-row">
+              <input className="peer-link-input" readOnly value={joinUrl} />
+              <button
+                type="button"
+                className="peer-copy-icon"
+                title={copied ? 'Copied' : 'Copy link'}
+                aria-label="Copy link"
+                onClick={() => {
+                  navigator.clipboard
+                    .writeText(joinUrl)
+                    .then(() => {
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 1500);
+                    })
+                    .catch(() => {
+                      /* clipboard unavailable */
+                    });
+                }}
+              >
+                {copied ? (
+                  '✓'
+                ) : (
+                  <svg
+                    width="15"
+                    height="15"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          )}
+          <p className="peer-disclaimer">
+            Uses WebRTC (PeerJS) — may fail on restrictive networks or firewalls.
+          </p>
+        </>
+      ) : (
+        <>
+          <span className={`peer-status-pill peer-status-pill--${pillClass(verifier.state)}`}>
+            {verifier.state === 'verifying'
+              ? 'Verifying'
+              : verifier.state === 'verified'
+                ? 'Verified'
+                : 'Connected'}
+          </span>
+          <p className="peer-pane-msg">
+            {(verifier.state === 'idle' || verifier.state === 'connected') &&
+              'Connected — ready to verify.'}
+            {verifier.state === 'verifying' && (verifier.message || 'Verifying the TLS session…')}
+            {verifier.state === 'verified' && '✓ Verified independently on the other device.'}
+            {verifier.state === 'error' && (verifier.message || 'Verification failed.')}
+          </p>
+        </>
+      )}
+    </>
+  );
 
-            {proving && proveProgress && !proveDone && (
-              <div className="peer-selftest-progress">
-                <span className="spinner spinner--dark" /> {proveProgress}
-              </div>
-            )}
-            {proveError && <div className="peer-error">❌ {proveError}</div>}
-            {proveDone && !proveError && (
-              <div className="peer-proof-sent">
-                ✓ Proof complete — verified on the other device.
-              </div>
-            )}
-          </>
-        )}
-      </section>
-    </div>
+  return (
+    <Topo
+      mode={mode}
+      proving={proving}
+      host={serverHost}
+      proverLocal
+      proverPane={proverPane}
+      verifierPane={verifierPane}
+    />
   );
 }
 
@@ -315,7 +669,13 @@ function VerifierView({ joinId }: { joinId: string }) {
   const [progress, setProgress] = useState('');
   const [result, setResult] = useState<VerifierResult | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const started = useRef(false);
+  const [mode, setMode] = useState<Mode>('Mpc');
+  const [server, setServer] = useState('');
+  const [prover, setProver] = useState<RemoteProver>({ state: 'idle' });
+  // True while a verifier session is in flight — guards against starting a
+  // second session over the same channel while one is running.
+  const runningRef = useRef(false);
+  const [busy, setBusy] = useState(false);
 
   // Boot the WASM runtime (needs cross-origin isolation — provided for ?j= pages).
   useEffect(() => {
@@ -344,93 +704,195 @@ function VerifierView({ joinId }: { joinId: string }) {
   // consume the MPC stream the instant the channel opens.
   const dialer = usePeerDialer(wasm.state === 'ready' ? joinId : null);
 
-  // The prover sends its limits as the first (string) frame; adopt them — same
-  // model as the verifier server, which takes the prover's register limits.
-  // Subsequent frames are raw MPC bytes handled inside runVerifierSession.
+  // Mark the prover connected once the channel opens — before it starts proving.
   useEffect(() => {
-    if (!dialer.conn || wasm.state !== 'ready' || started.current) return;
+    if (dialer.status === 'connected') {
+      setProver((p) => (p.state === 'idle' ? { state: 'connected' } : p));
+    }
+  }, [dialer.status]);
+
+  // The prover sends its limits as the first (string) frame; adopt them and
+  // start the session. It also streams {t:'ps'} status; we mirror it in the
+  // prover pane and stream {t:'vs'} back so the prover sees our state.
+  useEffect(() => {
+    if (!dialer.conn || wasm.state !== 'ready') return;
     const conn = dialer.conn;
-    const onFirst = (d: unknown) => {
-      if (typeof d !== 'string' || started.current) return;
-      let limits: PeerLimits;
+
+    const sendVs = (frame: Omit<VerifierStatusFrame, 't'>) => {
       try {
-        limits = JSON.parse(d) as PeerLimits;
+        conn.send(JSON.stringify({ t: 'vs', ...frame }));
+      } catch {
+        /* channel closed */
+      }
+    };
+
+    const onCtrl = (raw: unknown) => {
+      if (typeof raw !== 'string') return; // MPC bytes handled in runVerifierSession
+      let frame: CtrlFrame;
+      try {
+        frame = JSON.parse(raw) as CtrlFrame;
       } catch {
         return;
       }
-      started.current = true;
-      conn.off('data', onFirst);
-      setProgress('Starting verifier…');
-      runVerifierSession(limits, conn, setProgress)
-        .then(setResult)
-        .catch((e: unknown) => setError(e instanceof Error ? e.message : String(e)));
+      if (frame.t === 'ps') {
+        setProver({ state: 'proving', message: frame.message });
+      } else if (frame.t === 'limits' && !runningRef.current) {
+        // Each `limits` frame is a fresh proof — start a new verifier session.
+        // Repeatable: the prover can prove again over the same channel.
+        runningRef.current = true;
+        setBusy(true);
+        setResult(null);
+        setError(null);
+        if (frame.mode) setMode(frame.mode);
+        if (frame.server) setServer(frame.server);
+        setProver({ state: 'proving', message: 'Proving…' });
+        setProgress('Starting verifier…');
+        sendVs({ state: 'connected', threads: wasm.threads });
+        const onProg = (m: string) => {
+          setProgress(m);
+          sendVs({ state: 'verifying', message: m });
+        };
+        runVerifierSession(
+          { maxSentData: frame.maxSentData, maxRecvData: frame.maxRecvData, proxyBase: PROXY_BASE },
+          conn,
+          onProg,
+        )
+          .then((r) => {
+            setResult(r);
+            setProver({ state: 'done', message: 'Proof complete' });
+            sendVs({ state: 'verified', serverName: r.serverName, threads: r.threads });
+          })
+          .catch((e: unknown) => {
+            const msg = e instanceof Error ? e.message : String(e);
+            setError(msg);
+            setProver({ state: 'error', message: msg });
+            sendVs({ state: 'error', message: msg });
+          })
+          .finally(() => {
+            runningRef.current = false;
+            setBusy(false);
+          });
+      }
     };
-    conn.on('data', onFirst);
-    return () => {
-      conn.off('data', onFirst);
-    };
-  }, [dialer.conn, wasm.state]);
 
+    conn.on('data', onCtrl);
+    return () => {
+      conn.off('data', onCtrl);
+    };
+  }, [dialer.conn, wasm.state, wasm.threads]);
+
+  const proving = busy;
   const connecting = wasm.state === 'ready' && !result && !error && dialer.status !== 'error';
 
-  return (
-    <div className="peer-split peer-split--single">
-      <div className={`peer-wasm-banner peer-wasm-banner--${wasm.state}`}>
-        {wasm.state === 'ready' && (
-          <span>
-            🦀 In-browser verifier ready — WASM running with {wasm.threads} thread
-            {wasm.threads === 1 ? '' : 's'}
-          </span>
-        )}
-        {(wasm.state === 'initializing' || wasm.state === 'idle') && (
-          <span>
-            <span className="spinner spinner--dark" /> Loading in-browser TLSNotary verifier…
-          </span>
-        )}
-        {wasm.state === 'error' && <span>⚠️ In-browser verifier unavailable: {wasm.error}</span>}
+  const proverPane = (
+    <>
+      <div className="peer-pane-head">
+        <span className="peer-pane-role">Prover</span>
+        <span className="peer-pane-badge">💻 other device</span>
       </div>
-
-      <section className="peer-pane peer-pane--verifier">
-        <div className="peer-pane-head">
-          <span className="peer-pane-role">Verifier (this device)</span>
-          <span
-            className={`peer-status-pill peer-status-pill--${result ? 'verified' : error ? 'error' : 'connected'}`}
-          >
-            {result ? 'Verified' : error ? 'Error' : 'Verifying'}
-          </span>
-        </div>
-        <p className="peer-pane-sub">
-          Runs the MPC-TLS verifier in this browser and confirms what the prover proved.
-        </p>
-
-        {connecting && (
-          <div className="peer-verifier-progress">
-            <span className="spinner spinner--dark" />
-            <div>
-              <div className="peer-verifier-progress-title">
-                {dialer.status === 'connected' ? 'Verifying…' : 'Connecting to prover…'}
-              </div>
-              <div className="peer-verifier-progress-msg">{progress}</div>
-            </div>
-          </div>
-        )}
-
-        {dialer.error && !result && <div className="peer-error">❌ {dialer.error}</div>}
-        {error && <div className="peer-error">❌ {error}</div>}
-
-        {result && (
+      <span className={`peer-status-pill peer-status-pill--${pillClass(prover.state)}`}>
+        {prover.state === 'idle'
+          ? 'Connecting'
+          : prover.state === 'proving'
+            ? 'Proving'
+            : prover.state === 'done'
+              ? 'Done'
+              : prover.state === 'error'
+                ? 'Error'
+                : 'Connected'}
+      </span>
+      <p className="peer-pane-msg">
+        {prover.state === 'idle' && 'Connecting to the prover…'}
+        {prover.state === 'connected' && 'Connected — waiting for it to start the proof.'}
+        {prover.state === 'proving' && (
           <>
-            <div className="peer-verdict">
-              ✓ Verified in-browser — TLS session to {result.serverName ?? 'server'} authenticated (
-              {result.threads} threads, {(result.ms / 1000).toFixed(1)}s)
-            </div>
-            <div className="peer-fields-title">Received (verifier's authenticated view)</div>
-            <pre className="peer-selftest-pre">{result.recv}</pre>
-            <div className="peer-fields-title">Sent</div>
-            <pre className="peer-selftest-pre">{result.sent}</pre>
+            Proving {server || 'a site'}
+            {prover.message ? ` — ${prover.message}` : '…'}
           </>
         )}
-      </section>
-    </div>
+        {prover.state === 'done' && '✓ Proof sent.'}
+        {prover.state === 'error' && (prover.message || 'Prover error.')}
+      </p>
+    </>
+  );
+
+  const verifierPane = (
+    <>
+      <div className="peer-pane-head">
+        <span className="peer-pane-role">
+          Verifier <span className="peer-you">you</span>
+        </span>
+        <span className="peer-pane-badge">🦀 in-browser WASM</span>
+      </div>
+
+      {wasm.state === 'error' && (
+        <div className="peer-error">⚠️ In-browser verifier unavailable: {wasm.error}</div>
+      )}
+
+      {connecting && (
+        <div className="peer-verifier-progress">
+          <span className="spinner spinner--dark" />
+          <div>
+            <div className="peer-verifier-progress-title">
+              {proving
+                ? 'Verifying…'
+                : dialer.status === 'connected'
+                  ? 'Waiting for the prover…'
+                  : 'Connecting to prover…'}
+            </div>
+            <div className="peer-verifier-progress-msg">
+              {proving ? progress : 'The prover will start the proof from the other device.'}
+            </div>
+            {proving && server && (
+              <div className="peer-verifier-progress-msg">
+                {mode === 'Proxy' ? 'Proxy' : 'MPC'} mode · {server}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {dialer.error && !result && <div className="peer-error">❌ {dialer.error}</div>}
+      {error && <div className="peer-error">❌ {error}</div>}
+
+      {result && (
+        <>
+          <div className="peer-verdict">
+            ✓ Verified in this browser — authenticated TLS session to{' '}
+            {result.serverName ?? 'the server'} in {(result.ms / 1000).toFixed(1)}s
+          </div>
+          <div className="peer-fields-title">Request sent</div>
+          <pre className="peer-selftest-pre">{result.sent}</pre>
+          <div className="peer-fields-title">Response received (authenticated)</div>
+          <pre className="peer-selftest-pre">{result.recv}</pre>
+        </>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {/* Only surface the runtime banner while loading or on error — once ready,
+          the verifier pane's "🦀 in-browser WASM" badge already says it. */}
+      {wasm.state !== 'ready' && (
+        <div className={`peer-wasm-banner peer-wasm-banner--${wasm.state}`}>
+          {(wasm.state === 'initializing' || wasm.state === 'idle') && (
+            <span>
+              <span className="spinner spinner--dark" /> Loading in-browser TLSNotary verifier…
+            </span>
+          )}
+          {wasm.state === 'error' && <span>⚠️ In-browser verifier unavailable: {wasm.error}</span>}
+        </div>
+      )}
+
+      <Topo
+        mode={mode}
+        proving={proving}
+        host={server}
+        proverLocal={false}
+        proverPane={proverPane}
+        verifierPane={verifierPane}
+      />
+    </>
   );
 }

--- a/packages/demo/src/peer/PeerToPeerPage.tsx
+++ b/packages/demo/src/peer/PeerToPeerPage.tsx
@@ -335,7 +335,7 @@ function ProverView() {
 
   // Bridge the extension's MPC byte stream over the page's data channel, and
   // relay status both ways so each pane mirrors the other device:
-  //  - extension → page (TLSN_PEER_DATA_OUT) → conn.send → verifier
+  //  - extension → page (TLSN_RELAY_OUT) → conn.send → verifier
   //  - extension progress → conn.send({t:'ps'}) → verifier's prover pane
   //  - verifier → conn.on('data'): bytes → extension; {t:'vs'} → verifier pane
   const wireRelay = (conn: DataConnection, requestId: string): (() => void) => {
@@ -343,14 +343,14 @@ function ProverView() {
       if (event.origin !== window.location.origin) return;
       const d = event.data;
       if (!d || d.requestId !== requestId) return;
-      if (d.type === 'TLSN_PEER_DATA_OUT') {
+      if (d.type === 'TLSN_RELAY_OUT') {
         try {
           conn.send(b64ToBytes(d.data));
         } catch {
           /* channel closed */
         }
       } else if (d.type === 'TLSN_PROVE_PROGRESS') {
-        if (d.step === 'PEER_LIMITS') {
+        if (d.step === 'RELAY_LIMITS') {
           // First control frame: limits + mode + server name for the verifier.
           // Stamp mode/server from this page's own state (authoritative) so the
           // verifier always reflects the selected mode and target.
@@ -388,12 +388,12 @@ function ProverView() {
         return;
       }
       window.postMessage(
-        { type: 'TLSN_PEER_DATA_IN', requestId, data: bytesToB64(toU8(raw)) },
+        { type: 'TLSN_RELAY_IN', requestId, data: bytesToB64(toU8(raw)) },
         window.location.origin,
       );
     };
     const onClose = () => {
-      window.postMessage({ type: 'TLSN_PEER_DATA_CLOSED', requestId }, window.location.origin);
+      window.postMessage({ type: 'TLSN_RELAY_CLOSED', requestId }, window.location.origin);
     };
     window.addEventListener('message', onWindow);
     conn.on('data', onData);
@@ -423,7 +423,7 @@ function ProverView() {
       await window.tlsn.execCode(code, {
         requestId,
         // proxyBase: where the server hop is tunnelled. mode: MPC or Proxy.
-        sessionData: { peerRelay: '1', mode, proxyBase: PROXY_BASE },
+        sessionData: { relay: '1', mode, proxyBase: PROXY_BASE },
       });
       setProveDone(true);
     } catch (e: unknown) {

--- a/packages/demo/src/peer/main-peer.tsx
+++ b/packages/demo/src/peer/main-peer.tsx
@@ -1,0 +1,10 @@
+import ReactDOM from 'react-dom/client';
+import { PeerToPeerPage } from './PeerToPeerPage';
+
+// Separate, cross-origin-isolated entry (see vite.config.ts). The WASM verifier
+// needs SharedArrayBuffer, which requires COOP/COEP on this document. No analytics
+// here so the isolation doesn't block cross-origin scripts.
+//
+// Note: no React.StrictMode here — its dev-only double-mount would tear down and
+// recreate the long-lived PeerJS connection and WASM session mid-proof.
+ReactDOM.createRoot(document.getElementById('root')!).render(<PeerToPeerPage />);

--- a/packages/demo/src/peer/peer.css
+++ b/packages/demo/src/peer/peer.css
@@ -151,33 +151,45 @@
   padding: var(--spacing-lg);
   margin-bottom: var(--spacing-lg);
 }
-.peer-mode-tabs {
+/* Compact protocol selector: label + ⓘ on the left, segmented MPC/Proxy right. */
+.peer-mode-row {
   display: flex;
-  gap: var(--spacing-xs);
-  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-md);
 }
-.peer-mode-tab {
-  flex: 1;
-  min-width: 140px;
-  padding: 0.6rem 0.9rem;
-  border: 1px solid var(--gray-200);
+.peer-field-label--inline {
+  margin-bottom: 0;
+}
+.peer-seg {
+  display: inline-flex;
+  border: 1px solid var(--gray-300);
   border-radius: var(--radius-md);
-  background: var(--gray-50);
-  color: var(--gray-700);
-  font-size: 0.92rem;
-  font-weight: 600;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.peer-seg-btn {
+  border: 0;
+  background: #fff;
+  color: var(--gray-600);
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+  padding: 0.35rem 0.9rem;
   cursor: pointer;
-  transition:
-    background 0.15s,
-    border-color 0.15s;
+  transition: background 0.15s;
 }
-.peer-mode-tab:hover {
-  border-color: var(--primary-light);
+.peer-seg-btn + .peer-seg-btn {
+  border-left: 1px solid var(--gray-300);
 }
-.peer-mode-tab--active {
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
-  border-color: transparent;
+.peer-seg-btn--active {
+  background: var(--primary);
   color: #fff;
+}
+.peer-seg-btn:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 .peer-conn-body {
   margin-top: var(--spacing-md);
@@ -221,25 +233,26 @@
   background: #fff;
   min-width: 0;
 }
-.peer-copy-btn {
-  padding: 0.6rem 1rem;
-  border: none;
+.peer-copy-icon {
+  flex: 0 0 auto;
+  width: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--gray-300);
   border-radius: var(--radius-md);
-  background: var(--primary);
-  color: #fff;
-  font-weight: 600;
-  font-size: 0.88rem;
+  background: #fff;
+  color: var(--gray-600);
   cursor: pointer;
-  white-space: nowrap;
 }
-.peer-copy-btn:disabled {
-  background: var(--gray-300);
-  cursor: not-allowed;
+.peer-copy-icon:hover {
+  border-color: var(--primary);
+  color: var(--primary);
 }
 .peer-qr {
   display: block;
-  width: 180px;
-  height: 180px;
+  width: 150px;
+  height: 150px;
   border-radius: var(--radius-md);
   border: 1px solid var(--gray-200);
 }
@@ -343,6 +356,150 @@
   margin-bottom: var(--spacing-md);
   font-size: 0.9rem;
 }
+.peer-check-warn a {
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+}
+.peer-link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+/* "More info" modal */
+.peer-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 27, 45, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  z-index: 1000;
+}
+.peer-modal {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  max-width: 420px;
+  width: 100%;
+  padding: var(--spacing-lg);
+}
+.peer-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+.peer-modal-title {
+  font-weight: 800;
+  color: var(--gray-900);
+  font-size: 1.05rem;
+}
+.peer-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  color: var(--gray-500);
+  cursor: pointer;
+  padding: 0 0.2rem;
+}
+.peer-modal-body {
+  margin: 0;
+  color: var(--gray-700);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.peer-modal-body p {
+  margin: 0 0 0.6rem;
+}
+.peer-modal-body p:last-child {
+  margin-bottom: 0;
+}
+
+/* Small inline "ⓘ" info trigger next to a field label. */
+.peer-info-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1;
+  color: var(--gray-400);
+  cursor: pointer;
+  vertical-align: middle;
+}
+.peer-info-btn:hover {
+  color: var(--primary);
+}
+
+/* "What you'll prove" helper line under the plugin select. */
+.peer-claim {
+  margin: -0.4rem 0 var(--spacing-md);
+  font-size: 0.82rem;
+  color: var(--gray-600);
+  line-height: 1.4;
+}
+
+/* Numbered "how it works" steps in the prover pane. */
+.peer-steps {
+  list-style: none;
+  counter-reset: peer-step;
+  margin: 0 0 var(--spacing-md);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.peer-steps li {
+  counter-increment: peer-step;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.84rem;
+  color: var(--gray-600);
+}
+.peer-steps li::before {
+  content: counter(peer-step);
+  flex: 0 0 auto;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: var(--primary);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* "New to TLSNotary?" pointer under the hero. */
+.peer-newcomer {
+  margin: var(--spacing-sm) 0 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+.peer-newcomer a {
+  color: #fff;
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+/* Muted connectivity disclaimer inside the verifier pane (white card). */
+.peer-disclaimer {
+  color: var(--gray-500);
+  font-size: 0.78rem;
+  line-height: 1.4;
+  margin: var(--spacing-sm) 0 0;
+}
 
 .peer-error {
   background: var(--error-light);
@@ -374,11 +531,12 @@
   background: var(--gray-200);
   color: var(--gray-600);
 }
-.peer-status-pill--connected,
+.peer-status-pill--progress,
 .peer-status-pill--receiving {
   background: #dbeafe;
   color: #1e40af;
 }
+.peer-status-pill--connected,
 .peer-status-pill--verified {
   background: var(--success-light);
   color: #065f46;
@@ -479,4 +637,245 @@
   background: rgba(255, 255, 255, 0.15);
   padding: 0.1rem 0.35rem;
   border-radius: var(--radius-sm);
+}
+
+/* ===================================================================
+   Linear topology row: [Server]—ⓘ—[Prover] ~PeerJS~ [Verifier]. The Server
+   (and its TCP-proxy ⓘ link) sits beside whichever browser opens the server
+   connection — left of the prover in MPC, right of the verifier in Proxy.
+   =================================================================== */
+.peer-topo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  padding: var(--spacing-lg);
+}
+.peer-topo-pane {
+  flex: 0 1 320px;
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  background: var(--gray-50);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-height: 170px;
+  transition:
+    box-shadow 0.2s,
+    opacity 0.2s,
+    border-color 0.2s;
+}
+.peer-topo-pane--remote {
+  background: var(--gray-100);
+}
+.peer-topo-pane--local {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(36, 63, 95, 0.08);
+  background: #fff;
+}
+.peer-you {
+  font-size: 0.65rem;
+  font-weight: 700;
+  background: var(--primary);
+  color: #fff;
+  border-radius: var(--radius-sm);
+  padding: 0.05rem 0.4rem;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+.peer-pane-msg {
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+/* PeerJS channel + animated packets */
+.peer-topo-channel {
+  flex: 0 0 96px;
+  align-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.peer-track {
+  position: relative;
+  width: 100%;
+  height: 56px;
+}
+.peer-rail {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #6366f1;
+  border-radius: 2px;
+  transform: translateY(-50%);
+}
+.peer-clabel {
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  color: #6366f1;
+  text-transform: uppercase;
+  margin-top: 0.4rem;
+  text-align: center;
+}
+.peer-packet {
+  position: absolute;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-top: -3.5px;
+  opacity: 0;
+}
+.peer-packet--fwd {
+  background: var(--primary);
+}
+.peer-packet--rev {
+  background: var(--success);
+}
+.peer-track--proving .peer-packet--fwd {
+  animation: peerFwd 1.1s linear infinite;
+  opacity: 1;
+}
+.peer-track--proving .peer-packet--rev {
+  animation: peerRev 1.6s linear infinite;
+  opacity: 1;
+}
+@keyframes peerFwd {
+  from {
+    left: 4%;
+  }
+  to {
+    left: 92%;
+  }
+}
+@keyframes peerRev {
+  from {
+    left: 92%;
+  }
+  to {
+    left: 4%;
+  }
+}
+
+/* Server↔browser hop: a connector line with the TCP-proxy ⓘ. */
+.peer-link {
+  flex: 0 0 84px;
+  position: relative;
+  align-self: center;
+  height: 44px;
+  display: flex;
+  align-items: center;
+}
+.peer-link-rail {
+  height: 2px;
+  width: 100%;
+  background: #d98a1f;
+  opacity: 0.55;
+}
+.peer-link-rail--flow {
+  opacity: 1;
+  background-image: linear-gradient(90deg, #d98a1f 0 50%, transparent 0);
+  background-size: 12px 2px;
+  animation: peerDash 0.6s linear infinite;
+}
+@keyframes peerDash {
+  to {
+    background-position: 12px 0;
+  }
+}
+.peer-idot {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1.5px solid #d98a1f;
+  background: #fff;
+  color: #d98a1f;
+  font-weight: 800;
+  font-style: italic;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.peer-idot:hover {
+  background: #d98a1f;
+  color: #fff;
+}
+.peer-link-cap {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 4px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  white-space: nowrap;
+}
+.peer-node-n {
+  font-size: 0.7rem;
+  color: var(--gray-500);
+  margin-top: 0.1rem;
+}
+
+/* Server card — same visual language as the prover/verifier panes. */
+.peer-topo-node {
+  flex: 0 0 auto;
+  align-self: center;
+  border: 1.5px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: #fff;
+  min-width: 210px;
+  max-width: 240px;
+  text-align: left;
+}
+.peer-topo-node .peer-pane-head {
+  margin-bottom: var(--spacing-xs);
+}
+.peer-node-host {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9rem;
+  color: var(--gray-800);
+  word-break: break-all;
+}
+
+/* Narrow screens: stack the row vertically (the demo targets wide screens). */
+@media (max-width: 1040px) {
+  .peer-topo {
+    flex-direction: column;
+  }
+  .peer-topo-pane,
+  .peer-topo-node {
+    flex-basis: auto;
+    width: 100%;
+    max-width: 420px;
+  }
+  .peer-topo-channel {
+    flex-basis: auto;
+    width: 100%;
+  }
+  .peer-topo-channel .peer-track {
+    height: 32px;
+  }
+  .peer-link {
+    flex-basis: auto;
+    width: 100%;
+    max-width: 420px;
+  }
 }

--- a/packages/demo/src/peer/peer.css
+++ b/packages/demo/src/peer/peer.css
@@ -1,0 +1,482 @@
+/* Peer-to-peer demo page styles. Reuses the design tokens and several shared
+   classes (content-card, plugin-run-btn, spinner, plugin-progress*) from App.css. */
+
+.peer-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: var(--spacing-md);
+}
+.peer-back-link {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  font-weight: 600;
+}
+.peer-back-link:hover {
+  text-decoration: underline;
+}
+.peer-tag {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  color: #fff;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.peer-hero {
+  padding: var(--spacing-xl) 0;
+}
+
+/* In-browser WASM runtime status banner */
+.peer-wasm-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  border-radius: var(--radius-md);
+  padding: 0.6rem 1rem;
+  margin-bottom: var(--spacing-md);
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.peer-wasm-banner--ready {
+  background: var(--success-light);
+  color: #065f46;
+  border-color: rgba(16, 185, 129, 0.3);
+}
+.peer-wasm-banner--initializing,
+.peer-wasm-banner--idle {
+  background: #dbeafe;
+  color: #1e40af;
+  border-color: rgba(59, 130, 246, 0.3);
+}
+.peer-wasm-banner--error {
+  background: var(--warning-light);
+  color: #92400e;
+  border-color: rgba(245, 158, 11, 0.3);
+}
+
+.peer-channel-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  margin-bottom: var(--spacing-lg);
+  font-size: 0.95rem;
+  flex-wrap: wrap;
+}
+.peer-channel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.3);
+  flex-shrink: 0;
+}
+.peer-channel-note {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* In-browser self-test */
+.peer-selftest {
+  background: #fff;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  padding: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  border-left: 4px solid var(--secondary);
+}
+.peer-selftest-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
+}
+.peer-selftest-title {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--gray-900);
+}
+.peer-selftest-sub {
+  color: var(--gray-600);
+  font-size: 0.9rem;
+  margin-top: 0.2rem;
+  max-width: 48ch;
+}
+.peer-selftest-btn {
+  width: auto;
+  flex-shrink: 0;
+}
+.peer-selftest-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+.peer-selftest-result {
+  margin-top: var(--spacing-md);
+}
+.peer-selftest-pre {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm);
+  font-size: 0.8rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 220px;
+  overflow: auto;
+  margin: 0 0 var(--spacing-sm);
+  color: var(--gray-800);
+}
+
+/* Connection panel */
+.peer-conn-panel {
+  background: rgba(255, 255, 255, 0.96);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  padding: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+}
+.peer-mode-tabs {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+.peer-mode-tab {
+  flex: 1;
+  min-width: 140px;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  background: var(--gray-50);
+  color: var(--gray-700);
+  font-size: 0.92rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+}
+.peer-mode-tab:hover {
+  border-color: var(--primary-light);
+}
+.peer-mode-tab--active {
+  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
+  border-color: transparent;
+  color: #fff;
+}
+.peer-conn-body {
+  margin-top: var(--spacing-md);
+}
+.peer-conn-body--loopback {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: var(--gray-700);
+  font-size: 0.95rem;
+}
+.peer-conn-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+.peer-conn-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gray-600);
+}
+.peer-conn-hint {
+  color: var(--gray-600);
+  font-size: 0.9rem;
+  margin: 0 0 var(--spacing-sm);
+}
+.peer-link-row {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
+}
+.peer-link-input {
+  flex: 1;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--gray-800);
+  background: #fff;
+  min-width: 0;
+}
+.peer-copy-btn {
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.88rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.peer-copy-btn:disabled {
+  background: var(--gray-300);
+  cursor: not-allowed;
+}
+.peer-qr {
+  display: block;
+  width: 180px;
+  height: 180px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--gray-200);
+}
+.peer-qr-block {
+  margin-top: var(--spacing-lg);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--gray-200);
+}
+
+.peer-split {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--spacing-lg);
+  align-items: start;
+}
+.peer-split--single {
+  grid-template-columns: minmax(0, 560px);
+  justify-content: center;
+}
+.peer-arrow {
+  align-self: center;
+  font-size: 2rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+@media (max-width: 860px) {
+  .peer-split {
+    grid-template-columns: 1fr;
+  }
+  .peer-arrow {
+    transform: rotate(90deg);
+    justify-self: center;
+  }
+}
+
+.peer-pane {
+  background: #fff;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  padding: var(--spacing-xl);
+}
+.peer-pane--prover {
+  border-top: 4px solid var(--primary);
+}
+.peer-pane--verifier {
+  border-top: 4px solid var(--secondary);
+}
+
+.peer-pane-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-xs);
+}
+.peer-pane-role {
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--gray-900);
+}
+.peer-pane-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--gray-100);
+  color: var(--gray-600);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+}
+.peer-pane-sub {
+  color: var(--gray-600);
+  font-size: 0.95rem;
+  margin: 0 0 var(--spacing-lg);
+}
+
+.peer-field-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gray-700);
+  margin-bottom: var(--spacing-xs);
+}
+.peer-select {
+  width: 100%;
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+  background: #fff;
+  color: var(--gray-900);
+  margin-bottom: var(--spacing-md);
+}
+.peer-run-btn {
+  width: 100%;
+}
+
+.peer-check-warn {
+  background: var(--warning-light);
+  color: #92400e;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  font-size: 0.9rem;
+}
+
+.peer-error {
+  background: var(--error-light);
+  color: #991b1b;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-top: var(--spacing-md);
+  font-size: 0.9rem;
+}
+.peer-proof-sent {
+  background: var(--success-light);
+  color: #065f46;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-top: var(--spacing-md);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.peer-status-pill {
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+.peer-status-pill--idle {
+  background: var(--gray-200);
+  color: var(--gray-600);
+}
+.peer-status-pill--connected,
+.peer-status-pill--receiving {
+  background: #dbeafe;
+  color: #1e40af;
+}
+.peer-status-pill--verified {
+  background: var(--success-light);
+  color: #065f46;
+}
+.peer-status-pill--error {
+  background: var(--error-light);
+  color: #991b1b;
+}
+
+.peer-verifier-empty {
+  color: var(--gray-500);
+  font-size: 0.95rem;
+  padding: var(--spacing-lg) 0;
+  text-align: center;
+}
+.peer-verifier-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md) 0;
+}
+.peer-verifier-progress-title {
+  font-weight: 600;
+  color: var(--gray-800);
+}
+.peer-verifier-progress-msg {
+  color: var(--gray-500);
+  font-size: 0.9rem;
+}
+
+.spinner--dark {
+  border: 2px solid var(--gray-300);
+  border-top-color: var(--primary);
+}
+
+.peer-verdict {
+  background: var(--success-light);
+  color: #065f46;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  font-weight: 700;
+  margin-bottom: var(--spacing-md);
+}
+.peer-fields-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--gray-700);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: var(--spacing-xs);
+}
+.peer-fields {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+.peer-fields th {
+  text-align: left;
+  color: var(--gray-500);
+  font-weight: 600;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+.peer-fields td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--gray-100);
+  vertical-align: top;
+}
+.peer-fields-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  word-break: break-word;
+  color: var(--gray-800);
+}
+.peer-dir {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--radius-sm);
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+.peer-dir--sent {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+.peer-dir--recv {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.peer-footnote {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.85rem;
+  margin-top: var(--spacing-xl);
+  line-height: 1.6;
+}
+.peer-footnote code {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+}

--- a/packages/demo/src/peer/peer.css
+++ b/packages/demo/src/peer/peer.css
@@ -304,6 +304,10 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  /* Wrap the badge to its own line (intact) rather than break it mid-word when
+     the pane is narrow — e.g. "OTHER DEVICE" on the slim remote pane. */
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
   margin-bottom: var(--spacing-xs);
 }
 .peer-pane-role {
@@ -320,6 +324,8 @@
   color: var(--gray-600);
   padding: 0.2rem 0.5rem;
   border-radius: 999px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 .peer-pane-sub {
   color: var(--gray-600);
@@ -669,6 +675,9 @@
     border-color 0.2s;
 }
 .peer-topo-pane--remote {
+  /* The remote pane only mirrors a status pill, so it needs less width than the
+     local pane (which holds the controls / verified transcript). */
+  flex: 0 1 240px;
   background: var(--gray-100);
 }
 .peer-topo-pane--local {
@@ -841,8 +850,8 @@
   border-radius: var(--radius-lg);
   padding: var(--spacing-md) var(--spacing-lg);
   background: #fff;
-  min-width: 210px;
-  max-width: 240px;
+  min-width: 220px;
+  max-width: 260px;
   text-align: left;
 }
 .peer-topo-node .peer-pane-head {
@@ -850,12 +859,39 @@
 }
 .peer-node-host {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
   color: var(--gray-800);
-  word-break: break-all;
+  /* Break only when needed; <wbr> after each dot gives label-boundary wraps. */
+  overflow-wrap: anywhere;
 }
 
-/* Narrow screens: stack the row vertically (the demo targets wide screens). */
+/* Vertical connector motion, used when the row stacks (narrow screens). */
+@keyframes peerFwdV {
+  from {
+    top: 6%;
+  }
+  to {
+    top: 88%;
+  }
+}
+@keyframes peerRevV {
+  from {
+    top: 88%;
+  }
+  to {
+    top: 6%;
+  }
+}
+@keyframes peerDashV {
+  to {
+    background-position: 0 12px;
+  }
+}
+
+/* Narrow screens: stack the row vertically (the demo targets wide screens). The
+   horizontal proxy/P2P connectors rotate to short VERTICAL links so they still
+   join the stacked cards instead of floating sideways. */
 @media (max-width: 1040px) {
   .peer-topo {
     flex-direction: column;
@@ -866,16 +902,58 @@
     width: 100%;
     max-width: 420px;
   }
+
+  /* Blue P2P channel → vertical rail with downward-flowing packets. */
   .peer-topo-channel {
     flex-basis: auto;
-    width: 100%;
+    width: auto;
   }
   .peer-topo-channel .peer-track {
-    height: 32px;
+    width: 40px;
+    height: 40px;
   }
+  .peer-rail {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    right: auto;
+    width: 2px;
+    height: auto;
+    transform: translateX(-50%);
+  }
+  .peer-packet {
+    top: 0;
+    left: 50%;
+    margin-top: 0;
+    margin-left: -3.5px;
+  }
+  .peer-track--proving .peer-packet--fwd {
+    animation-name: peerFwdV;
+  }
+  .peer-track--proving .peer-packet--rev {
+    animation-name: peerRevV;
+  }
+
+  /* Orange TCP-proxy hop → vertical rail with the ⓘ centred and label beside it. */
   .peer-link {
     flex-basis: auto;
-    width: 100%;
-    max-width: 420px;
+    width: auto;
+    height: 48px;
+    justify-content: center;
+  }
+  .peer-link-rail {
+    width: 2px;
+    height: 100%;
+  }
+  .peer-link-rail--flow {
+    background-image: linear-gradient(180deg, #d98a1f 0 50%, transparent 0);
+    background-size: 2px 12px;
+    animation-name: peerDashV;
+  }
+  .peer-link-cap {
+    top: 50%;
+    left: calc(50% + 16px);
+    transform: translateY(-50%);
+    margin-top: 0;
   }
 }

--- a/packages/demo/src/peer/usePeerConnection.ts
+++ b/packages/demo/src/peer/usePeerConnection.ts
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import Peer, { DataConnection } from 'peerjs';
+
+export type ConnStatus =
+  | 'idle'
+  | 'opening'
+  | 'waiting'
+  | 'connecting'
+  | 'connected'
+  | 'closed'
+  | 'error';
+
+export interface PeerDialer {
+  /** The open data channel to the remote peer, or null until connected. */
+  conn: DataConnection | null;
+  status: ConnStatus;
+  error: string | null;
+}
+
+export interface PeerHostState {
+  /** This peer's id (available once the signaling socket opens). */
+  peerId: string | null;
+  /** The open data channel to the verifier, or null until it connects. */
+  conn: DataConnection | null;
+  status: ConnStatus;
+  error: string | null;
+}
+
+/**
+ * Host a PeerJS peer over a binary data channel and wait for a verifier to
+ * connect. Used by the prover page; `active` gates when hosting starts.
+ */
+export function usePeerHost(active: boolean): PeerHostState {
+  const [peerId, setPeerId] = useState<string | null>(null);
+  const [conn, setConn] = useState<DataConnection | null>(null);
+  const [status, setStatus] = useState<ConnStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    setStatus('opening');
+    const peer = new Peer();
+
+    peer.on('open', (id) => {
+      if (cancelled) return;
+      setPeerId(id);
+      setStatus('waiting');
+    });
+    peer.on('connection', (dataConn) => {
+      dataConn.on('open', () => {
+        if (cancelled) return;
+        setConn(dataConn);
+        setStatus('connected');
+      });
+      dataConn.on('close', () => {
+        if (!cancelled) setStatus('closed');
+      });
+      dataConn.on('error', (err) => {
+        if (!cancelled) {
+          setError(err.message || String(err));
+          setStatus('error');
+        }
+      });
+    });
+    peer.on('disconnected', () => {
+      try {
+        peer.reconnect();
+      } catch {
+        /* already destroyed */
+      }
+    });
+    peer.on('error', (err) => {
+      if (cancelled) return;
+      setError(err.message || String(err));
+      setStatus('error');
+    });
+
+    return () => {
+      cancelled = true;
+      peer.destroy();
+    };
+  }, [active]);
+
+  return { peerId, conn, status, error };
+}
+
+/**
+ * Dial a remote PeerJS peer over a binary data channel. Used by the verifier to
+ * connect to the prover (which hosts the peer). Pass `null` to stay idle.
+ */
+export function usePeerDialer(remoteId: string | null): PeerDialer {
+  const [conn, setConn] = useState<DataConnection | null>(null);
+  const [status, setStatus] = useState<ConnStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset when the target changes (React "adjust state during render" pattern).
+  const [prev, setPrev] = useState(remoteId);
+  if (prev !== remoteId) {
+    setPrev(remoteId);
+    setStatus(remoteId ? 'opening' : 'idle');
+    setError(null);
+    setConn(null);
+  }
+
+  useEffect(() => {
+    if (!remoteId) return;
+    let cancelled = false;
+    const peer = new Peer();
+
+    peer.on('open', () => {
+      if (cancelled) return;
+      setStatus('connecting');
+      const dataConn = peer.connect(remoteId, { serialization: 'binary', reliable: true });
+      dataConn.on('open', () => {
+        if (cancelled) return;
+        setConn(dataConn);
+        setStatus('connected');
+      });
+      dataConn.on('error', (err) => {
+        if (cancelled) return;
+        setError(err.message || String(err));
+        setStatus('error');
+      });
+      dataConn.on('close', () => {
+        if (!cancelled) setStatus('closed');
+      });
+    });
+
+    peer.on('disconnected', () => {
+      try {
+        peer.reconnect();
+      } catch {
+        /* already destroyed */
+      }
+    });
+    peer.on('error', (err) => {
+      if (cancelled) return;
+      setError(err.message || String(err));
+      setStatus('error');
+    });
+
+    return () => {
+      cancelled = true;
+      peer.destroy();
+    };
+  }, [remoteId]);
+
+  return { conn, status, error };
+}

--- a/packages/demo/src/peer/wasm.worker.ts
+++ b/packages/demo/src/peer/wasm.worker.ts
@@ -1,17 +1,11 @@
 import * as Comlink from 'comlink';
 import type * as TlsnWasm from 'tlsn-wasm';
-import type {
-  LoggingLevel,
-  CrateLogFilter,
-  HttpRequest,
-  ProverConfig,
-  VerifierConfig,
-} from 'tlsn-wasm';
+import type { LoggingLevel, CrateLogFilter, VerifierConfig } from 'tlsn-wasm';
 
-// Runs the TLSNotary WASM in a dedicated worker. The glue is loaded from a
-// static path (copied to /public by copy-wasm.js) rather than bundled, so the
-// rayon thread-spawner's internal `new URL('./spawn.js', import.meta.url)` and
-// `import('../../../tlsn_wasm.js')` resolve identically in dev and production.
+// Runs the TLSNotary WASM verifier in a dedicated worker. The glue is loaded
+// from a static path (copied to /public by copy-wasm.js) rather than bundled, so
+// the rayon thread-spawner's internal `new URL('./spawn.js', import.meta.url)`
+// and `import('../../../tlsn_wasm.js')` resolve identically in dev and production.
 
 let wasm: typeof TlsnWasm | null = null;
 let threadCount = 0;
@@ -72,78 +66,6 @@ class ByteQueue {
   }
 }
 
-// In-memory duplex pair: bytes written to side A are read on side B and vice
-// versa. Used to connect an in-page Prover and Verifier for the self-test.
-function makeLoopbackPair(): { a: IoChannel; b: IoChannel } {
-  const a2b = new ByteQueue();
-  const b2a = new ByteQueue();
-  const a: IoChannel = {
-    read: () => b2a.read(),
-    write: (d) => {
-      a2b.push(d.slice());
-      return Promise.resolve();
-    },
-    close: () => {
-      a2b.close();
-      return Promise.resolve();
-    },
-  };
-  const b: IoChannel = {
-    read: () => a2b.read(),
-    write: (d) => {
-      b2a.push(d.slice());
-      return Promise.resolve();
-    },
-    close: () => {
-      b2a.close();
-      return Promise.resolve();
-    },
-  };
-  return { a, b };
-}
-
-// IoChannel over a WebSocket (the prover↔server connection, via a TCP proxy).
-function createWsIo(url: string): Promise<IoChannel> {
-  return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
-    ws.binaryType = 'arraybuffer';
-    const queue = new ByteQueue();
-    ws.onopen = () =>
-      resolve({
-        read: () => queue.read(),
-        write: (d) => {
-          // Copy off (possibly shared) WASM memory into a plain ArrayBuffer.
-          const copy = new Uint8Array(d.length);
-          copy.set(d);
-          ws.send(copy);
-          return Promise.resolve();
-        },
-        close: () => {
-          ws.close();
-          return Promise.resolve();
-        },
-      });
-    ws.onmessage = (e) => queue.push(new Uint8Array(e.data as ArrayBuffer));
-    ws.onerror = () => reject(new Error('proxy websocket failed: ' + url));
-    ws.onclose = () => queue.close();
-  });
-}
-
-// ---- Logging ----
-
-const logBuffer: string[] = [];
-const origLog = console.log;
-console.log = (...args: unknown[]) => {
-  logBuffer.push(args.join(' '));
-  origLog.apply(console, args);
-};
-
-function getLogs(): string[] {
-  const logs = [...logBuffer];
-  logBuffer.length = 0;
-  return logs;
-}
-
 // ---- Public API (exposed over Comlink) ----
 
 export interface InitConfig {
@@ -173,16 +95,7 @@ async function init(config?: InitConfig): Promise<number> {
   return threadCount;
 }
 
-export interface SelfTestConfig {
-  proxyUrl: string;
-  serverName: string;
-  path: string;
-  authToken?: string;
-  maxSentData?: number;
-  maxRecvData?: number;
-}
-
-export interface SelfTestResult {
+export interface VerifierResult {
   serverName?: string;
   sent: string;
   recv: string;
@@ -190,111 +103,12 @@ export interface SelfTestResult {
   ms: number;
 }
 
-// Runs a complete in-browser proof: an in-page Prover and Verifier perform the
-// MPC-TLS protocol over a loopback channel, with the Prover reaching the target
-// server through a TCP proxy. Returns what the Verifier independently learned.
-async function selfTest(
-  cfg: SelfTestConfig,
-  onProgress?: (message: string) => void,
-): Promise<SelfTestResult> {
-  const w = await loadWasm();
-  const enc = new TextEncoder();
-  const maxSent = cfg.maxSentData ?? 2048;
-  const maxRecv = cfg.maxRecvData ?? 4096;
-  const log = (m: string) => {
-    try {
-      onProgress?.(m);
-    } catch {
-      /* progress sink closed */
-    }
-  };
-
-  const { a, b } = makeLoopbackPair();
-
-  const prover = new w.Prover({
-    server_name: cfg.serverName,
-    mode: 'Mpc',
-    max_sent_data: maxSent,
-    max_recv_data: maxRecv,
-    network: 'Latency',
-  } as ProverConfig);
-  const verifier = new w.Verifier({
-    max_sent_data: maxSent,
-    max_recv_data: maxRecv,
-  } as VerifierConfig);
-
-  const headers = new Map<string, number[]>();
-  headers.set('host', [...enc.encode(cfg.serverName)]);
-  headers.set('connection', [...enc.encode('close')]);
-  if (cfg.authToken) headers.set('authorization', [...enc.encode('Bearer ' + cfg.authToken)]);
-
-  const request = { uri: cfg.path, method: 'GET', headers } as HttpRequest;
-
-  const t0 = performance.now();
-
-  const verifierFlow = (async () => {
-    log('Verifier: connecting to prover…');
-    await verifier.connect(b as unknown as Parameters<typeof verifier.connect>[0]);
-    log('Verifier: MPC setup…');
-    await verifier.setup();
-    log('Verifier: running protocol…');
-    await verifier.run();
-    log('Verifier: verifying…');
-    return verifier.verify();
-  })();
-
-  const proverFlow = (async () => {
-    log('Prover: MPC setup…');
-    await prover.setup(a as unknown as Parameters<typeof prover.setup>[0]);
-    log('Prover: connecting to server via proxy…');
-    const serverIo = await createWsIo(cfg.proxyUrl);
-    log('Prover: sending request…');
-    await prover.send_request(
-      serverIo as unknown as Parameters<typeof prover.send_request>[0],
-      request,
-    );
-    const transcript = prover.transcript();
-    log('Prover: revealing transcript…');
-    await prover.reveal({
-      sent: [{ start: 0, end: transcript.sent.length }],
-      recv: [{ start: 0, end: transcript.recv.length }],
-      server_identity: true,
-    });
-  })();
-
-  const [output] = await Promise.all([verifierFlow, proverFlow]);
-  const ms = performance.now() - t0;
-
-  const decode = (arr?: number[]) =>
-    new TextDecoder()
-      .decode(new Uint8Array(arr || []))
-      .split('\u0000')
-      .join('\u2588');
-
-  return {
-    serverName: output.server_name,
-    sent: decode(output.transcript?.sent),
-    recv: decode(output.transcript?.recv),
-    threads: threadCount,
-    ms,
-  };
-}
-
 // Redacted/unauthenticated bytes come back as NUL; show them as a block.
 function decodeTranscript(arr?: number[]): string {
   return new TextDecoder()
     .decode(new Uint8Array(arr || []))
-    .split(' ')
+    .split(' ')
     .join('█');
-}
-
-function buildRequest(cfg: SelfTestConfig): HttpRequest {
-  const enc = new TextEncoder();
-  const headers = new Map<string, number[]>();
-  headers.set('host', [...enc.encode(cfg.serverName)]);
-  headers.set('connection', [...enc.encode('close')]);
-  if (cfg.authToken) headers.set('authorization', [...enc.encode('Bearer ' + cfg.authToken)]);
-  return { uri: cfg.path, method: 'GET', headers } as HttpRequest;
 }
 
 // ---- Live session over an external transport (e.g. a PeerJS data channel) ----
@@ -342,7 +156,7 @@ async function runVerifier(
   cfg: { maxSentData?: number; maxRecvData?: number },
   sendOut: (bytes: Uint8Array) => void,
   onProgress?: (m: string) => void,
-): Promise<SelfTestResult> {
+): Promise<VerifierResult> {
   const w = await loadWasm();
   sessionInbox = new ByteQueue();
   sessionSendOut = sendOut;
@@ -370,51 +184,9 @@ async function runVerifier(
   };
 }
 
-// Prover side: runs the MPC-TLS prover over the peer transport (to the verifier)
-// and a WebSocket proxy (to the target server).
-async function runProver(
-  cfg: SelfTestConfig,
-  sendOut: (bytes: Uint8Array) => void,
-  onProgress?: (m: string) => void,
-): Promise<{ ms: number }> {
-  const w = await loadWasm();
-  sessionInbox = new ByteQueue();
-  sessionSendOut = sendOut;
-  const log = progressLogger(onProgress);
-  const prover = new w.Prover({
-    server_name: cfg.serverName,
-    mode: 'Mpc',
-    max_sent_data: cfg.maxSentData ?? 2048,
-    max_recv_data: cfg.maxRecvData ?? 4096,
-    network: 'Latency',
-  } as ProverConfig);
-  const io = peerIo() as unknown as Parameters<typeof prover.setup>[0];
-  const t0 = performance.now();
-  log('MPC setup with verifier…');
-  await prover.setup(io);
-  log('Connecting to server via proxy…');
-  const serverIo = await createWsIo(cfg.proxyUrl);
-  log('Sending request…');
-  await prover.send_request(
-    serverIo as unknown as Parameters<typeof prover.send_request>[0],
-    buildRequest(cfg),
-  );
-  const transcript = prover.transcript();
-  log('Revealing transcript…');
-  await prover.reveal({
-    sent: [{ start: 0, end: transcript.sent.length }],
-    recv: [{ start: 0, end: transcript.recv.length }],
-    server_identity: true,
-  });
-  return { ms: performance.now() - t0 };
-}
-
 Comlink.expose({
   init,
-  getLogs,
-  selfTest,
   runVerifier,
-  runProver,
   deliverToWasm,
   signalPeerClosed,
 });

--- a/packages/demo/src/peer/wasm.worker.ts
+++ b/packages/demo/src/peer/wasm.worker.ts
@@ -151,6 +151,22 @@ function decodeTranscript(arr?: number[]): string {
 let sessionInbox: ByteQueue | null = null;
 let sessionSendOut: ((bytes: Uint8Array) => void) | null = null;
 
+// The prover supplies the data limits, which size verifier-side buffers. Clamp
+// them so a malicious/buggy prover can't OOM this tab with an absurd value (the
+// largest real plugin asks for 64 KiB; 1 MiB is generous headroom). If a value
+// is clamped, the limits no longer match the prover's and the MPC simply fails
+// — a safe outcome, not a crash.
+const MAX_DATA_LIMIT = 1 << 20; // 1 MiB
+// Fallback limits used only if the prover sends none (it normally supplies its
+// own in the limits frame). Sized to cover every bundled plugin — the largest
+// asks for 64 KiB recv / 4 KiB sent (idme).
+const DEFAULT_MAX_SENT_DATA = 1 << 13; // 8 KiB
+const DEFAULT_MAX_RECV_DATA = 1 << 17; // 128 KiB
+function clampLimit(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(value, MAX_DATA_LIMIT);
+}
+
 function peerIo(): IoChannel {
   const inbox = sessionInbox!;
   return {
@@ -194,8 +210,8 @@ async function runVerifier(
   sessionSendOut = sendOut;
   const log = progressLogger(onProgress);
   const verifier = new w.Verifier({
-    max_sent_data: cfg.maxSentData ?? 2048,
-    max_recv_data: cfg.maxRecvData ?? 4096,
+    max_sent_data: clampLimit(cfg.maxSentData, DEFAULT_MAX_SENT_DATA),
+    max_recv_data: clampLimit(cfg.maxRecvData, DEFAULT_MAX_RECV_DATA),
   } as VerifierConfig);
   const io = peerIo() as unknown as Parameters<typeof verifier.connect>[0];
   const t0 = performance.now();

--- a/packages/demo/src/peer/wasm.worker.ts
+++ b/packages/demo/src/peer/wasm.worker.ts
@@ -1,0 +1,420 @@
+import * as Comlink from 'comlink';
+import type * as TlsnWasm from 'tlsn-wasm';
+import type {
+  LoggingLevel,
+  CrateLogFilter,
+  HttpRequest,
+  ProverConfig,
+  VerifierConfig,
+} from 'tlsn-wasm';
+
+// Runs the TLSNotary WASM in a dedicated worker. The glue is loaded from a
+// static path (copied to /public by copy-wasm.js) rather than bundled, so the
+// rayon thread-spawner's internal `new URL('./spawn.js', import.meta.url)` and
+// `import('../../../tlsn_wasm.js')` resolve identically in dev and production.
+
+let wasm: typeof TlsnWasm | null = null;
+let threadCount = 0;
+
+async function loadWasm(): Promise<typeof TlsnWasm> {
+  if (wasm) return wasm;
+  // Fully-qualified URL so the dev server treats it as external and serves the
+  // static /public file as-is (no `?import` transform); the file is shipped
+  // unbundled so the rayon thread-spawner's relative imports resolve.
+  const glueUrl = new URL('/tlsn-wasm/tlsn_wasm.js', self.location.origin).href;
+  const mod = (await import(/* @vite-ignore */ glueUrl)) as unknown as typeof TlsnWasm;
+  await mod.default();
+  wasm = mod;
+  return mod;
+}
+
+// ---- IoChannel: the byte-stream contract the WASM expects ----
+
+interface IoChannel {
+  read(): Promise<Uint8Array | null>;
+  write(data: Uint8Array): Promise<void>;
+  close(): Promise<void>;
+}
+
+// Async byte queue: resolves a pending read as soon as a chunk arrives; returns
+// null once closed and drained (EOF).
+class ByteQueue {
+  private chunks: Uint8Array[] = [];
+  private resolver: ((value: Uint8Array | null) => void) | null = null;
+  private closed = false;
+
+  push(data: Uint8Array): void {
+    if (this.closed) return;
+    if (this.resolver) {
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve(data);
+    } else {
+      this.chunks.push(data);
+    }
+  }
+
+  read(): Promise<Uint8Array | null> {
+    if (this.chunks.length > 0) return Promise.resolve(this.chunks.shift()!);
+    if (this.closed) return Promise.resolve(null);
+    return new Promise((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.resolver) {
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve(null);
+    }
+  }
+}
+
+// In-memory duplex pair: bytes written to side A are read on side B and vice
+// versa. Used to connect an in-page Prover and Verifier for the self-test.
+function makeLoopbackPair(): { a: IoChannel; b: IoChannel } {
+  const a2b = new ByteQueue();
+  const b2a = new ByteQueue();
+  const a: IoChannel = {
+    read: () => b2a.read(),
+    write: (d) => {
+      a2b.push(d.slice());
+      return Promise.resolve();
+    },
+    close: () => {
+      a2b.close();
+      return Promise.resolve();
+    },
+  };
+  const b: IoChannel = {
+    read: () => a2b.read(),
+    write: (d) => {
+      b2a.push(d.slice());
+      return Promise.resolve();
+    },
+    close: () => {
+      b2a.close();
+      return Promise.resolve();
+    },
+  };
+  return { a, b };
+}
+
+// IoChannel over a WebSocket (the prover↔server connection, via a TCP proxy).
+function createWsIo(url: string): Promise<IoChannel> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.binaryType = 'arraybuffer';
+    const queue = new ByteQueue();
+    ws.onopen = () =>
+      resolve({
+        read: () => queue.read(),
+        write: (d) => {
+          // Copy off (possibly shared) WASM memory into a plain ArrayBuffer.
+          const copy = new Uint8Array(d.length);
+          copy.set(d);
+          ws.send(copy);
+          return Promise.resolve();
+        },
+        close: () => {
+          ws.close();
+          return Promise.resolve();
+        },
+      });
+    ws.onmessage = (e) => queue.push(new Uint8Array(e.data as ArrayBuffer));
+    ws.onerror = () => reject(new Error('proxy websocket failed: ' + url));
+    ws.onclose = () => queue.close();
+  });
+}
+
+// ---- Logging ----
+
+const logBuffer: string[] = [];
+const origLog = console.log;
+console.log = (...args: unknown[]) => {
+  logBuffer.push(args.join(' '));
+  origLog.apply(console, args);
+};
+
+function getLogs(): string[] {
+  const logs = [...logBuffer];
+  logBuffer.length = 0;
+  return logs;
+}
+
+// ---- Public API (exposed over Comlink) ----
+
+export interface InitConfig {
+  loggingLevel?: LoggingLevel;
+  hardwareConcurrency?: number;
+  crateFilters?: CrateLogFilter[];
+}
+
+async function init(config?: InitConfig): Promise<number> {
+  const {
+    loggingLevel = 'Info',
+    hardwareConcurrency = navigator.hardwareConcurrency,
+    crateFilters,
+  } = config || {};
+  const w = await loadWasm();
+  try {
+    await w.initialize(
+      { level: loggingLevel, crate_filters: crateFilters, span_events: undefined },
+      hardwareConcurrency,
+    );
+    threadCount = hardwareConcurrency;
+  } catch (err) {
+    console.log('Multi-threaded init failed, falling back to single thread: ' + String(err));
+    await w.initialize(undefined, 1);
+    threadCount = 1;
+  }
+  return threadCount;
+}
+
+export interface SelfTestConfig {
+  proxyUrl: string;
+  serverName: string;
+  path: string;
+  authToken?: string;
+  maxSentData?: number;
+  maxRecvData?: number;
+}
+
+export interface SelfTestResult {
+  serverName?: string;
+  sent: string;
+  recv: string;
+  threads: number;
+  ms: number;
+}
+
+// Runs a complete in-browser proof: an in-page Prover and Verifier perform the
+// MPC-TLS protocol over a loopback channel, with the Prover reaching the target
+// server through a TCP proxy. Returns what the Verifier independently learned.
+async function selfTest(
+  cfg: SelfTestConfig,
+  onProgress?: (message: string) => void,
+): Promise<SelfTestResult> {
+  const w = await loadWasm();
+  const enc = new TextEncoder();
+  const maxSent = cfg.maxSentData ?? 2048;
+  const maxRecv = cfg.maxRecvData ?? 4096;
+  const log = (m: string) => {
+    try {
+      onProgress?.(m);
+    } catch {
+      /* progress sink closed */
+    }
+  };
+
+  const { a, b } = makeLoopbackPair();
+
+  const prover = new w.Prover({
+    server_name: cfg.serverName,
+    mode: 'Mpc',
+    max_sent_data: maxSent,
+    max_recv_data: maxRecv,
+    network: 'Latency',
+  } as ProverConfig);
+  const verifier = new w.Verifier({
+    max_sent_data: maxSent,
+    max_recv_data: maxRecv,
+  } as VerifierConfig);
+
+  const headers = new Map<string, number[]>();
+  headers.set('host', [...enc.encode(cfg.serverName)]);
+  headers.set('connection', [...enc.encode('close')]);
+  if (cfg.authToken) headers.set('authorization', [...enc.encode('Bearer ' + cfg.authToken)]);
+
+  const request = { uri: cfg.path, method: 'GET', headers } as HttpRequest;
+
+  const t0 = performance.now();
+
+  const verifierFlow = (async () => {
+    log('Verifier: connecting to prover…');
+    await verifier.connect(b as unknown as Parameters<typeof verifier.connect>[0]);
+    log('Verifier: MPC setup…');
+    await verifier.setup();
+    log('Verifier: running protocol…');
+    await verifier.run();
+    log('Verifier: verifying…');
+    return verifier.verify();
+  })();
+
+  const proverFlow = (async () => {
+    log('Prover: MPC setup…');
+    await prover.setup(a as unknown as Parameters<typeof prover.setup>[0]);
+    log('Prover: connecting to server via proxy…');
+    const serverIo = await createWsIo(cfg.proxyUrl);
+    log('Prover: sending request…');
+    await prover.send_request(
+      serverIo as unknown as Parameters<typeof prover.send_request>[0],
+      request,
+    );
+    const transcript = prover.transcript();
+    log('Prover: revealing transcript…');
+    await prover.reveal({
+      sent: [{ start: 0, end: transcript.sent.length }],
+      recv: [{ start: 0, end: transcript.recv.length }],
+      server_identity: true,
+    });
+  })();
+
+  const [output] = await Promise.all([verifierFlow, proverFlow]);
+  const ms = performance.now() - t0;
+
+  const decode = (arr?: number[]) =>
+    new TextDecoder()
+      .decode(new Uint8Array(arr || []))
+      .split('\u0000')
+      .join('\u2588');
+
+  return {
+    serverName: output.server_name,
+    sent: decode(output.transcript?.sent),
+    recv: decode(output.transcript?.recv),
+    threads: threadCount,
+    ms,
+  };
+}
+
+// Redacted/unauthenticated bytes come back as NUL; show them as a block.
+function decodeTranscript(arr?: number[]): string {
+  return new TextDecoder()
+    .decode(new Uint8Array(arr || []))
+    .split(' ')
+    .join('█');
+}
+
+function buildRequest(cfg: SelfTestConfig): HttpRequest {
+  const enc = new TextEncoder();
+  const headers = new Map<string, number[]>();
+  headers.set('host', [...enc.encode(cfg.serverName)]);
+  headers.set('connection', [...enc.encode('close')]);
+  if (cfg.authToken) headers.set('authorization', [...enc.encode('Bearer ' + cfg.authToken)]);
+  return { uri: cfg.path, method: 'GET', headers } as HttpRequest;
+}
+
+// ---- Live session over an external transport (e.g. a PeerJS data channel) ----
+//
+// WebRTC can't run inside a worker, so the data channel lives on the main
+// thread. Incoming peer bytes are pushed in via deliverToWasm(); outgoing bytes
+// are handed to the main thread through the `sendOut` callback. One session per
+// worker (each browser runs a single party).
+
+let sessionInbox: ByteQueue | null = null;
+let sessionSendOut: ((bytes: Uint8Array) => void) | null = null;
+
+function peerIo(): IoChannel {
+  const inbox = sessionInbox!;
+  return {
+    read: () => inbox.read(),
+    write: (d) => {
+      // Copy off (possibly shared) WASM memory before handing to the main thread.
+      sessionSendOut?.(d.slice());
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+  };
+}
+
+function deliverToWasm(bytes: Uint8Array): void {
+  sessionInbox?.push(bytes);
+}
+
+function signalPeerClosed(): void {
+  sessionInbox?.close();
+}
+
+const progressLogger = (onProgress?: (m: string) => void) => (m: string) => {
+  try {
+    onProgress?.(m);
+  } catch {
+    /* progress sink closed */
+  }
+};
+
+// Verifier side: runs the MPC-TLS verifier over the peer transport and returns
+// what it independently learned.
+async function runVerifier(
+  cfg: { maxSentData?: number; maxRecvData?: number },
+  sendOut: (bytes: Uint8Array) => void,
+  onProgress?: (m: string) => void,
+): Promise<SelfTestResult> {
+  const w = await loadWasm();
+  sessionInbox = new ByteQueue();
+  sessionSendOut = sendOut;
+  const log = progressLogger(onProgress);
+  const verifier = new w.Verifier({
+    max_sent_data: cfg.maxSentData ?? 2048,
+    max_recv_data: cfg.maxRecvData ?? 4096,
+  } as VerifierConfig);
+  const io = peerIo() as unknown as Parameters<typeof verifier.connect>[0];
+  const t0 = performance.now();
+  log('Connecting to prover…');
+  await verifier.connect(io);
+  log('MPC setup…');
+  await verifier.setup();
+  log('Running protocol…');
+  await verifier.run();
+  log('Verifying…');
+  const output = await verifier.verify();
+  return {
+    serverName: output.server_name,
+    sent: decodeTranscript(output.transcript?.sent),
+    recv: decodeTranscript(output.transcript?.recv),
+    threads: threadCount,
+    ms: performance.now() - t0,
+  };
+}
+
+// Prover side: runs the MPC-TLS prover over the peer transport (to the verifier)
+// and a WebSocket proxy (to the target server).
+async function runProver(
+  cfg: SelfTestConfig,
+  sendOut: (bytes: Uint8Array) => void,
+  onProgress?: (m: string) => void,
+): Promise<{ ms: number }> {
+  const w = await loadWasm();
+  sessionInbox = new ByteQueue();
+  sessionSendOut = sendOut;
+  const log = progressLogger(onProgress);
+  const prover = new w.Prover({
+    server_name: cfg.serverName,
+    mode: 'Mpc',
+    max_sent_data: cfg.maxSentData ?? 2048,
+    max_recv_data: cfg.maxRecvData ?? 4096,
+    network: 'Latency',
+  } as ProverConfig);
+  const io = peerIo() as unknown as Parameters<typeof prover.setup>[0];
+  const t0 = performance.now();
+  log('MPC setup with verifier…');
+  await prover.setup(io);
+  log('Connecting to server via proxy…');
+  const serverIo = await createWsIo(cfg.proxyUrl);
+  log('Sending request…');
+  await prover.send_request(
+    serverIo as unknown as Parameters<typeof prover.send_request>[0],
+    buildRequest(cfg),
+  );
+  const transcript = prover.transcript();
+  log('Revealing transcript…');
+  await prover.reveal({
+    sent: [{ start: 0, end: transcript.sent.length }],
+    recv: [{ start: 0, end: transcript.recv.length }],
+    server_identity: true,
+  });
+  return { ms: performance.now() - t0 };
+}
+
+Comlink.expose({
+  init,
+  getLogs,
+  selfTest,
+  runVerifier,
+  runProver,
+  deliverToWasm,
+  signalPeerClosed,
+});

--- a/packages/demo/src/peer/wasm.worker.ts
+++ b/packages/demo/src/peer/wasm.worker.ts
@@ -66,6 +66,35 @@ class ByteQueue {
   }
 }
 
+// IoChannel over a WebSocket. In proxy mode the verifier opens the server
+// connection itself (the prover tunnels through us), but browsers can't do raw
+// TCP — so it goes through the same WS→TCP proxy the prover uses in MPC mode.
+function createWsIo(url: string): Promise<IoChannel> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.binaryType = 'arraybuffer';
+    const queue = new ByteQueue();
+    ws.onopen = () =>
+      resolve({
+        read: () => queue.read(),
+        write: (d) => {
+          // Copy off (possibly shared) WASM memory into a plain ArrayBuffer.
+          const copy = new Uint8Array(d.length);
+          copy.set(d);
+          ws.send(copy);
+          return Promise.resolve();
+        },
+        close: () => {
+          ws.close();
+          return Promise.resolve();
+        },
+      });
+    ws.onmessage = (e) => queue.push(new Uint8Array(e.data as ArrayBuffer));
+    ws.onerror = () => reject(new Error('proxy websocket failed: ' + url));
+    ws.onclose = () => queue.close();
+  });
+}
+
 // ---- Public API (exposed over Comlink) ----
 
 export interface InitConfig {
@@ -103,11 +132,12 @@ export interface VerifierResult {
   ms: number;
 }
 
-// Redacted/unauthenticated bytes come back as NUL; show them as a block.
+// Redacted/unauthenticated bytes come back as NUL; show those as a block while
+// keeping the real whitespace of the revealed plaintext intact.
 function decodeTranscript(arr?: number[]): string {
   return new TextDecoder()
     .decode(new Uint8Array(arr || []))
-    .split(' ')
+    .split(String.fromCharCode(0))
     .join('█');
 }
 
@@ -151,9 +181,11 @@ const progressLogger = (onProgress?: (m: string) => void) => (m: string) => {
 };
 
 // Verifier side: runs the MPC-TLS verifier over the peer transport and returns
-// what it independently learned.
+// what it independently learned. In Proxy mode `setup()` returns the server
+// name; we then open the server socket (through the TCP proxy) and hand it to
+// the verifier before running.
 async function runVerifier(
-  cfg: { maxSentData?: number; maxRecvData?: number },
+  cfg: { maxSentData?: number; maxRecvData?: number; proxyBase?: string },
   sendOut: (bytes: Uint8Array) => void,
   onProgress?: (m: string) => void,
 ): Promise<VerifierResult> {
@@ -170,18 +202,33 @@ async function runVerifier(
   log('Connecting to prover…');
   await verifier.connect(io);
   log('MPC setup…');
-  await verifier.setup();
+  const serverName = await verifier.setup();
+  if (serverName) {
+    // Proxy mode: we are the egress to the server. Open the TCP proxy socket.
+    const base = cfg.proxyBase ?? 'wss://demo.tlsnotary.org';
+    log(`Opening server socket → ${serverName}…`);
+    const serverIo = await createWsIo(`${base}/proxy?token=${serverName}`);
+    verifier.set_server_socket(serverIo as unknown as Parameters<typeof verifier.connect>[0]);
+  }
   log('Running protocol…');
   await verifier.run();
   log('Verifying…');
   const output = await verifier.verify();
-  return {
+  const result: VerifierResult = {
     serverName: output.server_name,
     sent: decodeTranscript(output.transcript?.sent),
     recv: decodeTranscript(output.transcript?.recv),
     threads: threadCount,
     ms: performance.now() - t0,
   };
+  // Transcripts are already decoded into JS strings above, so the WASM verifier
+  // can be released — repeated peer proofs would otherwise accumulate state.
+  try {
+    verifier.free();
+  } catch {
+    /* already disposed */
+  }
+  return result;
 }
 
 Comlink.expose({

--- a/packages/demo/src/peer/wasmRuntime.ts
+++ b/packages/demo/src/peer/wasmRuntime.ts
@@ -1,11 +1,11 @@
 import * as Comlink from 'comlink';
 import type { DataConnection } from 'peerjs';
-import type { InitConfig, SelfTestConfig, SelfTestResult } from './wasm.worker';
+import type { InitConfig, VerifierResult } from './wasm.worker';
 
-export type { SelfTestConfig, SelfTestResult } from './wasm.worker';
+export type { VerifierResult } from './wasm.worker';
 
-// Thin singleton wrapper around the WASM worker. The worker exposes `init`,
-// `getLogs`, and the `Prover`/`Verifier` classes (constructable over Comlink).
+// Thin singleton wrapper around the WASM verifier worker. The worker exposes
+// `init` and a `runVerifier` session bridged to a PeerJS data channel.
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type WorkerApi = any;
@@ -38,15 +38,6 @@ export interface WasmRuntimeStatus {
   error?: string;
 }
 
-/** Run an in-browser self-test proof (in-page Prover + Verifier over loopback). */
-export function runSelfTest(
-  cfg: SelfTestConfig,
-  onProgress?: (message: string) => void,
-): Promise<SelfTestResult> {
-  const api = getWorkerApi();
-  return api.selfTest(cfg, onProgress ? Comlink.proxy(onProgress) : undefined);
-}
-
 function toU8(d: unknown): Uint8Array {
   if (d instanceof Uint8Array) return d;
   return new Uint8Array(d as ArrayBufferLike);
@@ -66,21 +57,11 @@ export function runVerifierSession(
   cfg: { maxSentData?: number; maxRecvData?: number },
   conn: DataConnection,
   onProgress?: (message: string) => void,
-): Promise<SelfTestResult> {
+): Promise<VerifierResult> {
   const sendOut = wireConn(conn);
   return getWorkerApi().runVerifier(
     cfg,
     sendOut,
     onProgress ? Comlink.proxy(onProgress) : undefined,
   );
-}
-
-/** Run the MPC-TLS prover over a PeerJS data channel (verifier) + a TCP proxy. */
-export function runProverSession(
-  cfg: SelfTestConfig,
-  conn: DataConnection,
-  onProgress?: (message: string) => void,
-): Promise<{ ms: number }> {
-  const sendOut = wireConn(conn);
-  return getWorkerApi().runProver(cfg, sendOut, onProgress ? Comlink.proxy(onProgress) : undefined);
 }

--- a/packages/demo/src/peer/wasmRuntime.ts
+++ b/packages/demo/src/peer/wasmRuntime.ts
@@ -45,23 +45,42 @@ function toU8(d: unknown): Uint8Array {
 
 // Bridge a PeerJS data channel to the worker's WASM session: inbound peer bytes
 // → worker; the worker's outbound bytes (via the proxied callback) → peer.
-function wireConn(conn: DataConnection): (bytes: Uint8Array) => void {
+// String frames are out-of-band status (handled by the page), never MPC bytes.
+// Returns a `cleanup` so the per-session handlers are removed when the session
+// ends — without it a second proof would add a second handler and double-deliver.
+function wireConn(conn: DataConnection): {
+  sendOut: (bytes: Uint8Array) => void;
+  cleanup: () => void;
+} {
   const api = getWorkerApi();
-  conn.on('data', (d) => api.deliverToWasm(toU8(d)));
-  conn.on('close', () => api.signalPeerClosed());
-  return Comlink.proxy((bytes: Uint8Array) => conn.send(bytes));
+  const onData = (d: unknown) => {
+    if (typeof d === 'string') return;
+    api.deliverToWasm(toU8(d));
+  };
+  const onClose = () => api.signalPeerClosed();
+  conn.on('data', onData);
+  conn.on('close', onClose);
+  return {
+    sendOut: Comlink.proxy((bytes: Uint8Array) => conn.send(bytes)),
+    cleanup: () => {
+      conn.off('data', onData);
+      conn.off('close', onClose);
+    },
+  };
 }
 
-/** Run the MPC-TLS verifier over a PeerJS data channel; returns what it learned. */
+/**
+ * Run the MPC-TLS verifier over a PeerJS data channel; returns what it learned.
+ * Safe to call repeatedly on the same channel — each run wires fresh handlers
+ * and tears them down on completion, so sequential proofs don't accumulate.
+ */
 export function runVerifierSession(
-  cfg: { maxSentData?: number; maxRecvData?: number },
+  cfg: { maxSentData?: number; maxRecvData?: number; proxyBase?: string },
   conn: DataConnection,
   onProgress?: (message: string) => void,
 ): Promise<VerifierResult> {
-  const sendOut = wireConn(conn);
-  return getWorkerApi().runVerifier(
-    cfg,
-    sendOut,
-    onProgress ? Comlink.proxy(onProgress) : undefined,
-  );
+  const { sendOut, cleanup } = wireConn(conn);
+  return getWorkerApi()
+    .runVerifier(cfg, sendOut, onProgress ? Comlink.proxy(onProgress) : undefined)
+    .finally(cleanup);
 }

--- a/packages/demo/src/peer/wasmRuntime.ts
+++ b/packages/demo/src/peer/wasmRuntime.ts
@@ -1,0 +1,86 @@
+import * as Comlink from 'comlink';
+import type { DataConnection } from 'peerjs';
+import type { InitConfig, SelfTestConfig, SelfTestResult } from './wasm.worker';
+
+export type { SelfTestConfig, SelfTestResult } from './wasm.worker';
+
+// Thin singleton wrapper around the WASM worker. The worker exposes `init`,
+// `getLogs`, and the `Prover`/`Verifier` classes (constructable over Comlink).
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type WorkerApi = any;
+
+let workerApi: WorkerApi | null = null;
+let initPromise: Promise<number> | null = null;
+
+export function getWorkerApi(): WorkerApi {
+  if (!workerApi) {
+    const worker = new Worker(new URL('./wasm.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    workerApi = Comlink.wrap(worker);
+  }
+  return workerApi;
+}
+
+/** Initialize the WASM runtime once; returns the thread count in use. */
+export function initWasmRuntime(config?: InitConfig): Promise<number> {
+  if (!initPromise) {
+    initPromise = getWorkerApi().init(config) as Promise<number>;
+  }
+  return initPromise;
+}
+
+export interface WasmRuntimeStatus {
+  state: 'idle' | 'initializing' | 'ready' | 'error';
+  threads?: number;
+  isolated: boolean;
+  error?: string;
+}
+
+/** Run an in-browser self-test proof (in-page Prover + Verifier over loopback). */
+export function runSelfTest(
+  cfg: SelfTestConfig,
+  onProgress?: (message: string) => void,
+): Promise<SelfTestResult> {
+  const api = getWorkerApi();
+  return api.selfTest(cfg, onProgress ? Comlink.proxy(onProgress) : undefined);
+}
+
+function toU8(d: unknown): Uint8Array {
+  if (d instanceof Uint8Array) return d;
+  return new Uint8Array(d as ArrayBufferLike);
+}
+
+// Bridge a PeerJS data channel to the worker's WASM session: inbound peer bytes
+// → worker; the worker's outbound bytes (via the proxied callback) → peer.
+function wireConn(conn: DataConnection): (bytes: Uint8Array) => void {
+  const api = getWorkerApi();
+  conn.on('data', (d) => api.deliverToWasm(toU8(d)));
+  conn.on('close', () => api.signalPeerClosed());
+  return Comlink.proxy((bytes: Uint8Array) => conn.send(bytes));
+}
+
+/** Run the MPC-TLS verifier over a PeerJS data channel; returns what it learned. */
+export function runVerifierSession(
+  cfg: { maxSentData?: number; maxRecvData?: number },
+  conn: DataConnection,
+  onProgress?: (message: string) => void,
+): Promise<SelfTestResult> {
+  const sendOut = wireConn(conn);
+  return getWorkerApi().runVerifier(
+    cfg,
+    sendOut,
+    onProgress ? Comlink.proxy(onProgress) : undefined,
+  );
+}
+
+/** Run the MPC-TLS prover over a PeerJS data channel (verifier) + a TCP proxy. */
+export function runProverSession(
+  cfg: SelfTestConfig,
+  conn: DataConnection,
+  onProgress?: (message: string) => void,
+): Promise<{ ms: number }> {
+  const sendOut = wireConn(conn);
+  return getWorkerApi().runProver(cfg, sendOut, onProgress ? Comlink.proxy(onProgress) : undefined);
+}

--- a/packages/demo/src/peer/wasmRuntime.ts
+++ b/packages/demo/src/peer/wasmRuntime.ts
@@ -1,5 +1,6 @@
 import * as Comlink from 'comlink';
 import type { DataConnection } from 'peerjs';
+import { toUint8Array } from '@tlsn/common';
 import type { InitConfig, VerifierResult } from './wasm.worker';
 
 export type { VerifierResult } from './wasm.worker';
@@ -38,11 +39,6 @@ export interface WasmRuntimeStatus {
   error?: string;
 }
 
-function toU8(d: unknown): Uint8Array {
-  if (d instanceof Uint8Array) return d;
-  return new Uint8Array(d as ArrayBufferLike);
-}
-
 // Bridge a PeerJS data channel to the worker's WASM session: inbound peer bytes
 // → worker; the worker's outbound bytes (via the proxied callback) → peer.
 // String frames are out-of-band status (handled by the page), never MPC bytes.
@@ -55,7 +51,7 @@ function wireConn(conn: DataConnection): {
   const api = getWorkerApi();
   const onData = (d: unknown) => {
     if (typeof d === 'string') return;
-    api.deliverToWasm(toU8(d));
+    api.deliverToWasm(toUint8Array(d));
   };
   const onClose = () => api.signalPeerClosed();
   conn.on('data', onData);

--- a/packages/demo/src/plugins.ts
+++ b/packages/demo/src/plugins.ts
@@ -9,6 +9,7 @@ export const plugins: Record<string, Plugin> = Object.fromEntries(
       description: p.description,
       logo: p.logo,
       file: `/plugins/${p.id}.js`,
+      host: p.pluginConfig.requests[0]?.host ?? '',
       parseResult: (json) => json.results[json.results.length - 1].value,
       debug: p.debug ?? false,
     } satisfies Plugin,

--- a/packages/demo/src/types.ts
+++ b/packages/demo/src/types.ts
@@ -3,6 +3,8 @@ export interface Plugin {
   description: string;
   logo: string;
   file: string;
+  /** Target server host (e.g. `swissbank.tlsnotary.org`) — shown in the P2P topology. */
+  host: string;
   parseResult: (json: PluginResult) => string;
   /** Work-in-progress / experimental plugin — shown with a "WIP" badge. */
   debug?: boolean;

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -1,17 +1,67 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 // Get git commit hash from GIT_HASH env var (set by CI/Docker) or fallback to 'local'
 const gitHash = process.env.GIT_HASH || 'local';
+
+// Only the VERIFIER side of the peer-to-peer page runs the WASM verifier, which
+// needs SharedArrayBuffer → cross-origin isolation. The verifier is opened via a
+// `?j=<peerId>` link; isolate only that document. The prover side (no query)
+// must NOT be isolated — it relies on the extension's injected `window.tlsn`,
+// which COEP would block. The main demo page is never isolated either.
+function crossOriginIsolatePeer(): Plugin {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const apply = (req: any, res: any, next: any) => {
+    const url = req.url || '';
+    const path = url.split('?')[0];
+    const isVerifierDoc = (path === '/peer.html' || path === '/peer') && url.includes('j=');
+    // Make every same-origin asset embeddable inside the isolated verifier.
+    res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
+    // COEP on assets/workers (so they load inside the isolated verifier) and on
+    // the verifier document itself — but never on the bare prover/main documents.
+    if (path !== '/' && path !== '/index.html' && path !== '/peer.html' && path !== '/peer') {
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    }
+    if (isVerifierDoc) {
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    }
+    next();
+  };
+  return {
+    name: 'coi-peer',
+    configureServer(server) {
+      server.middlewares.use(apply);
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(apply);
+    },
+  };
+}
 
 export default defineConfig({
   define: {
     __GIT_COMMIT_HASH__: JSON.stringify(gitHash),
   },
-  plugins: [react()],
+  plugins: [react(), crossOriginIsolatePeer()],
+  // tlsn-wasm ships its own .wasm + nested worker via `new URL(..., import.meta.url)`;
+  // excluding it from dep-optimization keeps those asset URLs intact.
+  optimizeDeps: { exclude: ['tlsn-wasm'] },
+  worker: { format: 'es' },
   build: {
     outDir: 'dist',
     sourcemap: true,
+    // Don't inline assets/workers as data: URLs — tlsn-wasm's rayon thread
+    // spawner uses `new URL('./spawn.js', import.meta.url)` internally, which
+    // breaks when the worker is inlined as a data: URL.
+    assetsInlineLimit: 0,
+    rollupOptions: {
+      input: {
+        main: resolve(import.meta.dirname, 'index.html'),
+        peer: resolve(import.meta.dirname, 'peer.html'),
+      },
+    },
   },
   server: {
     port: 3000,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "0.1.0.1500",
+  "version": "0.1.0.1501",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -163,12 +163,12 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
     return; // No response needed
   }
 
-  // Peer relay: outbound MPC bytes from offscreen → originating tab (→ page → data channel)
-  if (request.type === 'PEER_DATA_OUT') {
+  // Relay: outbound MPC bytes from offscreen → originating tab (→ page → data channel)
+  if (request.type === 'RELAY_OUT') {
     const route = progressRoutes.get(request.requestId);
     if (route) {
       browser.tabs.sendMessage(route.tabId, {
-        type: 'PEER_DATA_OUT',
+        type: 'RELAY_OUT',
         requestId: request.requestId,
         data: request.data,
       });
@@ -176,16 +176,16 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
     return; // No response needed
   }
 
-  // Peer relay: inbound MPC bytes from the page (via content script) → offscreen.
+  // Relay: inbound MPC bytes from the page (via content script) → offscreen.
   // Forward under a DISTINCT type the offscreen handles, so it delivers each
   // chunk once (the content script's runtime.sendMessage is also broadcast
   // directly to the offscreen — handling the raw type there would double it).
-  if (request.type === 'PEER_DATA_IN') {
-    chrome.runtime.sendMessage({ type: 'PEER_DATA_DELIVER', data: request.data }).catch(() => {});
+  if (request.type === 'RELAY_IN') {
+    chrome.runtime.sendMessage({ type: 'RELAY_DELIVER', data: request.data }).catch(() => {});
     return; // No response needed
   }
-  if (request.type === 'PEER_DATA_CLOSED') {
-    chrome.runtime.sendMessage({ type: 'PEER_DATA_DELIVER_CLOSED' }).catch(() => {});
+  if (request.type === 'RELAY_CLOSED') {
+    chrome.runtime.sendMessage({ type: 'RELAY_DELIVER_CLOSED' }).catch(() => {});
     return; // No response needed
   }
 

--- a/packages/extension/src/entries/Background/index.ts
+++ b/packages/extension/src/entries/Background/index.ts
@@ -163,6 +163,32 @@ browser.runtime.onMessage.addListener((msg: unknown, sender: browser.Runtime.Mes
     return; // No response needed
   }
 
+  // Peer relay: outbound MPC bytes from offscreen → originating tab (→ page → data channel)
+  if (request.type === 'PEER_DATA_OUT') {
+    const route = progressRoutes.get(request.requestId);
+    if (route) {
+      browser.tabs.sendMessage(route.tabId, {
+        type: 'PEER_DATA_OUT',
+        requestId: request.requestId,
+        data: request.data,
+      });
+    }
+    return; // No response needed
+  }
+
+  // Peer relay: inbound MPC bytes from the page (via content script) → offscreen.
+  // Forward under a DISTINCT type the offscreen handles, so it delivers each
+  // chunk once (the content script's runtime.sendMessage is also broadcast
+  // directly to the offscreen — handling the raw type there would double it).
+  if (request.type === 'PEER_DATA_IN') {
+    chrome.runtime.sendMessage({ type: 'PEER_DATA_DELIVER', data: request.data }).catch(() => {});
+    return; // No response needed
+  }
+  if (request.type === 'PEER_DATA_CLOSED') {
+    chrome.runtime.sendMessage({ type: 'PEER_DATA_DELIVER_CLOSED' }).catch(() => {});
+    return; // No response needed
+  }
+
   // Handle code execution requests
   if (request.type === 'EXEC_CODE') {
     logger.debug('EXEC_CODE request received');

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -221,11 +221,11 @@ browser.runtime.onMessage.addListener((msg: unknown) => {
     return; // No response needed
   }
 
-  // Peer relay: forward outbound MPC bytes from the extension to the page,
+  // Relay: forward outbound MPC bytes from the extension to the page,
   // which sends them over its data channel to the verifier.
-  if (request.type === 'PEER_DATA_OUT') {
+  if (request.type === 'RELAY_OUT') {
     window.postMessage(
-      { type: 'TLSN_PEER_DATA_OUT', requestId: request.requestId, data: request.data },
+      { type: 'TLSN_RELAY_OUT', requestId: request.requestId, data: request.data },
       window.location.origin,
     );
     return; // No response needed
@@ -279,11 +279,11 @@ window.addEventListener('message', (event) => {
       });
   }
 
-  // Peer relay: inbound MPC bytes from the page's data channel → extension.
-  if (event.data?.type === 'TLSN_PEER_DATA_IN') {
+  // Relay: inbound MPC bytes from the page's data channel → extension.
+  if (event.data?.type === 'TLSN_RELAY_IN') {
     browser.runtime
       .sendMessage({
-        type: 'PEER_DATA_IN',
+        type: 'RELAY_IN',
         requestId: event.data.requestId,
         data: event.data.data,
       })
@@ -292,9 +292,9 @@ window.addEventListener('message', (event) => {
       });
     return;
   }
-  if (event.data?.type === 'TLSN_PEER_DATA_CLOSED') {
+  if (event.data?.type === 'TLSN_RELAY_CLOSED') {
     browser.runtime
-      .sendMessage({ type: 'PEER_DATA_CLOSED', requestId: event.data.requestId })
+      .sendMessage({ type: 'RELAY_CLOSED', requestId: event.data.requestId })
       .catch(() => {});
     return;
   }

--- a/packages/extension/src/entries/Content/index.ts
+++ b/packages/extension/src/entries/Content/index.ts
@@ -221,6 +221,16 @@ browser.runtime.onMessage.addListener((msg: unknown) => {
     return; // No response needed
   }
 
+  // Peer relay: forward outbound MPC bytes from the extension to the page,
+  // which sends them over its data channel to the verifier.
+  if (request.type === 'PEER_DATA_OUT') {
+    window.postMessage(
+      { type: 'TLSN_PEER_DATA_OUT', requestId: request.requestId, data: request.data },
+      window.location.origin,
+    );
+    return; // No response needed
+  }
+
   if (request.type === 'GET_PAGE_INFO') {
     return Promise.resolve({
       title: document.title,
@@ -267,6 +277,26 @@ window.addEventListener('message', (event) => {
       .catch((error) => {
         logger.error('[Content Script] Failed to send OPEN_WINDOW message:', error);
       });
+  }
+
+  // Peer relay: inbound MPC bytes from the page's data channel → extension.
+  if (event.data?.type === 'TLSN_PEER_DATA_IN') {
+    browser.runtime
+      .sendMessage({
+        type: 'PEER_DATA_IN',
+        requestId: event.data.requestId,
+        data: event.data.data,
+      })
+      .catch(() => {
+        /* extension context may be gone */
+      });
+    return;
+  }
+  if (event.data?.type === 'TLSN_PEER_DATA_CLOSED') {
+    browser.runtime
+      .sendMessage({ type: 'PEER_DATA_CLOSED', requestId: event.data.requestId })
+      .catch(() => {});
+    return;
   }
 
   // Handle code execution requests

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -40,16 +40,16 @@ const OffscreenApp: React.FC = () => {
         });
       }
 
-      // Peer relay: inbound MPC bytes from the verifier (forwarded by the
+      // Relay: inbound MPC bytes from the verifier (forwarded by the
       // background under a distinct type so each chunk is delivered exactly once
       // — the content script's runtime.sendMessage is ALSO broadcast directly to
-      // this offscreen, so we must NOT also handle the raw PEER_DATA_IN here).
-      if (request.type === 'PEER_DATA_DELIVER') {
-        sessionManager.handlePeerDataIn(request.data as string);
+      // this offscreen, so we must NOT also handle the raw RELAY_IN here).
+      if (request.type === 'RELAY_DELIVER') {
+        sessionManager.handleRelayIn(request.data as string);
         return;
       }
-      if (request.type === 'PEER_DATA_DELIVER_CLOSED') {
-        sessionManager.handlePeerClosed();
+      if (request.type === 'RELAY_DELIVER_CLOSED') {
+        sessionManager.handleRelayClosed();
         return;
       }
 

--- a/packages/extension/src/entries/Offscreen/index.tsx
+++ b/packages/extension/src/entries/Offscreen/index.tsx
@@ -40,6 +40,19 @@ const OffscreenApp: React.FC = () => {
         });
       }
 
+      // Peer relay: inbound MPC bytes from the verifier (forwarded by the
+      // background under a distinct type so each chunk is delivered exactly once
+      // — the content script's runtime.sendMessage is ALSO broadcast directly to
+      // this offscreen, so we must NOT also handle the raw PEER_DATA_IN here).
+      if (request.type === 'PEER_DATA_DELIVER') {
+        sessionManager.handlePeerDataIn(request.data as string);
+        return;
+      }
+      if (request.type === 'PEER_DATA_DELIVER_CLOSED') {
+        sessionManager.handlePeerClosed();
+        return;
+      }
+
       // Handle code execution requests
       if (request.type === 'EXEC_CODE_OFFSCREEN') {
         logger.debug('Offscreen executing code:', request.code);

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "version": "0.1.0.1500",
+  "version": "0.1.0.1501",
   "name": "TLSNotary",
   "description": "A Chrome extension for TLSNotary",
   "options_page": "options.html",

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -350,7 +350,7 @@ export class ProveManager {
 
   /**
    * Peer verifier mode: the verifier runs in another browser. The MPC byte
-   * stream is relayed through the demo page (which owns the WebRTC/PeerJS
+   * stream is relayed through the host page (which owns the WebRTC/PeerJS
    * connection): outbound bytes go to `onOut`; inbound bytes arrive via
    * deliverPeerData(). In `Proxy` mode the server connection routes through the
    * verifier (which opens its own TCP proxy), so the prover passes no server_io.

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -352,17 +352,19 @@ export class ProveManager {
    * Peer verifier mode: the verifier runs in another browser. The MPC byte
    * stream is relayed through the demo page (which owns the WebRTC/PeerJS
    * connection): outbound bytes go to `onOut`; inbound bytes arrive via
-   * deliverPeerData(). Always MPC — the verifier browser can't open server TCP.
+   * deliverPeerData(). In `Proxy` mode the server connection routes through the
+   * verifier (which opens its own TCP proxy), so the prover passes no server_io.
    */
   async createProverRelay(
     serverDns: string,
     onOut: (bytes: Uint8Array) => void,
     maxRecvData = 16384,
     maxSentData = 4096,
+    mode: ProverMode = 'Mpc',
   ): Promise<string> {
     const proverId = await workerApi.createProver({
       server_name: serverDns,
-      mode: 'Mpc',
+      mode,
       max_sent_data: maxSentData,
       max_sent_records: undefined,
       max_recv_data_online: undefined,

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -34,9 +34,9 @@ const workerApi = Comlink.wrap<{
   }) => Promise<void>;
   createProver: (config: ProverConfig) => Promise<string>;
   setupProver: (proverId: string, verifierUrl: string) => Promise<void>;
-  setupProverPeer: (proverId: string, sendOut: (bytes: Uint8Array) => void) => Promise<void>;
+  setupProverRelay: (proverId: string, sendOut: (bytes: Uint8Array) => void) => Promise<void>;
   deliverToWasm: (bytes: Uint8Array) => void;
-  signalPeerClosed: () => void;
+  signalRelayClosed: () => void;
   sendRequest: (
     proverId: string,
     proxyUrl: string | undefined,
@@ -349,10 +349,10 @@ export class ProveManager {
   }
 
   /**
-   * Peer verifier mode: the verifier runs in another browser. The MPC byte
-   * stream is relayed through the host page (which owns the WebRTC/PeerJS
+   * Relayed verifier mode: the verifier runs in another browser. The MPC byte
+   * stream is relayed through the host page (which owns the transport
    * connection): outbound bytes go to `onOut`; inbound bytes arrive via
-   * deliverPeerData(). In `Proxy` mode the server connection routes through the
+   * deliverRelayData(). In `Proxy` mode the server connection routes through the
    * verifier (which opens its own TCP proxy), so the prover passes no server_io.
    */
   async createProverRelay(
@@ -377,7 +377,7 @@ export class ProveManager {
     });
 
     try {
-      await workerApi.setupProverPeer(proverId, Comlink.proxy(onOut));
+      await workerApi.setupProverRelay(proverId, Comlink.proxy(onOut));
       return proverId;
     } catch (error) {
       logger.error('[ProveManager] Failed to create relay prover:', error);
@@ -386,14 +386,14 @@ export class ProveManager {
     }
   }
 
-  /** Deliver bytes received from the peer (relayed by the page) to the prover. */
-  deliverPeerData(bytes: Uint8Array): void {
+  /** Deliver bytes received over the relay (from the host page) to the prover. */
+  deliverRelayData(bytes: Uint8Array): void {
     workerApi.deliverToWasm(bytes);
   }
 
-  /** Signal that the relayed peer channel closed. */
-  signalPeerClosed(): void {
-    workerApi.signalPeerClosed();
+  /** Signal that the relayed channel closed. */
+  signalRelayClosed(): void {
+    workerApi.signalRelayClosed();
   }
 
   /**

--- a/packages/extension/src/offscreen/ProveManager/index.ts
+++ b/packages/extension/src/offscreen/ProveManager/index.ts
@@ -34,6 +34,9 @@ const workerApi = Comlink.wrap<{
   }) => Promise<void>;
   createProver: (config: ProverConfig) => Promise<string>;
   setupProver: (proverId: string, verifierUrl: string) => Promise<void>;
+  setupProverPeer: (proverId: string, sendOut: (bytes: Uint8Array) => void) => Promise<void>;
+  deliverToWasm: (bytes: Uint8Array) => void;
+  signalPeerClosed: () => void;
   sendRequest: (
     proverId: string,
     proxyUrl: string | undefined,
@@ -343,6 +346,52 @@ export class ProveManager {
       await this.cleanupProver(proverId);
       throw error;
     }
+  }
+
+  /**
+   * Peer verifier mode: the verifier runs in another browser. The MPC byte
+   * stream is relayed through the demo page (which owns the WebRTC/PeerJS
+   * connection): outbound bytes go to `onOut`; inbound bytes arrive via
+   * deliverPeerData(). Always MPC — the verifier browser can't open server TCP.
+   */
+  async createProverRelay(
+    serverDns: string,
+    onOut: (bytes: Uint8Array) => void,
+    maxRecvData = 16384,
+    maxSentData = 4096,
+  ): Promise<string> {
+    const proverId = await workerApi.createProver({
+      server_name: serverDns,
+      mode: 'Mpc',
+      max_sent_data: maxSentData,
+      max_sent_records: undefined,
+      max_recv_data_online: undefined,
+      max_recv_data: maxRecvData,
+      max_recv_records_online: undefined,
+      defer_decryption_from_start: undefined,
+      network: 'Bandwidth',
+      client_auth: undefined,
+      root_certs: undefined,
+    });
+
+    try {
+      await workerApi.setupProverPeer(proverId, Comlink.proxy(onOut));
+      return proverId;
+    } catch (error) {
+      logger.error('[ProveManager] Failed to create relay prover:', error);
+      await this.cleanupProver(proverId);
+      throw error;
+    }
+  }
+
+  /** Deliver bytes received from the peer (relayed by the page) to the prover. */
+  deliverPeerData(bytes: Uint8Array): void {
+    workerApi.deliverToWasm(bytes);
+  }
+
+  /** Signal that the relayed peer channel closed. */
+  signalPeerClosed(): void {
+    workerApi.signalPeerClosed();
   }
 
   /**

--- a/packages/extension/src/offscreen/ProveManager/worker.ts
+++ b/packages/extension/src/offscreen/ProveManager/worker.ts
@@ -238,6 +238,87 @@ async function setupProver(proverId: string, verifierUrl: string): Promise<void>
   }
 }
 
+// ============================================================================
+// Peer relay transport
+//
+// For peer-to-peer proofs the verifier runs in another browser. WebRTC lives in
+// the demo page (not here), so the verifier's bytes are relayed: outbound bytes
+// go to a main-thread `sendOut` callback (→ page → data channel); inbound bytes
+// are pushed back via deliverToWasm(). This is a plain byte bridge — no WebRTC.
+// ============================================================================
+
+let peerInbox: Uint8Array[] = [];
+let peerReadResolver: ((value: Uint8Array | null) => void) | null = null;
+let peerClosed = false;
+let peerSendOut: ((bytes: Uint8Array) => void) | null = null;
+
+function peerIo(): IoChannel {
+  return {
+    async read(): Promise<Uint8Array | null> {
+      if (peerInbox.length > 0) return peerInbox.shift()!;
+      if (peerClosed) return null;
+      return new Promise((res) => {
+        peerReadResolver = res;
+      });
+    },
+    async write(data: Uint8Array): Promise<void> {
+      // Copy off (possibly shared) WASM memory before crossing to the main thread.
+      peerSendOut?.(data.slice());
+    },
+    async close(): Promise<void> {
+      /* the main thread / page owns the data channel lifecycle */
+    },
+  };
+}
+
+/** Push bytes received from the peer (called from the main thread). */
+function deliverToWasm(bytes: Uint8Array): void {
+  if (peerReadResolver) {
+    const resolve = peerReadResolver;
+    peerReadResolver = null;
+    resolve(bytes);
+  } else {
+    peerInbox.push(bytes);
+  }
+}
+
+/** Signal the peer channel closed (EOF). */
+function signalPeerClosed(): void {
+  peerClosed = true;
+  if (peerReadResolver) {
+    const resolve = peerReadResolver;
+    peerReadResolver = null;
+    resolve(null);
+  }
+}
+
+/** Set up the prover over the relayed peer channel instead of a WebSocket. */
+async function setupProverPeer(
+  proverId: string,
+  sendOut: (bytes: Uint8Array) => void,
+): Promise<void> {
+  const prover = provers.get(proverId);
+  if (!prover) throw new Error(`Prover not found: ${proverId}`);
+
+  peerInbox = [];
+  peerReadResolver = null;
+  peerClosed = false;
+  peerSendOut = sendOut;
+
+  await Promise.race([
+    prover.setup(peerIo()),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () =>
+          reject(
+            new Error(`setupProverPeer timed out after ${SETUP_TIMEOUT_MS}ms for ${proverId}`),
+          ),
+        SETUP_TIMEOUT_MS,
+      ),
+    ),
+  ]);
+}
+
 /**
  * Sends an HTTP request through the prover via WebSocket proxy URL.
  */
@@ -431,6 +512,9 @@ Comlink.expose({
   init,
   createProver,
   setupProver,
+  setupProverPeer,
+  deliverToWasm,
+  signalPeerClosed,
   sendRequest,
   getTranscript,
   computeReveal,

--- a/packages/extension/src/offscreen/ProveManager/worker.ts
+++ b/packages/extension/src/offscreen/ProveManager/worker.ts
@@ -242,7 +242,7 @@ async function setupProver(proverId: string, verifierUrl: string): Promise<void>
 // Peer relay transport
 //
 // For peer-to-peer proofs the verifier runs in another browser. WebRTC lives in
-// the demo page (not here), so the verifier's bytes are relayed: outbound bytes
+// the host page (not here), so the verifier's bytes are relayed: outbound bytes
 // go to a main-thread `sendOut` callback (→ page → data channel); inbound bytes
 // are pushed back via deliverToWasm(). This is a plain byte bridge — no WebRTC.
 // ============================================================================

--- a/packages/extension/src/offscreen/ProveManager/worker.ts
+++ b/packages/extension/src/offscreen/ProveManager/worker.ts
@@ -245,6 +245,12 @@ async function setupProver(proverId: string, verifierUrl: string): Promise<void>
 // the host page (not here), so the verifier's bytes are relayed: outbound bytes
 // go to a main-thread `sendOut` callback (→ page → data channel); inbound bytes
 // are pushed back via deliverToWasm(). This is a plain byte bridge — no WebRTC.
+//
+// These are module-level singletons, so they assume ONE relayed proof at a time
+// per worker. That holds because the host page disables its Prove button while a
+// proof is in flight, serializing relayed proofs; inbound RELAY_IN chunks are
+// likewise forwarded to the single active prover without a requestId. Concurrent
+// relayed proofs in one offscreen would cross-talk on this state.
 // ============================================================================
 
 let relayInbox: Uint8Array[] = [];

--- a/packages/extension/src/offscreen/ProveManager/worker.ts
+++ b/packages/extension/src/offscreen/ProveManager/worker.ts
@@ -239,31 +239,31 @@ async function setupProver(proverId: string, verifierUrl: string): Promise<void>
 }
 
 // ============================================================================
-// Peer relay transport
+// Relay transport
 //
-// For peer-to-peer proofs the verifier runs in another browser. WebRTC lives in
+// For relayed proofs the verifier runs in another browser. WebRTC lives in
 // the host page (not here), so the verifier's bytes are relayed: outbound bytes
 // go to a main-thread `sendOut` callback (→ page → data channel); inbound bytes
 // are pushed back via deliverToWasm(). This is a plain byte bridge — no WebRTC.
 // ============================================================================
 
-let peerInbox: Uint8Array[] = [];
-let peerReadResolver: ((value: Uint8Array | null) => void) | null = null;
-let peerClosed = false;
-let peerSendOut: ((bytes: Uint8Array) => void) | null = null;
+let relayInbox: Uint8Array[] = [];
+let relayReadResolver: ((value: Uint8Array | null) => void) | null = null;
+let relayClosed = false;
+let relaySendOut: ((bytes: Uint8Array) => void) | null = null;
 
-function peerIo(): IoChannel {
+function relayIo(): IoChannel {
   return {
     async read(): Promise<Uint8Array | null> {
-      if (peerInbox.length > 0) return peerInbox.shift()!;
-      if (peerClosed) return null;
+      if (relayInbox.length > 0) return relayInbox.shift()!;
+      if (relayClosed) return null;
       return new Promise((res) => {
-        peerReadResolver = res;
+        relayReadResolver = res;
       });
     },
     async write(data: Uint8Array): Promise<void> {
       // Copy off (possibly shared) WASM memory before crossing to the main thread.
-      peerSendOut?.(data.slice());
+      relaySendOut?.(data.slice());
     },
     async close(): Promise<void> {
       /* the main thread / page owns the data channel lifecycle */
@@ -271,47 +271,47 @@ function peerIo(): IoChannel {
   };
 }
 
-/** Push bytes received from the peer (called from the main thread). */
+/** Push bytes received from the relay (called from the main thread). */
 function deliverToWasm(bytes: Uint8Array): void {
-  if (peerReadResolver) {
-    const resolve = peerReadResolver;
-    peerReadResolver = null;
+  if (relayReadResolver) {
+    const resolve = relayReadResolver;
+    relayReadResolver = null;
     resolve(bytes);
   } else {
-    peerInbox.push(bytes);
+    relayInbox.push(bytes);
   }
 }
 
-/** Signal the peer channel closed (EOF). */
-function signalPeerClosed(): void {
-  peerClosed = true;
-  if (peerReadResolver) {
-    const resolve = peerReadResolver;
-    peerReadResolver = null;
+/** Signal the relayed channel closed (EOF). */
+function signalRelayClosed(): void {
+  relayClosed = true;
+  if (relayReadResolver) {
+    const resolve = relayReadResolver;
+    relayReadResolver = null;
     resolve(null);
   }
 }
 
-/** Set up the prover over the relayed peer channel instead of a WebSocket. */
-async function setupProverPeer(
+/** Set up the prover over the relayed channel instead of a WebSocket. */
+async function setupProverRelay(
   proverId: string,
   sendOut: (bytes: Uint8Array) => void,
 ): Promise<void> {
   const prover = provers.get(proverId);
   if (!prover) throw new Error(`Prover not found: ${proverId}`);
 
-  peerInbox = [];
-  peerReadResolver = null;
-  peerClosed = false;
-  peerSendOut = sendOut;
+  relayInbox = [];
+  relayReadResolver = null;
+  relayClosed = false;
+  relaySendOut = sendOut;
 
   await Promise.race([
-    prover.setup(peerIo()),
+    prover.setup(relayIo()),
     new Promise<never>((_, reject) =>
       setTimeout(
         () =>
           reject(
-            new Error(`setupProverPeer timed out after ${SETUP_TIMEOUT_MS}ms for ${proverId}`),
+            new Error(`setupProverRelay timed out after ${SETUP_TIMEOUT_MS}ms for ${proverId}`),
           ),
         SETUP_TIMEOUT_MS,
       ),
@@ -512,9 +512,9 @@ Comlink.expose({
   init,
   createProver,
   setupProver,
-  setupProverPeer,
+  setupProverRelay,
   deliverToWasm,
-  signalPeerClosed,
+  signalRelayClosed,
   sendRequest,
   getTranscript,
   computeReveal,

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -32,7 +32,7 @@ import { validateProvePermission, validateOpenWindowPermission } from './permiss
 const PREVIEW_MAX_CHARS = 256;
 
 // Rewrite a proxy URL's origin (protocol + host) to `base`, keeping its path +
-// `?token=<host>`. Lets the peer demo relay the prover↔server TCP through a
+// `?token=<host>`. Lets the host page relay the prover↔server TCP through a
 // reachable proxy without rebuilding plugins. No-op if base is unset/invalid.
 function applyProxyBase(proxyUrl: string, base?: string): string {
   if (!base) return proxyUrl;
@@ -235,8 +235,8 @@ export class SessionManager {
         };
 
         // Peer verifier mode: the verifier runs in another browser. The MPC byte
-        // stream is relayed through the demo page (which owns the PeerJS/WebRTC
-        // connection) — selected by `peerRelay: '1'` in sessionData. Always MPC.
+        // stream is relayed through the host page (which owns the PeerJS/WebRTC
+        // connection) — selected by `peerRelay: '1'` in sessionData.
         const isPeer = sessionData.peerRelay === '1';
 
         // Mode is a user/platform decision, not a plugin decision.
@@ -290,7 +290,7 @@ export class SessionManager {
           // websockify proxy is opened. In MPC mode we pass the websockify URL
           // through to the worker, which will create a JsIo channel for it.
           // `proxyBase` (sessionData) overrides the plugin's build-time proxy
-          // origin — used by the peer demo to relay through a reachable proxy
+          // origin — used by the host page to relay through a reachable proxy
           // (e.g. wss://demo.tlsnotary.org) while keeping the ?token=<host>.
           const workerProxyUrl =
             mode === 'Proxy'

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -141,16 +141,16 @@ export class SessionManager {
   }
 
   /**
-   * Peer relay: deliver an inbound MPC chunk (relayed by the page from the
+   * Relay: deliver an inbound MPC chunk (relayed by the page from the
    * verifier's data channel) to the active prover.
    */
-  handlePeerDataIn(b64: string): void {
-    this.proveManager.deliverPeerData(b64ToBytes(b64));
+  handleRelayIn(b64: string): void {
+    this.proveManager.deliverRelayData(b64ToBytes(b64));
   }
 
-  /** Peer relay: signal the data channel closed. */
-  handlePeerClosed(): void {
-    this.proveManager.signalPeerClosed();
+  /** Relay: signal the data channel closed. */
+  handleRelayClosed(): void {
+    this.proveManager.signalRelayClosed();
   }
 
   /**
@@ -186,11 +186,11 @@ export class SessionManager {
     };
 
     // Relay an outbound MPC chunk to the page (which owns the data channel).
-    const emitPeerDataOut = (bytes: Uint8Array) => {
+    const emitRelayOut = (bytes: Uint8Array) => {
       if (!requestId) return;
       SessionManager.getChromeRuntime()
-        .sendMessage({ type: 'PEER_DATA_OUT', requestId, data: bytesToB64(bytes) })
-        .catch((err: unknown) => logger.warn('[SessionManager] emitPeerDataOut failed:', err));
+        .sendMessage({ type: 'RELAY_OUT', requestId, data: bytesToB64(bytes) })
+        .catch((err: unknown) => logger.warn('[SessionManager] emitRelayOut failed:', err));
     };
 
     const host = new Host({
@@ -234,34 +234,34 @@ export class SessionManager {
           onProgress?.({ step, progress, message });
         };
 
-        // Peer verifier mode: the verifier runs in another browser. The MPC byte
-        // stream is relayed through the host page (which owns the PeerJS/WebRTC
-        // connection) — selected by `peerRelay: '1'` in sessionData.
-        const isPeer = sessionData.peerRelay === '1';
+        // Relayed verifier mode: the verifier runs in another browser. The MPC byte
+        // stream is relayed through the host page (which owns the transport
+        // connection) — selected by `relay: '1'` in sessionData.
+        const isRelay = sessionData.relay === '1';
 
         // Mode is a user/platform decision, not a plugin decision.
-        // Read from sessionData provided by the caller of execCode(). Peer mode
+        // Read from sessionData provided by the caller of execCode(). Relay mode
         // supports both: in Proxy mode the verifier browser opens the server TCP
         // (through its own proxy) and the prover tunnels through the verifier.
         const mode = (sessionData.mode as 'Mpc' | 'Proxy') ?? 'Mpc';
-        const modeLabel = isPeer ? `peer (${mode})` : mode === 'Proxy' ? 'Proxy' : 'MPC';
-        logger.debug('[SessionManager] Prove mode:', mode, 'peer:', isPeer);
+        const modeLabel = isRelay ? `relay (${mode})` : mode === 'Proxy' ? 'Proxy' : 'MPC';
+        logger.debug('[SessionManager] Prove mode:', mode, 'relay:', isRelay);
 
         emitBoth('CONNECTING', 0.0, `Connecting to verifier (${modeLabel} mode)...`);
 
-        // Peer mode: tell the verifier (in the other browser) which limits to
+        // Relay mode: tell the verifier (in the other browser) which limits to
         // commit to — same model as the verifier server, which adopts the
         // prover's maxSentData/maxRecvData from its register message.
-        if (isPeer) {
+        if (isRelay) {
           const maxSentData = proverOptions.maxSentData ?? 4096;
           const maxRecvData = proverOptions.maxRecvData ?? 16384;
-          emitBoth('PEER_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData, mode }));
+          emitBoth('RELAY_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData, mode }));
         }
 
-        const proverId = isPeer
+        const proverId = isRelay
           ? await proveManager.createProverRelay(
               url.hostname,
-              (bytes) => emitPeerDataOut(bytes),
+              (bytes) => emitRelayOut(bytes),
               proverOptions.maxRecvData,
               proverOptions.maxSentData,
               mode,
@@ -350,9 +350,9 @@ export class SessionManager {
           }
 
           // Send reveal config (ranges + handlers) to verifier BEFORE calling reveal().
-          // Peer mode has no server control channel — the WASM verifier in the
+          // Relay mode has no server control channel — the WASM verifier in the
           // other browser learns the revealed ranges directly through the MPC.
-          if (!isPeer) {
+          if (!isRelay) {
             emitBoth('SENDING_REVEAL_CONFIG', 0.6, 'Configuring selective disclosure...');
             await proveManager.sendRevealConfig(proverId, {
               sent: sentRangesWithHandlers,
@@ -374,12 +374,12 @@ export class SessionManager {
             logger.debug('reveal openings', openings);
           }
 
-          // Get structured response from verifier. In peer mode the result lives
+          // Get structured response from verifier. In relay mode the result lives
           // on the verifying browser (its own verify() output) — there is no
           // server response to wait for, so the prover just completes.
           emitBoth('WAITING_FOR_VERIFICATION', 0.85, 'Waiting for verification...');
-          const response = isPeer
-            ? { results: [], peer: true }
+          const response = isRelay
+            ? { results: [], relay: true }
             : await proveManager.getResponse(proverId);
 
           emitBoth('COMPLETE', 1.0, 'Complete');

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -12,7 +12,7 @@ import type {
   RevealRangeDescriptor,
   WindowMessage,
 } from '@tlsn/plugin-sdk';
-import { logger } from '@tlsn/common';
+import { logger, bytesToBase64, base64ToBytes } from '@tlsn/common';
 
 /**
  * Minimal interface for the Chrome runtime API surface used by SessionManager.
@@ -45,19 +45,6 @@ function applyProxyBase(proxyUrl: string, base?: string): string {
   } catch {
     return proxyUrl;
   }
-}
-
-// Base64 (de)serialization for relayed MPC bytes over the chrome message bridge.
-function bytesToB64(bytes: Uint8Array): string {
-  let s = '';
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
-  return btoa(s);
-}
-function b64ToBytes(b64: string): Uint8Array {
-  const s = atob(b64);
-  const bytes = new Uint8Array(s.length);
-  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
-  return bytes;
 }
 
 function buildLabel(handler: CanonicalHandler): string {
@@ -145,7 +132,7 @@ export class SessionManager {
    * verifier's data channel) to the active prover.
    */
   handleRelayIn(b64: string): void {
-    this.proveManager.deliverRelayData(b64ToBytes(b64));
+    this.proveManager.deliverRelayData(base64ToBytes(b64));
   }
 
   /** Relay: signal the data channel closed. */
@@ -189,7 +176,7 @@ export class SessionManager {
     const emitRelayOut = (bytes: Uint8Array) => {
       if (!requestId) return;
       SessionManager.getChromeRuntime()
-        .sendMessage({ type: 'RELAY_OUT', requestId, data: bytesToB64(bytes) })
+        .sendMessage({ type: 'RELAY_OUT', requestId, data: bytesToBase64(bytes) })
         .catch((err: unknown) => logger.warn('[SessionManager] emitRelayOut failed:', err));
     };
 

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -238,11 +238,15 @@ export class SessionManager {
 
         // Relay mode: tell the verifier (in the other browser) which limits to
         // commit to — same model as the verifier server, which adopts the
-        // prover's maxSentData/maxRecvData from its register message.
+        // prover's maxSentData/maxRecvData from its register message. This is a
+        // control frame the host page consumes (and never displays), so it goes
+        // to the page only (emitProgress) — NOT emitBoth, which would render the
+        // raw JSON as the plugin UI's progress text. The plugin stays on the
+        // preceding "Connecting to verifier…" message.
         if (isRelay) {
           const maxSentData = proverOptions.maxSentData ?? 4096;
           const maxRecvData = proverOptions.maxRecvData ?? 16384;
-          emitBoth('RELAY_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData, mode }));
+          emitProgress('RELAY_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData, mode }));
         }
 
         const proverId = isRelay

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -240,9 +240,11 @@ export class SessionManager {
         const isPeer = sessionData.peerRelay === '1';
 
         // Mode is a user/platform decision, not a plugin decision.
-        // Read from sessionData provided by the caller of execCode().
-        const mode = isPeer ? 'Mpc' : ((sessionData.mode as 'Mpc' | 'Proxy') ?? 'Mpc');
-        const modeLabel = isPeer ? 'peer' : mode === 'Proxy' ? 'Proxy' : 'MPC';
+        // Read from sessionData provided by the caller of execCode(). Peer mode
+        // supports both: in Proxy mode the verifier browser opens the server TCP
+        // (through its own proxy) and the prover tunnels through the verifier.
+        const mode = (sessionData.mode as 'Mpc' | 'Proxy') ?? 'Mpc';
+        const modeLabel = isPeer ? `peer (${mode})` : mode === 'Proxy' ? 'Proxy' : 'MPC';
         logger.debug('[SessionManager] Prove mode:', mode, 'peer:', isPeer);
 
         emitBoth('CONNECTING', 0.0, `Connecting to verifier (${modeLabel} mode)...`);
@@ -253,7 +255,7 @@ export class SessionManager {
         if (isPeer) {
           const maxSentData = proverOptions.maxSentData ?? 4096;
           const maxRecvData = proverOptions.maxRecvData ?? 16384;
-          emitBoth('PEER_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData }));
+          emitBoth('PEER_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData, mode }));
         }
 
         const proverId = isPeer
@@ -262,6 +264,7 @@ export class SessionManager {
               (bytes) => emitPeerDataOut(bytes),
               proverOptions.maxRecvData,
               proverOptions.maxSentData,
+              mode,
             )
           : await proveManager.createProver(
               url.hostname,

--- a/packages/extension/src/offscreen/SessionManager.ts
+++ b/packages/extension/src/offscreen/SessionManager.ts
@@ -31,6 +31,35 @@ import { validateProvePermission, validateOpenWindowPermission } from './permiss
 /** Maximum number of preview characters shown per reveal range. */
 const PREVIEW_MAX_CHARS = 256;
 
+// Rewrite a proxy URL's origin (protocol + host) to `base`, keeping its path +
+// `?token=<host>`. Lets the peer demo relay the prover↔server TCP through a
+// reachable proxy without rebuilding plugins. No-op if base is unset/invalid.
+function applyProxyBase(proxyUrl: string, base?: string): string {
+  if (!base) return proxyUrl;
+  try {
+    const u = new URL(proxyUrl);
+    // Use the base's origin (protocol + host, incl. its default port handling)
+    // and keep the original path + ?token=<host>. Rebuilding from origin avoids
+    // the URL.host setter retaining a stale port (e.g. :7047).
+    return `${new URL(base).origin}${u.pathname}${u.search}`;
+  } catch {
+    return proxyUrl;
+  }
+}
+
+// Base64 (de)serialization for relayed MPC bytes over the chrome message bridge.
+function bytesToB64(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+function b64ToBytes(b64: string): Uint8Array {
+  const s = atob(b64);
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+  return bytes;
+}
+
 function buildLabel(handler: CanonicalHandler): string {
   const part =
     handler.part.charAt(0).toUpperCase() + handler.part.slice(1).toLowerCase().replace(/_/g, ' ');
@@ -112,6 +141,19 @@ export class SessionManager {
   }
 
   /**
+   * Peer relay: deliver an inbound MPC chunk (relayed by the page from the
+   * verifier's data channel) to the active prover.
+   */
+  handlePeerDataIn(b64: string): void {
+    this.proveManager.deliverPeerData(b64ToBytes(b64));
+  }
+
+  /** Peer relay: signal the data channel closed. */
+  handlePeerClosed(): void {
+    this.proveManager.signalPeerClosed();
+  }
+
+  /**
    * Create a per-execution Host with callbacks that close over execution-scoped
    * state (config, requestId, sessionData). This prevents concurrent plugin
    * executions from contaminating each other's permission validation.
@@ -141,6 +183,14 @@ export class SessionManager {
           source,
         })
         .catch((err: unknown) => logger.warn('[SessionManager] emitProgress failed:', err));
+    };
+
+    // Relay an outbound MPC chunk to the page (which owns the data channel).
+    const emitPeerDataOut = (bytes: Uint8Array) => {
+      if (!requestId) return;
+      SessionManager.getChromeRuntime()
+        .sendMessage({ type: 'PEER_DATA_OUT', requestId, data: bytesToB64(bytes) })
+        .catch((err: unknown) => logger.warn('[SessionManager] emitPeerDataOut failed:', err));
     };
 
     const host = new Host({
@@ -184,22 +234,43 @@ export class SessionManager {
           onProgress?.({ step, progress, message });
         };
 
+        // Peer verifier mode: the verifier runs in another browser. The MPC byte
+        // stream is relayed through the demo page (which owns the PeerJS/WebRTC
+        // connection) — selected by `peerRelay: '1'` in sessionData. Always MPC.
+        const isPeer = sessionData.peerRelay === '1';
+
         // Mode is a user/platform decision, not a plugin decision.
         // Read from sessionData provided by the caller of execCode().
-        const mode = (sessionData.mode as 'Mpc' | 'Proxy') ?? 'Mpc';
-        const modeLabel = mode === 'Proxy' ? 'Proxy' : 'MPC';
-        logger.debug('[SessionManager] Prove mode:', mode, 'sessionData:', sessionData);
+        const mode = isPeer ? 'Mpc' : ((sessionData.mode as 'Mpc' | 'Proxy') ?? 'Mpc');
+        const modeLabel = isPeer ? 'peer' : mode === 'Proxy' ? 'Proxy' : 'MPC';
+        logger.debug('[SessionManager] Prove mode:', mode, 'peer:', isPeer);
 
         emitBoth('CONNECTING', 0.0, `Connecting to verifier (${modeLabel} mode)...`);
 
-        const proverId = await proveManager.createProver(
-          url.hostname,
-          proverOptions.verifierUrl,
-          proverOptions.maxRecvData,
-          proverOptions.maxSentData,
-          sessionData,
-          mode,
-        );
+        // Peer mode: tell the verifier (in the other browser) which limits to
+        // commit to — same model as the verifier server, which adopts the
+        // prover's maxSentData/maxRecvData from its register message.
+        if (isPeer) {
+          const maxSentData = proverOptions.maxSentData ?? 4096;
+          const maxRecvData = proverOptions.maxRecvData ?? 16384;
+          emitBoth('PEER_LIMITS', 0.02, JSON.stringify({ maxSentData, maxRecvData }));
+        }
+
+        const proverId = isPeer
+          ? await proveManager.createProverRelay(
+              url.hostname,
+              (bytes) => emitPeerDataOut(bytes),
+              proverOptions.maxRecvData,
+              proverOptions.maxSentData,
+            )
+          : await proveManager.createProver(
+              url.hostname,
+              proverOptions.verifierUrl,
+              proverOptions.maxRecvData,
+              proverOptions.maxSentData,
+              sessionData,
+              mode,
+            );
 
         // Register per-prover WASM progress callback
         if (requestId) {
@@ -215,7 +286,13 @@ export class SessionManager {
           // verifier session multiplexer, so no separate WebSocket to the
           // websockify proxy is opened. In MPC mode we pass the websockify URL
           // through to the worker, which will create a JsIo channel for it.
-          const workerProxyUrl = mode === 'Proxy' ? undefined : proverOptions.proxyUrl;
+          // `proxyBase` (sessionData) overrides the plugin's build-time proxy
+          // origin — used by the peer demo to relay through a reachable proxy
+          // (e.g. wss://demo.tlsnotary.org) while keeping the ?token=<host>.
+          const workerProxyUrl =
+            mode === 'Proxy'
+              ? undefined
+              : applyProxyBase(proverOptions.proxyUrl, sessionData.proxyBase);
 
           // Send request via ProveManager which handles IoChannel creation in the worker.
           emitBoth('SENDING_REQUEST', 0.3, 'Sending request...');
@@ -269,12 +346,16 @@ export class SessionManager {
             });
           }
 
-          // Send reveal config (ranges + handlers) to verifier BEFORE calling reveal()
-          emitBoth('SENDING_REVEAL_CONFIG', 0.6, 'Configuring selective disclosure...');
-          await proveManager.sendRevealConfig(proverId, {
-            sent: sentRangesWithHandlers,
-            recv: recvRangesWithHandlers,
-          });
+          // Send reveal config (ranges + handlers) to verifier BEFORE calling reveal().
+          // Peer mode has no server control channel — the WASM verifier in the
+          // other browser learns the revealed ranges directly through the MPC.
+          if (!isPeer) {
+            emitBoth('SENDING_REVEAL_CONFIG', 0.6, 'Configuring selective disclosure...');
+            await proveManager.sendRevealConfig(proverId, {
+              sent: sentRangesWithHandlers,
+              recv: recvRangesWithHandlers,
+            });
+          }
 
           // Reveal the ranges (and hash-commit ranges if any handlers use action: HASH).
           // openings.sent[i] / openings.recv[i] expose { hash, blinder } for each
@@ -290,9 +371,13 @@ export class SessionManager {
             logger.debug('reveal openings', openings);
           }
 
-          // Get structured response from verifier (now includes handler results)
+          // Get structured response from verifier. In peer mode the result lives
+          // on the verifying browser (its own verify() output) — there is no
+          // server response to wait for, so the prover just completes.
           emitBoth('WAITING_FOR_VERIFICATION', 0.85, 'Waiting for verification...');
-          const response = await proveManager.getResponse(proverId);
+          const response = isPeer
+            ? { results: [], peer: true }
+            : await proveManager.getResponse(proverId);
 
           emitBoth('COMPLETE', 1.0, 'Complete');
 

--- a/packages/extension/src/types/messages.ts
+++ b/packages/extension/src/types/messages.ts
@@ -49,7 +49,11 @@ export type BackgroundMessage =
       height?: number;
       showOverlay?: boolean;
     }
-  | { type: 'TO_BG_RE_RENDER_PLUGIN_UI'; windowId: number };
+  | { type: 'TO_BG_RE_RENDER_PLUGIN_UI'; windowId: number }
+  // Peer relay: page→extension inbound MPC bytes, and offscreen→tab outbound.
+  | { type: 'PEER_DATA_IN'; requestId: string; data: string }
+  | { type: 'PEER_DATA_OUT'; requestId: string; data: string }
+  | { type: 'PEER_DATA_CLOSED'; requestId: string };
 
 /** Messages handled by the Content script */
 export type ContentMessage =
@@ -63,7 +67,8 @@ export type ContentMessage =
       source: string;
     }
   | { type: 'GET_PAGE_INFO' }
-  | { type: 'RENDER_PLUGIN_UI'; json: DomJson; windowId: number };
+  | { type: 'RENDER_PLUGIN_UI'; json: DomJson; windowId: number }
+  | { type: 'PEER_DATA_OUT'; requestId: string; data: string };
 
 /** Messages handled by the Offscreen document */
 export type OffscreenMessage =
@@ -74,7 +79,12 @@ export type OffscreenMessage =
       requestId?: string;
       sessionData?: Record<string, unknown>;
     }
-  | { type: 'GET_PLUGIN_STATS_OFFSCREEN'; code: string; pageOrigin: string };
+  | { type: 'GET_PLUGIN_STATS_OFFSCREEN'; code: string; pageOrigin: string }
+  // Forwarded by the background (distinct type so the offscreen handles each
+  // inbound chunk exactly once — a content script's runtime.sendMessage is also
+  // broadcast directly to the offscreen, which would otherwise double-deliver).
+  | { type: 'PEER_DATA_DELIVER'; data: string }
+  | { type: 'PEER_DATA_DELIVER_CLOSED' };
 
 // ---------------------------------------------------------------------------
 // Responses returned from sendMessage calls

--- a/packages/extension/src/types/messages.ts
+++ b/packages/extension/src/types/messages.ts
@@ -50,10 +50,10 @@ export type BackgroundMessage =
       showOverlay?: boolean;
     }
   | { type: 'TO_BG_RE_RENDER_PLUGIN_UI'; windowId: number }
-  // Peer relay: page→extension inbound MPC bytes, and offscreen→tab outbound.
-  | { type: 'PEER_DATA_IN'; requestId: string; data: string }
-  | { type: 'PEER_DATA_OUT'; requestId: string; data: string }
-  | { type: 'PEER_DATA_CLOSED'; requestId: string };
+  // Relay: page→extension inbound MPC bytes, and offscreen→tab outbound.
+  | { type: 'RELAY_IN'; requestId: string; data: string }
+  | { type: 'RELAY_OUT'; requestId: string; data: string }
+  | { type: 'RELAY_CLOSED'; requestId: string };
 
 /** Messages handled by the Content script */
 export type ContentMessage =
@@ -68,7 +68,7 @@ export type ContentMessage =
     }
   | { type: 'GET_PAGE_INFO' }
   | { type: 'RENDER_PLUGIN_UI'; json: DomJson; windowId: number }
-  | { type: 'PEER_DATA_OUT'; requestId: string; data: string };
+  | { type: 'RELAY_OUT'; requestId: string; data: string };
 
 /** Messages handled by the Offscreen document */
 export type OffscreenMessage =
@@ -83,8 +83,8 @@ export type OffscreenMessage =
   // Forwarded by the background (distinct type so the offscreen handles each
   // inbound chunk exactly once — a content script's runtime.sendMessage is also
   // broadcast directly to the offscreen, which would otherwise double-deliver).
-  | { type: 'PEER_DATA_DELIVER'; data: string }
-  | { type: 'PEER_DATA_DELIVER_CLOSED' };
+  | { type: 'RELAY_DELIVER'; data: string }
+  | { type: 'RELAY_DELIVER_CLOSED' };
 
 // ---------------------------------------------------------------------------
 // Responses returned from sendMessage calls


### PR DESCRIPTION
## Summary

Adds a **peer-to-peer web-proof** demo: prove a fact from your browser with the TLSNotary extension and have **another browser verify it directly** — the MPC-TLS session runs between the two browsers with **no hosted verifier**. The verifier runs the WASM `Verifier` in-page; the extension stays transport-agnostic and only relays the verifier-channel bytes.

Status: **Preview** (new isolated `peer.html` entry; the existing demo and extension flows are unchanged).

## What's in it

**Extension (transport-agnostic peer relay)**
- Relays the prover's verifier-channel MPC bytes to/from the host page (the page owns the WebRTC/PeerJS connection — no PeerJS in the extension).
- Supports both **MPC** and **Proxy** mode over the relay; the negotiated `PEER_LIMITS` frame carries the mode + limits so the in-browser verifier can open the server socket itself in Proxy mode.

**Demo (`packages/demo`, `peer.html`)**
- Linear topology UI: **Server — Prover — Verifier**, with the Server (and its TCP-proxy hop, shown as an ⓘ) beside whichever browser connects — left in MPC, right in Proxy.
- MPC/Proxy toggle, repeatable proofs over one paired channel, and a live status mirror so each pane reflects the other device.
- In-browser WASM verifier (cross-origin isolated `peer.html?j=`), PeerJS pairing via QR/link.
- Onboarding copy: steps, "what do you want to prove?", protocol explainer, extension-install link.

## How to test (two devices / browsers)
1. `npm run dev` in `packages/demo`; rebuild + reload the extension.
2. Open `/peer.html`, pick a plugin and MPC/Proxy, pair the verifier by scanning the QR (or open the link in a second browser).
3. Prove; the other browser verifies in-page. Repeat / switch plugin or mode without reloading.

Proxy reachability uses `wss://demo.tlsnotary.org`.

## Verification
- demo: `type-check`, `lint`, `build` ✓
- extension: `lint` ✓, `test` (184) ✓
- End-to-end MPC + Proxy proofs confirmed live on two devices.
