### PR TITLE
feat(demo): enable peer-to-peer preview link

### DIFF
--- a/packages/demo/src/App.tsx
+++ b/packages/demo/src/App.tsx
@@ -446,11 +446,9 @@ export function App() {
           <a href="#build-your-own" className="hero-cta hero-cta-secondary">
             Build your own →
           </a>
-          {/* Re-enable once the relay-capable extension (>= 0.1.0.1501) is
-              live on the Chrome Web Store; until then peer.html can't work. */}
-          {/* <a href="/peer.html" className="hero-cta hero-cta-secondary">
+          <a href="/peer.html" className="hero-cta hero-cta-secondary">
             Peer-to-peer (preview) →
-          </a> */}
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
The relay-capable extension (`0.1.0.1501`) is now live on the Chrome Web Store, so the gated **Peer-to-peer (preview) →** hero link can be re-enabled. This reverts the temporary gating from #362 ([App.tsx](packages/demo/src/App.tsx)).

Merging auto-deploys the demo, surfacing the P2P preview on `demo.tlsnotary.org`.

**Deliberately not bumping `MIN_EXTENSION_VERSION`** (stays `0.1.0.1500`): it gates the *main* demo, which is fully compatible with `0.1.0.1500`. Bumping it would falsely flag users mid-rollout as "outdated" for a feature they aren't using.

**Known follow-up:** `PeerToPeerPage` gates only on `window.tlsn?.execCode` presence, not version — so a user still on `0.1.0.1500` would pass the check and then silently hang on the relay `execCode` call. A version guard on the P2P page (require ≥ `0.1.0.1501`, else show "update extension") would close that gap cleanly.