### PR TITLE
fix(mobile): unblock iOS build on Xcode 26 (fmt consteval)

### DIFF
--- a/app/mobile/app.json
+++ b/app/mobile/app.json
@@ -40,7 +40,12 @@
       "output": "static",
       "favicon": "./assets/images/favicon.png"
     },
-    "plugins": ["expo-router", "./plugins/exclude-x86_64", "./plugins/adi-registration"],
+    "plugins": [
+      "expo-router",
+      "./plugins/exclude-x86_64",
+      "./plugins/adi-registration",
+      "./plugins/fmt-consteval-fix"
+    ],
     "experiments": {
       "typedRoutes": true
     },

--- a/app/mobile/plugins/fmt-consteval-fix.js
+++ b/app/mobile/plugins/fmt-consteval-fix.js
@@ -1,0 +1,45 @@
+const { withDangerousMod } = require('expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+// Xcode 26's clang tightened C++20 `consteval` enforcement, and the `fmt`
+// library bundled inside RCT-Folly no longer compiles ("call to consteval
+// function ... is not a constant expression" in RCT-Folly's json.cpp /
+// json_pointer.cpp). Disable fmt's consteval path on the targets that compile
+// fmt code so it falls back to runtime format-string checks.
+//
+// TODO: remove once we're on an Expo SDK that bundles the upstream fmt fix
+// (React Native >= 0.83). Tracking: https://github.com/expo/expo/issues/44229
+module.exports = function fmtConstevalFix(config) {
+  return withDangerousMod(config, [
+    'ios',
+    (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      let podfile = fs.readFileSync(podfilePath, 'utf8');
+
+      const snippet = `
+    # Xcode 26 clang breaks fmt's consteval path; disable it for fmt/RCT-Folly.
+    installer.pods_project.targets.each do |target|
+      next unless ['fmt', 'RCT-Folly'].include?(target.name)
+      target.build_configurations.each do |bc|
+        defs = bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        defs = [defs] unless defs.is_a?(Array)
+        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
+        bc.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
+      end
+    end`;
+
+      // Insert after react_native_post_install (idempotent — skip if already present)
+      const sentinel = '# [fmt-consteval-fix-plugin]';
+      if (!podfile.includes(sentinel)) {
+        podfile = podfile.replace(
+          /(\s+react_native_post_install\([\s\S]*?\)\n)/,
+          `$1\n    ${sentinel}${snippet}\n`,
+        );
+      }
+
+      fs.writeFileSync(podfilePath, podfile);
+      return config;
+    },
+  ]);
+};


### PR DESCRIPTION
## Problem

The `ios-build` job fails on the `macos-26` runner (now shipping Xcode 26.5). Xcode 26's clang tightened C++20 `consteval` enforcement, and the `fmt` library bundled inside RCT-Folly no longer compiles:

```
call to consteval function 'fmt::basic_format_string<...>::basic_format_string<FMT_COMPILE_STRING, 0>'
is not a constant expression
```

The failures are in RCT-Folly translation units (`json.cpp`, `json_pointer.cpp`) that include the fmt headers. This is a toolchain/ecosystem break — unrelated to any app or plugin code (Android and `mobile-check` are unaffected).

## Fix

Adopt the new toolchain rather than pin an older Xcode. Add an Expo config plugin (`plugins/fmt-consteval-fix.js`) that defines `FMT_USE_CONSTEVAL=0` on the `fmt` and `RCT-Folly` pod targets via a Podfile `post_install` patch, so fmt falls back to runtime format-string checking. Matches the existing `exclude-x86_64.js` pattern (idempotent, sentinel-guarded). RCT-Folly stays on C++20 — only fmt's consteval path is disabled, avoiding unrelated regressions.

Since `ios/` is gitignored (Expo CNG — regenerated by `expo prebuild` each EAS build), the fix must live in a config plugin, not a hand-edited Podfile.

## Forward-looking / removal

The upstream fmt fix is landing in React Native >= 0.83. Once we're on an Expo SDK that bundles it, delete this plugin and rebuild clean. Tracked in [expo/expo#44229](https://github.com/expo/expo/issues/44229).

## Verification

Plugin loads as a function, `app.json` is valid JSON with the plugin registered, and it lints clean. Full validation is the `ios-build` CI job on this PR (needs the macos-26 + Xcode 26.5 toolchain).